### PR TITLE
fix: address CodeRabbit findings for ontology guide

### DIFF
--- a/app/docs/guide/layout.tsx
+++ b/app/docs/guide/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { GuideSidebar } from "@/components/docs/GuideSidebar";
 
 export default function GuideLayout({ children }: { children: React.ReactNode }) {

--- a/app/docs/guide/types/page.tsx
+++ b/app/docs/guide/types/page.tsx
@@ -130,10 +130,10 @@ export default function TypesPage() {
             <table className="w-full text-sm">
               <thead className="bg-slate-50 dark:bg-slate-700">
                 <tr>
-                  <th className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Type</th>
-                  <th className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Expressiveness</th>
-                  <th className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Reasoning</th>
-                  <th className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Example</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Type</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Expressiveness</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Reasoning</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Example</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200 dark:divide-slate-700">

--- a/app/docs/guide/vocabularies/page.tsx
+++ b/app/docs/guide/vocabularies/page.tsx
@@ -211,9 +211,9 @@ ex:Mammals a skos:Concept ;
             <table className="w-full text-sm">
               <thead className="bg-slate-50 dark:bg-slate-700">
                 <tr>
-                  <th className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Vocabulary</th>
-                  <th className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Prefix</th>
-                  <th className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Purpose</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Vocabulary</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Prefix</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Purpose</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200 dark:divide-slate-700">

--- a/components/docs/GuideSidebar.tsx
+++ b/components/docs/GuideSidebar.tsx
@@ -21,6 +21,7 @@ export function GuideSidebar() {
             <Link
               key={chapter.slug}
               href={href}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
                 "flex items-start gap-2.5 px-3 py-2 rounded-md text-sm transition-colors",
                 isActive

--- a/lib/docs/guide-chapters.ts
+++ b/lib/docs/guide-chapters.ts
@@ -45,6 +45,9 @@ export const guideChapters: GuideChapter[] = [
 
 export function getAdjacentChapters(currentSlug: string) {
   const index = guideChapters.findIndex((c) => c.slug === currentSlug);
+  if (index === -1) {
+    return { prev: null, next: null };
+  }
   return {
     prev: index > 0 ? guideChapters[index - 1] : null,
     next: index < guideChapters.length - 1 ? guideChapters[index + 1] : null,


### PR DESCRIPTION
- Fix getAdjacentChapters to return { prev: null, next: null } for missing slugs
- Remove 'use client' directive from GuideLayout (it's a Server Component)
- Add scope="col" to table headers in Types guide page for accessibility
- Add scope="col" to table headers in Vocabularies guide page for accessibility
- Add aria-current="page" to active sidebar link in GuideSidebar for assistive tech

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added scope attributes to table headers for better screen reader support across guide pages.
  * Enhanced sidebar navigation with current page indicators for improved navigation context.

* **Bug Fixes**
  * Fixed navigation handler to gracefully handle missing guide references, returning appropriate empty states instead of unintended results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->