### PR TITLE
fix: handle nullable index fields from API

### DIFF
--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -874,8 +874,8 @@ export default function EditorPage() {
         values: a.values,
       })),
       deprecated: detail.deprecated,
-      equivalent_iris: detail.equivalent_iris,
-      disjoint_iris: detail.disjoint_iris,
+      equivalent_iris: detail.equivalent_iris ?? undefined,
+      disjoint_iris: detail.disjoint_iris ?? undefined,
     };
 
     // Route through the appropriate save handler

--- a/components/editor/ClassDetailPanel.tsx
+++ b/components/editor/ClassDetailPanel.tsx
@@ -1010,7 +1010,7 @@ export function ClassDetailPanel({
             <div className="flex items-center gap-4">
               <StatItem label="subclasses" value={classDetail.child_count} />
               <span className="text-slate-300 dark:text-slate-600">&middot;</span>
-              <StatItem label="instances" value={classDetail.instance_count} />
+              <StatItem label="instances" value={classDetail.instance_count ?? "—"} />
             </div>
           </Section>
 
@@ -1041,7 +1041,7 @@ export function ClassDetailPanel({
           />
 
           {/* Equivalent Classes (read-only) */}
-          {classDetail.equivalent_iris.length > 0 && (
+          {classDetail.equivalent_iris && classDetail.equivalent_iris.length > 0 && (
             <Section title="Equivalent Classes" tooltip="owl:equivalentClass" icon={<Equal className="h-4 w-4" />}>
               <div className="space-y-1">
                 {classDetail.equivalent_iris.map((iri) => (
@@ -1052,7 +1052,7 @@ export function ClassDetailPanel({
           )}
 
           {/* Disjoint Classes (read-only) */}
-          {classDetail.disjoint_iris.length > 0 && (
+          {classDetail.disjoint_iris && classDetail.disjoint_iris.length > 0 && (
             <Section title="Disjoint With" tooltip="owl:disjointWith" icon={<Ban className="h-4 w-4" />}>
               <div className="space-y-1">
                 {classDetail.disjoint_iris.map((iri) => (
@@ -1144,7 +1144,7 @@ function IriLink({ iri, label, onClick }: IriLinkProps) {
 
 interface StatItemProps {
   label: string;
-  value: number;
+  value: number | string | null;
 }
 
 function StatItem({ label, value }: StatItemProps) {

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -331,7 +331,7 @@ export interface OWLClass {
   deprecated: boolean;
   parent_iris: string[];
   child_count: number;
-  instance_count: number;
+  instance_count: number | null;
 }
 
 export interface OWLClassListResponse {
@@ -390,10 +390,10 @@ export interface OWLClassDetail {
   deprecated: boolean;
   parent_iris: string[];
   parent_labels: Record<string, string>;  // Map of IRI to resolved label
-  equivalent_iris: string[];
-  disjoint_iris: string[];
+  equivalent_iris: string[] | null;
+  disjoint_iris: string[] | null;
   child_count: number;
-  instance_count: number;
+  instance_count: number | null;
   is_defined: boolean;
   source_ontology?: string;
   annotations: AnnotationProperty[];  // DC, SKOS, and other annotation properties

--- a/lib/graph/buildGraphData.ts
+++ b/lib/graph/buildGraphData.ts
@@ -149,13 +149,13 @@ export function buildGraphFromClassDetail(
     }
 
     // equivalentClass edges
-    for (const eqIri of detail.equivalent_iris) {
+    for (const eqIri of detail.equivalent_iris ?? []) {
       ensureNode(eqIri);
       addEdge(iri, eqIri, "equivalentClass");
     }
 
     // disjointWith edges
-    for (const djIri of detail.disjoint_iris) {
+    for (const djIri of detail.disjoint_iris ?? []) {
       ensureNode(djIri);
       addEdge(iri, djIri, "disjointWith");
     }

--- a/lib/hooks/useAutoSave.ts
+++ b/lib/hooks/useAutoSave.ts
@@ -195,8 +195,8 @@ export function useAutoSave({
         parent_iris: draft.parentIris,
         annotations: [...cleanAnnotations, ...relationshipAnnotations],
         deprecated: detail?.deprecated,
-        equivalent_iris: detail?.equivalent_iris,
-        disjoint_iris: detail?.disjoint_iris,
+        equivalent_iris: detail?.equivalent_iris ?? undefined,
+        disjoint_iris: detail?.disjoint_iris ?? undefined,
       };
 
       if (saveMode === "suggest" && onSuggestSave) {

--- a/lib/hooks/useGraphData.ts
+++ b/lib/hooks/useGraphData.ts
@@ -89,12 +89,12 @@ export function useGraphData({
               newNeighborIris.push(parentIri);
             }
           }
-          for (const eqIri of detail.equivalent_iris) {
+          for (const eqIri of detail.equivalent_iris ?? []) {
             if (!resolvedNodesRef.current.has(eqIri)) {
               newNeighborIris.push(eqIri);
             }
           }
-          for (const djIri of detail.disjoint_iris) {
+          for (const djIri of detail.disjoint_iris ?? []) {
             if (!resolvedNodesRef.current.has(djIri)) {
               newNeighborIris.push(djIri);
             }
@@ -158,8 +158,8 @@ export function useGraphData({
     const referenced = new Set<string>();
     for (const detail of resolvedNodesRef.current.values()) {
       for (const iri of detail.parent_iris) referenced.add(iri);
-      for (const iri of detail.equivalent_iris) referenced.add(iri);
-      for (const iri of detail.disjoint_iris) referenced.add(iri);
+      for (const iri of detail.equivalent_iris ?? []) referenced.add(iri);
+      for (const iri of detail.disjoint_iris ?? []) referenced.add(iri);
       for (const iri of getSeeAlsoIris(detail)) referenced.add(iri);
     }
     return [...referenced].filter(
@@ -250,8 +250,8 @@ export function useGraphData({
         // Depth 1: immediate neighbors (including seeAlso/isDefinedBy targets)
         const depth1Iris = [
           ...focusDetail.parent_iris,
-          ...focusDetail.equivalent_iris,
-          ...focusDetail.disjoint_iris,
+          ...(focusDetail.equivalent_iris ?? []),
+          ...(focusDetail.disjoint_iris ?? []),
           ...getSeeAlsoIris(focusDetail),
         ];
         const depth2Candidates = await fetchNeighbors(depth1Iris);
@@ -303,8 +303,8 @@ export function useGraphData({
         if (detail) {
           const neighborIris = [
             ...detail.parent_iris,
-            ...detail.equivalent_iris,
-            ...detail.disjoint_iris,
+            ...(detail.equivalent_iris ?? []),
+            ...(detail.disjoint_iris ?? []),
             ...getSeeAlsoIris(detail),
           ];
           await fetchNeighbors(neighborIris);


### PR DESCRIPTION
## Summary

- Update `OWLClass` and `OWLClassDetail` types to allow `null` for `instance_count`, `equivalent_iris`, and `disjoint_iris`
- Add null guards in `ClassDetailPanel`, `buildGraphData`, `useGraphData` to prevent runtime crashes
- Convert `null` → `undefined` when building `ClassUpdatePayload` in editor page and `useAutoSave`
- Display "—" for null `instance_count` in statistics

Companion to CatholicOS/ontokit-api#18. Closes #49.

## Test plan

- [ ] `npx tsc --noEmit` — type check passes
- [ ] `npx vitest run` — all 90 tests pass
- [ ] Load a class served from the index path; statistics show "—" for instance count
- [ ] Equivalent/disjoint sections hidden (not crashed) when API returns `null`
- [ ] Graph view renders without errors when arrays are `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editor, autosave, and graph features now tolerate missing class relationship fields (equivalent/disjoint IRIs) without errors.
  * Graph building and neighbor loading skip absent relationships instead of failing during iteration.
  * Class detail panel shows "—" when instance counts are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->