### PR TITLE
Fix CodeQL security alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags: [ontokit-web-*]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -13,7 +13,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -32,12 +32,12 @@ if (!current.includes("-dev") && !current.includes("-rc")) {
 
 const release = current.replace("-dev", "").replace("-rc", "");
 
-execSync(`npm pkg set version=${release}`, { stdio: "inherit" });
+execFileSync("npm", ["pkg", "set", `version=${release}`], { stdio: "inherit" });
 console.log(`Updated package.json: ${current} -> ${release}`);
 
 // Git commit
-execSync(`git add ${packagePath}`, { stdio: "inherit" });
-execSync(`git commit -m "chore: releasing ${release}"`, { stdio: "inherit" });
+execFileSync("git", ["add", packagePath], { stdio: "inherit" });
+execFileSync("git", ["commit", "-m", `chore: releasing ${release}`], { stdio: "inherit" });
 console.log(`Created commit: chore: releasing ${release}`);
 console.log();
 console.log("Next steps:");

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -11,7 +11,7 @@
  */
 
 import { resolve, dirname } from "node:path";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -34,12 +34,12 @@ if (!/^\d+\.\d+\.\d+$/.test(version)) {
 
 const devVersion = `${version}-dev`;
 
-execSync(`npm pkg set version=${devVersion}`, { stdio: "inherit" });
+execFileSync("npm", ["pkg", "set", `version=${devVersion}`], { stdio: "inherit" });
 console.log(`Updated package.json to ${devVersion}`);
 
 // Git commit
-execSync(`git add ${packagePath}`, { stdio: "inherit" });
-execSync(`git commit -m "chore: setting version to ${devVersion}"`, {
+execFileSync("git", ["add", packagePath], { stdio: "inherit" });
+execFileSync("git", ["commit", "-m", `chore: setting version to ${devVersion}`], {
   stdio: "inherit",
 });
 console.log(`Created commit: chore: setting version to ${devVersion}`);


### PR DESCRIPTION
## Summary
- Add top-level `permissions: contents: read` to release workflow so the `quality` job runs with least-privilege `GITHUB_TOKEN`
- Replace `execSync` with `execFileSync` in `prepare-release.mjs` and `set-version.mjs` to avoid shell command injection via uncontrolled absolute paths

Resolves CodeQL alerts #2, #3, #4.

## Test plan
- [x] Verify `npm run lint` and `npm run type-check` still pass
- [x] Confirm release workflow triggers correctly on tag push (YAML change is additive `permissions` block — does not affect trigger config)
- [x] Run `node scripts/set-version.mjs 0.4.0` locally to verify `execFileSync` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions and release automation scripts for improved security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->