### PR TITLE
fix: improve auth UX for private projects in editor

### DIFF
--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -1092,13 +1092,15 @@ export default function EditorPage() {
 
               {/* Sign-in CTA for unauthenticated users */}
               {!hasValidAccess && (
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => signIn("zitadel")}
-                  className="flex items-center gap-1 rounded-full bg-primary-50 px-3 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100 dark:bg-primary-900/20 dark:text-primary-400 dark:hover:bg-primary-900/30"
+                  className="gap-1 rounded-full bg-primary-50 px-3 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100 dark:bg-primary-900/20 dark:text-primary-400 dark:hover:bg-primary-900/30"
                 >
                   <LogIn className="h-3 w-3" />
                   Sign in to suggest edits
-                </button>
+                </Button>
               )}
             </div>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- **Private project error**: unauthenticated users now see "Sign in to request access" with a sign-in button instead of the generic "You don't have access" message
- **Public project source**: allow source content loading without an access token (public projects shouldn't require auth for read-only source view)
- **Error state**: add LogIn icon and signIn action alongside the "Back to Projects" link

## Test plan
- [ ] Visit a private project editor while signed out — should see sign-in prompt with button
- [ ] Visit a private project editor while signed in without access — should see "no access" error
- [ ] Visit a public project editor while signed out — source should load (read-only)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-denied messaging to distinguish unauthenticated vs authenticated users and classify 404/other load errors.
  * Clarified unauthenticated error screen with a centered Sign In and Back action.

* **New Features**
  * Added sign-in prompts in header, error screens, and an inline CTA to encourage authentication.
  * Disabled add-entity actions and related keyboard shortcut when suggestions aren’t allowed.
  * Sync and Normalize controls now only visible to users with valid access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #31