### PR TITLE
fix: improve import error UX with server-reachability probe

### DIFF
--- a/app/projects/new/page.tsx
+++ b/app/projects/new/page.tsx
@@ -319,7 +319,7 @@ export default function NewProjectPage() {
                     disabled={isSubmitting}
                   />
                   {importError && (
-                    <div className="mt-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+                    <div role="alert" className="mt-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
                       <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
                       <div>
                         <p className="font-medium">Import failed</p>

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -195,8 +195,8 @@ function uploadFileWithProgress<T>(
       // to distinguish the two cases so the user gets an actionable message.
       let serverReachable = false;
       try {
-        const probe = await fetch(`${API_BASE}/`, { method: "HEAD", mode: "cors" });
-        serverReachable = probe.ok;
+        await fetch(`${API_BASE}/`, { method: "HEAD", mode: "cors" });
+        serverReachable = true;
       } catch {
         // probe failed — server truly unreachable
       }


### PR DESCRIPTION
## Summary
- **XHR error handler** now probes the API root before reporting — distinguishes "server down" from "server returned a CORS-blocked error" (e.g. unhandled 500 without CORS headers)
- **5-minute timeout** added for large file uploads (was unlimited)
- **Error banner** moved out of FileUpload component into a dedicated alert with icon, so the file selection doesn't look invalid
- **Error cleared** when user selects a new file

## Context
Importing an 18MB OWL file showed "Could not reach the server" even though the server was running — the actual cause was a 500 from a missing DB migration whose response lacked CORS headers, triggering the XHR `error` event instead of `load`.

## Test plan
- [ ] Import a valid ontology file — should upload and redirect to the new project
- [ ] Stop the API server, try import — should show "Could not reach the server"
- [ ] Trigger a server 500 on import — should show "The server encountered an error..."
- [ ] Select a new file after an error — error banner should clear

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 5-minute timeout protection for file uploads.
  * Improved error messaging to distinguish between network connectivity failures and server unavailability.

* **Bug Fixes**
  * Enhanced error handling to prevent unhandled exceptions during file import.
  * Errors now clear when selecting a new file.
  * Error messages display in a dedicated alert panel for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #29