### PR TITLE
fix: remove duplicate BranchBadge from editor header

### DIFF
--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -16,7 +16,7 @@ import { ModeSwitcher } from "@/components/editor/ModeSwitcher";
 import { ContinuousEditingToggle } from "@/components/editor/ContinuousEditingToggle";
 import { DeveloperEditorLayout } from "@/components/editor/developer/DeveloperEditorLayout";
 import { StandardEditorLayout } from "@/components/editor/standard/StandardEditorLayout";
-import { BranchSelector, BranchBadge, RevisionHistoryPanel, HistoryButton } from "@/components/revision";
+import { BranchSelector, RevisionHistoryPanel, HistoryButton } from "@/components/revision";
 import { useQueryClient } from "@tanstack/react-query";
 import { BranchProvider, branchQueryKeys } from "@/lib/context/BranchContext";
 import { useOntologyTree } from "@/lib/hooks/useOntologyTree";
@@ -1076,8 +1076,6 @@ export default function EditorPage() {
               <div className="h-5 w-px bg-slate-200 dark:bg-slate-700" />
               <h1 className="font-semibold text-slate-900 dark:text-white">{project.name}</h1>
               <span className="text-sm text-slate-500 dark:text-slate-400">{totalClasses} classes</span>
-              <BranchBadge />
-
               {/* Mode Switcher */}
               <ModeSwitcher />
               {canSuggest && <ContinuousEditingToggle />}


### PR DESCRIPTION
## Summary
- Removed the `BranchBadge` component from the editor header, which was redundantly displaying the current branch name alongside the `BranchSelector`
- The `BranchSelector` (right side of the header) already shows the branch name and provides branch switching functionality, making `BranchBadge` unnecessary

Closes #9

## Test plan
- [ ] Open a project editor page and verify the branch name appears only once (in the `BranchSelector` dropdown on the right side of the header)
- [ ] Verify branch switching still works correctly via `BranchSelector`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the branch badge from the editor header. This interface element previously displayed branch information alongside the project name and class count. While the badge is no longer visible, all other revision management and branching controls remain unchanged and fully functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->