### PR TITLE
feat: AUTH_MODE support, anonymous suggestions, and sign-in-to-edit UX

### DIFF
--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useSession, signIn } from "next-auth/react";
 import { useParams, useSearchParams, useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Settings, FileCode, GitPullRequest, Activity, RefreshCw, Lightbulb, Eye, Keyboard, LogIn } from "lucide-react";
+import { ArrowLeft, Settings, FileCode, GitPullRequest, Activity, RefreshCw, Lightbulb, Eye, Keyboard, LogIn, Pencil } from "lucide-react";
 import { Header } from "@/components/layout/header";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -42,6 +42,8 @@ import { useSuggestionBeacon } from "@/lib/hooks/useSuggestionBeacon";
 import { DeleteImpactAnalysis } from "@/components/editor/DeleteImpactAnalysis";
 import { RemoteSyncIndicator } from "@/components/editor/RemoteSyncIndicator";
 import { ShareButton } from "@/components/editor/ShareButton";
+import { useAnonymousSuggestion } from "@/lib/hooks/useAnonymousSuggestion";
+import { CreditModal } from "@/components/suggestions/CreditModal";
 
 import type { OntologySourceEditorRef } from "@/components/editor/OntologySourceEditor";
 
@@ -82,6 +84,7 @@ export default function EditorPage() {
 
   // Auth mode — set at build time by next.config.ts
   const zitadelConfigured = process.env.NEXT_PUBLIC_ZITADEL_CONFIGURED === "true";
+  const authMode = process.env.NEXT_PUBLIC_AUTH_MODE || "required";
 
   // Branch state
   const queryClient = useQueryClient();
@@ -194,6 +197,20 @@ export default function EditorPage() {
 
   // Suggestion session (only active for suggesters who can't directly edit)
   const [submitDialogOpen, setSubmitDialogOpen] = useState(false);
+
+  // Anonymous proposal mode: available when AUTH_MODE != required and user is NOT signed in as editor/suggester
+  const canPropose = authMode !== "required" && !canSuggest;
+  const [creditModalOpen, setCreditModalOpen] = useState(false);
+
+  const anonymousSuggestion = useAnonymousSuggestion({
+    projectId,
+    onSubmitted: (prNumber) => {
+      toast.success(`Proposal submitted as PR #${prNumber}`);
+    },
+    onError: (msg) => toast.error("Proposal error", msg),
+  });
+
+  const isAnonymousProposalMode = canPropose && anonymousSuggestion.isActive;
 
   const suggestionSession = useSuggestionSession({
     projectId,
@@ -640,6 +657,59 @@ export default function EditorPage() {
     iriPatternDetectedRef.current = false;
   }, [session, projectId, activeBranch, project, sourceContent, toast, suggestionSession, setSourceContent, setSourceIriIndex]);
 
+  // Handle anonymous proposal mode class update
+  // Routes through anonymousSuggestion.saveToSession() instead of the normal commit path
+  const handleAnonymousClassUpdate = useCallback(async (classIri: string, data: ClassUpdatePayload) => {
+    if (!activeBranch && !anonymousSuggestion.branch) {
+      throw new Error("No branch selected");
+    }
+
+    // Ensure session exists before saving
+    if (!anonymousSuggestion.sessionId) {
+      await anonymousSuggestion.startSession();
+    }
+
+    // Load source from the anonymous suggestion branch (or current active branch as fallback)
+    const branchToLoad = anonymousSuggestion.branch || activeBranch;
+    let source = sourceContent;
+    if (!source) {
+      const response = await revisionsApi.getFileAtVersion(
+        projectId,
+        branchToLoad!,
+        undefined, // no Bearer token needed for anonymous
+        project?.git_ontology_path,
+      );
+      source = response.content;
+    }
+
+    const modifiedSource = updateClassInTurtle(source, classIri, data);
+    const label = data.labels[0]?.value || getLocalName(classIri);
+
+    await anonymousSuggestion.saveToSession(modifiedSource, classIri, label);
+
+    setSourceContent(modifiedSource);
+    toast.success(`Proposed update to "${label}"`);
+    updateNodeLabel(classIri, label);
+    setDetailRefreshKey((k) => k + 1);
+    setSourceIriIndex(new Map());
+    iriPatternDetectedRef.current = false;
+  }, [activeBranch, anonymousSuggestion, projectId, project?.git_ontology_path, sourceContent, toast, updateNodeLabel, setSourceContent, setSourceIriIndex]);
+
+  // Handle anonymous proposal "Propose Edit" button click
+  const handleProposeEdit = useCallback(async () => {
+    if (!anonymousSuggestion.isActive) {
+      await anonymousSuggestion.startSession();
+    }
+    // After session starts, isAnonymousProposalMode becomes true (canPropose && isActive),
+    // which re-renders ClassDetailPanel with canEdit=true allowing form editing
+  }, [anonymousSuggestion]);
+
+  // Handle "Submit Proposal" — called by CreditModal onSubmitCredit after user fills in name/email (or skips)
+  const handleAnonymousSubmit = useCallback(async (name: string | null, email: string | null) => {
+    setCreditModalOpen(false);
+    await anonymousSuggestion.submitSession(undefined, name ?? undefined, email ?? undefined);
+  }, [anonymousSuggestion]);
+
   // Handle drag-and-drop reparent class
   // Fetches full class detail, modifies parent_iris, then routes through the appropriate save handler
   const handleReparentClass = useCallback(async (
@@ -693,9 +763,13 @@ export default function EditorPage() {
     };
 
     // Route through the appropriate save handler
-    const saveHandler = isSuggestionMode ? handleSuggestClassUpdate : handleUpdateClass;
+    const saveHandler = isAnonymousProposalMode
+      ? handleAnonymousClassUpdate
+      : isSuggestionMode
+      ? handleSuggestClassUpdate
+      : handleUpdateClass;
     await saveHandler(classIri, payload);
-  }, [session, projectId, activeBranch, isSuggestionMode, handleUpdateClass, handleSuggestClassUpdate]);
+  }, [session, projectId, activeBranch, isAnonymousProposalMode, isSuggestionMode, handleUpdateClass, handleSuggestClassUpdate, handleAnonymousClassUpdate]);
 
   // Handle branch change
   const handleBranchChange = useCallback((branchName: string) => {
@@ -900,6 +974,14 @@ export default function EditorPage() {
                 </span>
               )}
 
+              {/* Anonymous proposal mode indicator */}
+              {isAnonymousProposalMode && (
+                <span className="flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                  <Pencil className="h-3 w-3" />
+                  Proposing
+                </span>
+              )}
+
               {/* Sign-in CTA for unauthenticated users (only when Zitadel is configured) */}
               {!hasValidAccess && zitadelConfigured && (
                 <Button
@@ -927,6 +1009,34 @@ export default function EditorPage() {
                   <span className="rounded-full bg-amber-500/30 px-1.5 py-0.5 text-xs">
                     {suggestionSession.changesCount}
                   </span>
+                </Button>
+              )}
+
+              {/* Submit Proposal button (anonymous mode) */}
+              {isAnonymousProposalMode && anonymousSuggestion.changesCount > 0 && (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  className="gap-2 bg-emerald-600 hover:bg-emerald-700"
+                  onClick={() => setCreditModalOpen(true)}
+                >
+                  <Pencil className="h-4 w-4" />
+                  Submit Proposal
+                  <span className="rounded-full bg-emerald-500/30 px-1.5 py-0.5 text-xs">
+                    {anonymousSuggestion.changesCount}
+                  </span>
+                </Button>
+              )}
+
+              {/* Discard Proposal button (anonymous mode) */}
+              {isAnonymousProposalMode && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-2 text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                  onClick={() => anonymousSuggestion.discardSession()}
+                >
+                  Discard
                 </Button>
               )}
 
@@ -1066,11 +1176,11 @@ export default function EditorPage() {
                 <DeveloperEditorLayout
                   projectId={projectId}
                   accessToken={session?.accessToken}
-                  activeBranch={activeBranch}
-                  canEdit={!!canEdit}
+                  activeBranch={isAnonymousProposalMode && anonymousSuggestion.branch ? anonymousSuggestion.branch : activeBranch}
+                  canEdit={isAnonymousProposalMode ? true : !!canEdit}
                   entityNavigationRef={entityNavigationRef}
                   canSuggest={!!canSuggest}
-                  isSuggestionMode={isSuggestionMode}
+                  isSuggestionMode={isAnonymousProposalMode ? true : isSuggestionMode}
                   nodes={nodes}
                   isTreeLoading={isTreeLoading}
                   treeError={treeError}
@@ -1101,26 +1211,35 @@ export default function EditorPage() {
                   onDeleteClass={handleDeleteClass}
                   onCopyIri={handleCopyIri}
                   selectedNodeFallback={selectedNodeFallback}
-                  onUpdateClass={isSuggestionMode ? handleSuggestClassUpdate : handleUpdateClass}
+                  onUpdateClass={
+                    isAnonymousProposalMode
+                      ? handleAnonymousClassUpdate
+                      : isSuggestionMode
+                      ? handleSuggestClassUpdate
+                      : handleUpdateClass
+                  }
                   detailRefreshKey={detailRefreshKey}
                   onUpdateProperty={isSuggestionMode ? handleSuggestPropertyUpdate : handleUpdateProperty}
                   onUpdateIndividual={isSuggestionMode ? handleSuggestIndividualUpdate : handleUpdateIndividual}
                   onReparentClass={handleReparentClass}
                   reparentOptimistic={reparentOptimistic}
                   rollbackReparent={rollbackReparent}
-                  showSignInToEdit={!hasValidAccess && zitadelConfigured}
+                  showSignInToEdit={!hasValidAccess && zitadelConfigured && !canPropose}
                   onSignInToEdit={() => signIn("zitadel", { callbackUrl: window.location.href })}
+                  canPropose={canPropose && !isAnonymousProposalMode}
+                  onProposeEdit={handleProposeEdit}
+                  isAnonymousProposalMode={isAnonymousProposalMode}
                 />
               </div>
             ) : (
               <StandardEditorLayout
                 projectId={projectId}
                 accessToken={session?.accessToken}
-                activeBranch={activeBranch}
-                canEdit={!!canEdit}
+                activeBranch={isAnonymousProposalMode && anonymousSuggestion.branch ? anonymousSuggestion.branch : activeBranch}
+                canEdit={isAnonymousProposalMode ? true : !!canEdit}
                 canSuggest={!!canSuggest}
                 entityNavigationRef={entityNavigationRef}
-                isSuggestionMode={isSuggestionMode}
+                isSuggestionMode={isAnonymousProposalMode ? true : isSuggestionMode}
                 nodes={nodes}
                 isTreeLoading={isTreeLoading}
                 treeError={treeError}
@@ -1140,7 +1259,13 @@ export default function EditorPage() {
                 onDeleteClass={handleDeleteClass}
                 onCopyIri={handleCopyIri}
                 selectedNodeFallback={selectedNodeFallback}
-                onUpdateClass={isSuggestionMode ? handleSuggestClassUpdate : handleUpdateClass}
+                onUpdateClass={
+                  isAnonymousProposalMode
+                    ? handleAnonymousClassUpdate
+                    : isSuggestionMode
+                    ? handleSuggestClassUpdate
+                    : handleUpdateClass
+                }
                 detailRefreshKey={detailRefreshKey}
                 sourceContent={sourceContent}
                 onUpdateProperty={isSuggestionMode ? handleSuggestPropertyUpdate : handleUpdateProperty}
@@ -1148,8 +1273,11 @@ export default function EditorPage() {
                 onReparentClass={handleReparentClass}
                 reparentOptimistic={reparentOptimistic}
                 rollbackReparent={rollbackReparent}
-                showSignInToEdit={!hasValidAccess && zitadelConfigured}
+                showSignInToEdit={!hasValidAccess && zitadelConfigured && !canPropose}
                 onSignInToEdit={() => signIn("zitadel", { callbackUrl: window.location.href })}
+                canPropose={canPropose && !isAnonymousProposalMode}
+                onProposeEdit={handleProposeEdit}
+                isAnonymousProposalMode={isAnonymousProposalMode}
               />
             )}
           </div>
@@ -1246,6 +1374,13 @@ export default function EditorPage() {
         open={shortcutDialogOpen}
         onOpenChange={setShortcutDialogOpen}
         shortcuts={keyboardShortcuts}
+      />
+
+      {/* Credit Modal for anonymous proposal submissions — opens before submit to collect optional credit info */}
+      <CreditModal
+        open={creditModalOpen}
+        onClose={() => handleAnonymousSubmit(null, null)}
+        onSubmitCredit={handleAnonymousSubmit}
       />
     </BranchProvider>
   );

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -80,6 +80,9 @@ export default function EditorPage() {
     setProjectViewMode("editor");
   }, [setProjectViewMode]);
 
+  // Auth mode — set at build time by next.config.ts
+  const zitadelConfigured = process.env.NEXT_PUBLIC_ZITADEL_CONFIGURED === "true";
+
   // Branch state
   const queryClient = useQueryClient();
   const [activeBranch, setActiveBranch] = useState<string | undefined>(undefined);
@@ -796,8 +799,8 @@ export default function EditorPage() {
                 {error || "Project not found"}
               </h2>
               <div className="mt-4 flex items-center justify-center gap-3">
-                {errorKind === "private-403" && (
-                  <Button onClick={() => signIn("zitadel")} className="gap-2">
+                {errorKind === "private-403" && zitadelConfigured && (
+                  <Button onClick={() => signIn("zitadel", { callbackUrl: window.location.href })} className="gap-2">
                     <LogIn className="h-4 w-4" />
                     Sign In
                   </Button>
@@ -897,16 +900,16 @@ export default function EditorPage() {
                 </span>
               )}
 
-              {/* Sign-in CTA for unauthenticated users */}
-              {!hasValidAccess && (
+              {/* Sign-in CTA for unauthenticated users (only when Zitadel is configured) */}
+              {!hasValidAccess && zitadelConfigured && (
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => signIn("zitadel")}
+                  onClick={() => signIn("zitadel", { callbackUrl: window.location.href })}
                   className="gap-1 rounded-full bg-primary-50 px-3 py-1 text-xs font-medium text-primary-700 hover:bg-primary-100 dark:bg-primary-900/20 dark:text-primary-400 dark:hover:bg-primary-900/30"
                 >
                   <LogIn className="h-3 w-3" />
-                  Sign in to suggest edits
+                  Sign in to edit
                 </Button>
               )}
             </div>
@@ -1105,6 +1108,8 @@ export default function EditorPage() {
                   onReparentClass={handleReparentClass}
                   reparentOptimistic={reparentOptimistic}
                   rollbackReparent={rollbackReparent}
+                  showSignInToEdit={!hasValidAccess && zitadelConfigured}
+                  onSignInToEdit={() => signIn("zitadel", { callbackUrl: window.location.href })}
                 />
               </div>
             ) : (
@@ -1143,6 +1148,8 @@ export default function EditorPage() {
                 onReparentClass={handleReparentClass}
                 reparentOptimistic={reparentOptimistic}
                 rollbackReparent={rollbackReparent}
+                showSignInToEdit={!hasValidAccess && zitadelConfigured}
+                onSignInToEdit={() => signIn("zitadel", { callbackUrl: window.location.href })}
               />
             )}
           </div>

--- a/app/projects/[id]/suggestions/review/page.tsx
+++ b/app/projects/[id]/suggestions/review/page.tsx
@@ -407,8 +407,13 @@ export default function SuggestionReviewPage() {
                           <div className="flex-1">
                             <div className="flex items-center gap-2">
                               <span className="text-sm font-medium text-slate-900 dark:text-white">
-                                {s.submitter?.name || s.submitter?.email || "Unknown user"}
+                                {s.submitter?.name || s.submitter?.email || (s.is_anonymous ? "Anonymous" : "Unknown user")}
                               </span>
+                              {s.is_anonymous && (
+                                <span className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                                  Anonymous
+                                </span>
+                              )}
                               {(s.revision ?? 1) > 1 && (
                                 <span className="rounded-sm bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
                                   v{s.revision}
@@ -510,9 +515,16 @@ export default function SuggestionReviewPage() {
                                 <h4 className="text-xs font-medium uppercase tracking-wider text-slate-400 dark:text-slate-500">
                                   Submitted by
                                 </h4>
-                                <p className="mt-1 text-sm text-slate-900 dark:text-white">
-                                  {s.submitter?.name || s.submitter?.email || "Unknown user"}
-                                </p>
+                                <div className="mt-1 flex items-center gap-2">
+                                  <p className="text-sm text-slate-900 dark:text-white">
+                                    {s.submitter?.name || s.submitter?.email || (s.is_anonymous ? "Anonymous" : "Unknown user")}
+                                  </p>
+                                  {s.is_anonymous && (
+                                    <span className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                                      Anonymous
+                                    </span>
+                                  )}
+                                </div>
                                 <p className="text-xs text-slate-500 dark:text-slate-400">
                                   <Clock className="mr-1 inline h-3 w-3" />
                                   {lastActivity.toLocaleString()}

--- a/auth.ts
+++ b/auth.ts
@@ -1,6 +1,12 @@
 import NextAuth from "next-auth";
 import type { NextAuthConfig, User } from "next-auth";
 import "next-auth/jwt";
+import { getAuthMode, isZitadelConfigured } from "@/lib/auth-mode";
+
+// When auth is not required, provide a default secret so NextAuth doesn't crash
+if (getAuthMode() !== "required" && !process.env.NEXTAUTH_SECRET) {
+  process.env.NEXTAUTH_SECRET = "ontokit-optional-auth-secret";
+}
 
 // Zitadel provider configuration
 const zitadelProvider = {
@@ -26,7 +32,9 @@ const zitadelProvider = {
 };
 
 export const authConfig: NextAuthConfig = {
-  providers: [zitadelProvider],
+  providers: getAuthMode() === "disabled" || !isZitadelConfigured()
+    ? []
+    : [zitadelProvider],
   events: {
     async signOut(_message) {
       // This event fires after local session is cleared
@@ -44,6 +52,11 @@ export const authConfig: NextAuthConfig = {
           expiresAt: account.expires_at,
           user,
         };
+      }
+
+      // Skip token refresh when Zitadel is not configured
+      if (!isZitadelConfigured()) {
+        return token;
       }
 
       // Return previous token if the access token has not expired yet
@@ -95,10 +108,9 @@ export const authConfig: NextAuthConfig = {
       return session;
     },
   },
-  pages: {
-    signIn: "/auth/signin",
-    error: "/auth/error",
-  },
+  pages: getAuthMode() === "required"
+    ? { signIn: "/auth/signin", error: "/auth/error" }
+    : {},
   debug: process.env.NODE_ENV === "development",
 };
 

--- a/components/auth/user-menu.tsx
+++ b/components/auth/user-menu.tsx
@@ -9,6 +9,11 @@ import { useState, useRef, useEffect } from "react";
 const ZITADEL_ISSUER = process.env.NEXT_PUBLIC_ZITADEL_ISSUER || "http://localhost:8080";
 const ZITADEL_CLIENT_ID = process.env.NEXT_PUBLIC_ZITADEL_CLIENT_ID || "";
 
+// Auth mode flags — set at build time by next.config.ts
+const authMode = process.env.NEXT_PUBLIC_AUTH_MODE || "required";
+const zitadelConfigured = process.env.NEXT_PUBLIC_ZITADEL_CONFIGURED === "true";
+const showAuthUI = authMode === "required" || (authMode === "optional" && zitadelConfigured);
+
 export function UserMenu() {
   const { data: session, status } = useSession();
   const [isOpen, setIsOpen] = useState(false);
@@ -42,6 +47,7 @@ export function UserMenu() {
   }
 
   if (!session) {
+    if (!showAuthUI) return null;
     return (
       <button
         onClick={() => signIn("zitadel")}

--- a/components/editor/ClassDetailPanel.tsx
+++ b/components/editor/ClassDetailPanel.tsx
@@ -26,6 +26,7 @@ import {
   StickyNote,
   Hash,
   Link2,
+  LogIn,
 } from "lucide-react";
 import { projectOntologyApi, type OWLClassDetail, type ClassUpdatePayload, type AnnotationUpdate } from "@/lib/api/client";
 import type { LocalizedString } from "@/lib/api/client";
@@ -75,6 +76,10 @@ interface ClassDetailPanelProps {
   refreshKey?: number;
   /** Extra actions rendered in the header row (e.g. Graph button) */
   headerActions?: ReactNode;
+  /** Show "Sign in to edit" button for anonymous users when Zitadel is configured */
+  showSignInToEdit?: boolean;
+  /** Called when anonymous user clicks "Sign in to edit" */
+  onSignInToEdit?: () => void;
 }
 
 export function ClassDetailPanel({
@@ -90,6 +95,8 @@ export function ClassDetailPanel({
   onUpdateClass,
   refreshKey,
   headerActions,
+  showSignInToEdit,
+  onSignInToEdit,
 }: ClassDetailPanelProps) {
   const [classDetail, setClassDetail] = useState<OWLClassDetail | null>(null);
   const [classIssues, setClassIssues] = useState<LintIssue[]>([]);
@@ -590,6 +597,16 @@ export function ClassDetailPanel({
               </h2>
               <div className="flex shrink-0 items-center gap-1">
                 {headerActions}
+                {!canEdit && !isEditing && showSignInToEdit && onSignInToEdit && (
+                  <button
+                    onClick={onSignInToEdit}
+                    className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-primary-600 hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-900/20"
+                    title="Sign in to edit this class"
+                  >
+                    <LogIn className="h-3.5 w-3.5" />
+                    Sign in to edit
+                  </button>
+                )}
               </div>
             </div>
             <div className="mt-1 flex items-center gap-2">

--- a/components/editor/ClassDetailPanel.tsx
+++ b/components/editor/ClassDetailPanel.tsx
@@ -27,6 +27,7 @@ import {
   Hash,
   Link2,
   LogIn,
+  Pencil,
 } from "lucide-react";
 import { projectOntologyApi, type OWLClassDetail, type ClassUpdatePayload, type AnnotationUpdate } from "@/lib/api/client";
 import type { LocalizedString } from "@/lib/api/client";
@@ -80,6 +81,12 @@ interface ClassDetailPanelProps {
   showSignInToEdit?: boolean;
   /** Called when anonymous user clicks "Sign in to edit" */
   onSignInToEdit?: () => void;
+  /** Show "Propose Edit" button for anonymous users (AUTH_MODE != required) */
+  canPropose?: boolean;
+  /** Called when anonymous user clicks "Propose Edit" */
+  onProposeEdit?: () => void;
+  /** True when anonymous proposal mode is active (editing is allowed) */
+  isAnonymousProposalMode?: boolean;
 }
 
 export function ClassDetailPanel({
@@ -97,6 +104,9 @@ export function ClassDetailPanel({
   headerActions,
   showSignInToEdit,
   onSignInToEdit,
+  canPropose,
+  onProposeEdit,
+  isAnonymousProposalMode: _isAnonymousProposalMode,
 }: ClassDetailPanelProps) {
   const [classDetail, setClassDetail] = useState<OWLClassDetail | null>(null);
   const [classIssues, setClassIssues] = useState<LintIssue[]>([]);
@@ -597,7 +607,29 @@ export function ClassDetailPanel({
               </h2>
               <div className="flex shrink-0 items-center gap-1">
                 {headerActions}
-                {!canEdit && !isEditing && showSignInToEdit && onSignInToEdit && (
+                {!canEdit && canPropose && !isEditing && onProposeEdit && (
+                  <>
+                    <button
+                      onClick={onProposeEdit}
+                      className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-emerald-600 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-900/20"
+                      title="Propose an edit to this class"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                      Propose Edit
+                    </button>
+                    {showSignInToEdit && onSignInToEdit && (
+                      <button
+                        onClick={onSignInToEdit}
+                        className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-500 hover:bg-slate-50 dark:text-slate-400 dark:hover:bg-slate-800"
+                        title="Sign in for full editing"
+                      >
+                        <LogIn className="h-3 w-3" />
+                        Sign in for full editing
+                      </button>
+                    )}
+                  </>
+                )}
+                {!canEdit && !canPropose && !isEditing && showSignInToEdit && onSignInToEdit && (
                   <button
                     onClick={onSignInToEdit}
                     className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-primary-600 hover:bg-primary-50 dark:text-primary-400 dark:hover:bg-primary-900/20"

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -117,6 +117,10 @@ export interface DeveloperEditorLayoutProps {
 
   /** Ref populated with a function to navigate to any entity type */
   entityNavigationRef?: React.RefObject<((iri: string, type?: string) => void) | null>;
+
+  // Sign-in-to-edit affordance for anonymous users
+  showSignInToEdit?: boolean;
+  onSignInToEdit?: () => void;
 }
 
 export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
@@ -165,6 +169,8 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
     onReparentClass,
     reparentOptimistic,
     rollbackReparent,
+    showSignInToEdit,
+    onSignInToEdit,
   } = props;
 
   const toast = useToast();
@@ -563,6 +569,8 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
                   canEdit={canEdit || isSuggestionMode}
                   onUpdateClass={onUpdateClass}
                   refreshKey={detailRefreshKey}
+                  showSignInToEdit={showSignInToEdit}
+                  onSignInToEdit={onSignInToEdit}
                 />
               ) : activeTab === "properties" ? (
                 <PropertyDetailPanel

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -121,6 +121,11 @@ export interface DeveloperEditorLayoutProps {
   // Sign-in-to-edit affordance for anonymous users
   showSignInToEdit?: boolean;
   onSignInToEdit?: () => void;
+
+  // Anonymous proposal mode
+  canPropose?: boolean;
+  onProposeEdit?: () => void;
+  isAnonymousProposalMode?: boolean;
 }
 
 export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
@@ -171,6 +176,9 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
     rollbackReparent,
     showSignInToEdit,
     onSignInToEdit,
+    canPropose,
+    onProposeEdit,
+    isAnonymousProposalMode,
   } = props;
 
   const toast = useToast();
@@ -571,6 +579,9 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
                   refreshKey={detailRefreshKey}
                   showSignInToEdit={showSignInToEdit}
                   onSignInToEdit={onSignInToEdit}
+                  canPropose={canPropose}
+                  onProposeEdit={onProposeEdit}
+                  isAnonymousProposalMode={isAnonymousProposalMode}
                 />
               ) : activeTab === "properties" ? (
                 <PropertyDetailPanel

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -89,6 +89,10 @@ export interface StandardEditorLayoutProps {
 
   /** Ref populated with a function to navigate to any entity type */
   entityNavigationRef?: React.RefObject<((iri: string, type?: string) => void) | null>;
+
+  // Sign-in-to-edit affordance for anonymous users
+  showSignInToEdit?: boolean;
+  onSignInToEdit?: () => void;
 }
 
 export function StandardEditorLayout(props: StandardEditorLayoutProps) {
@@ -126,6 +130,8 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
     onReparentClass,
     reparentOptimistic,
     rollbackReparent,
+    showSignInToEdit,
+    onSignInToEdit,
   } = props;
 
   const toast = useToast();
@@ -459,6 +465,8 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
             canEdit={canEdit || isSuggestionMode}
             onUpdateClass={onUpdateClass}
             refreshKey={detailRefreshKey}
+            showSignInToEdit={showSignInToEdit}
+            onSignInToEdit={onSignInToEdit}
             headerActions={selectedIri ? (
               <button
                 onClick={() => setShowGraph(true)}

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -93,6 +93,11 @@ export interface StandardEditorLayoutProps {
   // Sign-in-to-edit affordance for anonymous users
   showSignInToEdit?: boolean;
   onSignInToEdit?: () => void;
+
+  // Anonymous proposal mode
+  canPropose?: boolean;
+  onProposeEdit?: () => void;
+  isAnonymousProposalMode?: boolean;
 }
 
 export function StandardEditorLayout(props: StandardEditorLayoutProps) {
@@ -132,6 +137,9 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
     rollbackReparent,
     showSignInToEdit,
     onSignInToEdit,
+    canPropose,
+    onProposeEdit,
+    isAnonymousProposalMode,
   } = props;
 
   const toast = useToast();
@@ -467,6 +475,9 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
             refreshKey={detailRefreshKey}
             showSignInToEdit={showSignInToEdit}
             onSignInToEdit={onSignInToEdit}
+            canPropose={canPropose}
+            onProposeEdit={onProposeEdit}
+            isAnonymousProposalMode={isAnonymousProposalMode}
             headerActions={selectedIri ? (
               <button
                 onClick={() => setShowGraph(true)}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -7,11 +7,6 @@ import { NotificationBell } from "@/components/layout/notification-bell";
 import { ThemeToggle } from "@/components/editor/ThemeToggle";
 import { cn } from "@/lib/utils";
 
-// Auth mode flags — set at build time by next.config.ts
-const authMode = process.env.NEXT_PUBLIC_AUTH_MODE || "required";
-const zitadelConfigured = process.env.NEXT_PUBLIC_ZITADEL_CONFIGURED === "true";
-const showAuthUI = authMode === "required" || (authMode === "optional" && zitadelConfigured);
-
 const navLinks = [
   { href: "/", label: "Projects" },
   { href: "/info", label: "Info" },
@@ -21,6 +16,11 @@ const navLinks = [
 
 export function Header() {
   const pathname = usePathname();
+
+  // Auth mode flags — must be inside component for correct client-side hydration
+  const authMode = process.env.NEXT_PUBLIC_AUTH_MODE || "required";
+  const zitadelConfigured = process.env.NEXT_PUBLIC_ZITADEL_CONFIGURED === "true";
+  const showAuthUI = authMode === "required" || (authMode === "optional" && zitadelConfigured);
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-slate-200 dark:border-slate-700 bg-white/95 dark:bg-slate-900/95 backdrop-blur-sm supports-backdrop-filter:bg-white/60">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -7,6 +7,11 @@ import { NotificationBell } from "@/components/layout/notification-bell";
 import { ThemeToggle } from "@/components/editor/ThemeToggle";
 import { cn } from "@/lib/utils";
 
+// Auth mode flags — set at build time by next.config.ts
+const authMode = process.env.NEXT_PUBLIC_AUTH_MODE || "required";
+const zitadelConfigured = process.env.NEXT_PUBLIC_ZITADEL_CONFIGURED === "true";
+const showAuthUI = authMode === "required" || (authMode === "optional" && zitadelConfigured);
+
 const navLinks = [
   { href: "/", label: "Projects" },
   { href: "/info", label: "Info" },
@@ -50,8 +55,8 @@ export function Header() {
         </div>
         <div className="flex items-center gap-4">
           <ThemeToggle />
-          <NotificationBell />
-          <UserMenu />
+          {showAuthUI && <NotificationBell />}
+          {showAuthUI && <UserMenu />}
         </div>
       </div>
     </header>

--- a/components/suggestions/CreditModal.tsx
+++ b/components/suggestions/CreditModal.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { UserCheck } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useAnonymousCreditStore } from "@/lib/stores/anonymousCreditStore";
+
+interface CreditModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmitCredit: (name: string | null, email: string | null) => void;
+}
+
+/**
+ * Post-submission modal that lets anonymous contributors optionally
+ * provide their name and email for credit attribution.
+ *
+ * Appears AFTER a successful suggestion submit — it does not block the
+ * submission itself. Credit info is remembered in localStorage via
+ * useAnonymousCreditStore for future proposals.
+ *
+ * Includes a hidden honeypot field (name="website") that bots will fill
+ * but human users won't see. The parent should pass this value through
+ * to the submit payload as website="" (already handled by useAnonymousSuggestion).
+ */
+export function CreditModal({ open, onClose, onSubmitCredit }: CreditModalProps) {
+  const creditStore = useAnonymousCreditStore();
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [honeypot, setHoneypot] = useState("");
+
+  // Pre-fill from cached credit on open
+  useEffect(() => {
+    if (open) {
+      setName(creditStore.name ?? "");
+      setEmail(creditStore.email ?? "");
+      setHoneypot(""); // Always reset honeypot
+    }
+  }, [open, creditStore.name, creditStore.email]);
+
+  const handleSave = () => {
+    // If the honeypot field was filled (bot behavior), silently treat as skip
+    if (honeypot) {
+      onClose();
+      return;
+    }
+
+    const trimmedName = name.trim() || null;
+    const trimmedEmail = email.trim() || null;
+
+    // Cache credit info for future proposals (even if both are null = skip)
+    if (trimmedName || trimmedEmail) {
+      creditStore.setCredit(trimmedName, trimmedEmail);
+    }
+
+    onSubmitCredit(trimmedName, trimmedEmail);
+    onClose();
+  };
+
+  const handleSkip = () => {
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <UserCheck className="h-5 w-5 text-emerald-500" />
+            Want credit for your suggestions?
+          </DialogTitle>
+          <DialogDescription>
+            Your changes have been submitted for review. Optionally share your name and email so the project maintainers can follow up.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="my-4 space-y-3">
+          {/* Name field */}
+          <div>
+            <label
+              htmlFor="credit-name"
+              className="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400"
+            >
+              Name <span className="text-slate-400">(optional)</span>
+            </label>
+            <input
+              id="credit-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              autoComplete="name"
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:placeholder:text-slate-500"
+            />
+          </div>
+
+          {/* Email field */}
+          <div>
+            <label
+              htmlFor="credit-email"
+              className="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400"
+            >
+              Email <span className="text-slate-400">(optional)</span>
+            </label>
+            <input
+              id="credit-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="your@email.com"
+              autoComplete="email"
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm placeholder:text-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100 dark:placeholder:text-slate-500"
+            />
+          </div>
+
+          {/* Honeypot field — invisible to humans, filled by bots */}
+          <input
+            name="website"
+            type="text"
+            value={honeypot}
+            onChange={(e) => setHoneypot(e.target.value)}
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              left: "-9999px",
+              opacity: 0,
+              pointerEvents: "none",
+            }}
+          />
+
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Your info will only be used to attribute your contribution. We won&apos;t add you to any mailing list.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleSkip}
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            className="bg-emerald-600 hover:bg-emerald-700 text-white"
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/api/suggestions.ts
+++ b/lib/api/suggestions.ts
@@ -4,6 +4,9 @@
  * Manages the suggestion workflow for non-technical users (suggesters).
  * Each session maps to a suggestion branch; edits auto-save as commits,
  * and explicit submission creates a PR for review.
+ *
+ * Also provides anonymousSuggestionsApi for unauthenticated users —
+ * uses X-Anonymous-Token header instead of Authorization: Bearer.
  */
 
 import { api } from "./client";
@@ -92,6 +95,32 @@ export interface SuggestionResubmitPayload {
 export interface SuggestionBeaconPayload {
   session_id: string;
   content: string;
+}
+
+// --- Anonymous suggestion types ---
+
+/**
+ * Response from creating an anonymous suggestion session.
+ * The anonymous_token must be stored client-side and passed as
+ * X-Anonymous-Token on all subsequent calls for this session.
+ */
+export interface AnonymousSessionCreateResponse {
+  session_id: string;
+  branch: string;
+  created_at: string;
+  anonymous_token: string;
+}
+
+/**
+ * Payload for submitting an anonymous suggestion session.
+ * submitter_name and submitter_email are optional credit fields.
+ * website is a honeypot — always send as empty string; bots fill it.
+ */
+export interface AnonymousSubmitPayload {
+  summary?: string;
+  submitter_name?: string;
+  submitter_email?: string;
+  website?: string; // honeypot field — always send empty string
 }
 
 // --- API ---
@@ -240,4 +269,85 @@ export const suggestionsApi = {
       data,
       { headers: { Authorization: `Bearer ${token}` } },
     ),
+};
+
+// --- Anonymous suggestion API ---
+
+/**
+ * API client for anonymous (unauthenticated) suggestion sessions.
+ *
+ * All methods use X-Anonymous-Token header rather than Authorization: Bearer.
+ * The anonymous token is returned on session creation and must be stored
+ * in localStorage and passed to all subsequent calls.
+ *
+ * Only available when AUTH_MODE is "optional" or "disabled" on the server.
+ */
+export const anonymousSuggestionsApi = {
+  /**
+   * Create a new anonymous suggestion session.
+   * No token required — returns an anonymous_token to use for subsequent calls.
+   */
+  createSession: (projectId: string) =>
+    api.post<AnonymousSessionCreateResponse>(
+      `/api/v1/projects/${projectId}/suggestions/anonymous/sessions`,
+    ),
+
+  /**
+   * Save content to the anonymous suggestion branch.
+   */
+  save: (
+    projectId: string,
+    sessionId: string,
+    data: SuggestionSavePayload,
+    anonymousToken: string,
+  ) =>
+    api.put<SuggestionSaveResponse>(
+      `/api/v1/projects/${projectId}/suggestions/anonymous/sessions/${sessionId}/save`,
+      data,
+      { headers: { "X-Anonymous-Token": anonymousToken } },
+    ),
+
+  /**
+   * Submit the anonymous suggestion session — creates a PR for review.
+   * Optionally includes submitter_name/email for credit attribution.
+   * Always send website as empty string (honeypot — bots fill this, humans don't).
+   */
+  submit: (
+    projectId: string,
+    sessionId: string,
+    data: AnonymousSubmitPayload,
+    anonymousToken: string,
+  ) =>
+    api.post<SuggestionSubmitResponse>(
+      `/api/v1/projects/${projectId}/suggestions/anonymous/sessions/${sessionId}/submit`,
+      data,
+      { headers: { "X-Anonymous-Token": anonymousToken } },
+    ),
+
+  /**
+   * Discard an anonymous suggestion session (deletes the suggestion branch).
+   */
+  discard: (projectId: string, sessionId: string, anonymousToken: string) =>
+    api.post<void>(
+      `/api/v1/projects/${projectId}/suggestions/anonymous/sessions/${sessionId}/discard`,
+      undefined,
+      { headers: { "X-Anonymous-Token": anonymousToken } },
+    ),
+
+  /**
+   * Send a beacon payload to flush the last draft on browser close.
+   * Uses navigator.sendBeacon — cannot set X-Anonymous-Token header,
+   * so the token is passed as a query param.
+   */
+  beacon: (
+    projectId: string,
+    sessionId: string,
+    content: string,
+    anonymousToken: string,
+  ) => {
+    const url = `${API_BASE}/api/v1/projects/${projectId}/suggestions/anonymous/beacon?token=${encodeURIComponent(anonymousToken)}`;
+    const payload = JSON.stringify({ session_id: sessionId, content });
+    const blob = new Blob([payload], { type: "application/json" });
+    return navigator.sendBeacon(url, blob);
+  },
 };

--- a/lib/api/suggestions.ts
+++ b/lib/api/suggestions.ts
@@ -64,6 +64,7 @@ export interface SuggestionSessionSummary {
   reviewed_at?: string;
   revision?: number;
   summary?: string;
+  is_anonymous?: boolean;
 }
 
 export interface SuggestionSessionListResponse {

--- a/lib/auth-mode.ts
+++ b/lib/auth-mode.ts
@@ -1,0 +1,27 @@
+/**
+ * Centralized auth mode configuration.
+ *
+ * AUTH_MODE controls authentication behavior:
+ * - "required" (default): Zitadel OIDC, must sign in to use app
+ * - "optional": Browse anonymously, sign in available if Zitadel configured
+ * - "disabled": No auth at all, anonymous browsing only
+ */
+
+export type AuthMode = "required" | "optional" | "disabled";
+
+/** Server-side auth mode (reads process.env directly) */
+export function getAuthMode(): AuthMode {
+  const mode = process.env.AUTH_MODE?.toLowerCase();
+  if (mode === "optional" || mode === "disabled") return mode;
+  return "required";
+}
+
+/** Whether Zitadel OIDC is configured (server-side check) */
+export function isZitadelConfigured(): boolean {
+  return !!(process.env.ZITADEL_ISSUER && process.env.ZITADEL_CLIENT_ID);
+}
+
+/** Whether auth is required (must sign in to use the app) */
+export function isAuthRequired(): boolean {
+  return getAuthMode() === "required";
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isAuthRequired } from "./auth-mode";
 
 const serverSchema = z.object({
   ZITADEL_ISSUER: z.url("ZITADEL_ISSUER must be a valid URL"),
@@ -19,7 +20,21 @@ export type ServerEnv = z.infer<typeof serverSchema>;
 export type ClientEnv = z.infer<typeof clientSchema>;
 
 function validateServerEnv(): ServerEnv {
-  const result = serverSchema.safeParse(process.env);
+  // When auth is not required, Zitadel vars are optional
+  const schema = isAuthRequired()
+    ? serverSchema
+    : z.object({
+        ZITADEL_ISSUER: z.url().optional(),
+        ZITADEL_CLIENT_ID: z.string().optional(),
+        ZITADEL_CLIENT_SECRET: z.string().optional(),
+        NEXTAUTH_URL: z.url().optional(),
+        NEXTAUTH_SECRET: z
+          .string()
+          .min(1, "NEXTAUTH_SECRET is required")
+          .default("ontokit-dev-secret"),
+      });
+
+  const result = schema.safeParse(process.env);
   if (!result.success) {
     const tree = z.treeifyError(result.error);
     const messages = Object.entries(tree.properties ?? {})
@@ -33,7 +48,7 @@ function validateServerEnv(): ServerEnv {
         `Set the required variables before starting the server.`
     );
   }
-  return result.data;
+  return result.data as ServerEnv;
 }
 
 function validateClientEnv(): ClientEnv {

--- a/lib/hooks/useAnonymousSuggestion.ts
+++ b/lib/hooks/useAnonymousSuggestion.ts
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import {
+  anonymousSuggestionsApi,
+  type SuggestionSavePayload,
+} from "@/lib/api/suggestions";
+import {
+  useAnonymousTokenStore,
+} from "@/lib/stores/anonymousCreditStore";
+
+import type { SuggestionStatus } from "@/lib/hooks/useSuggestionSession";
+
+// Re-export SuggestionStatus so callers can use it from this module too
+export type { SuggestionStatus };
+
+export interface UseAnonymousSuggestionReturn {
+  sessionId: string | null;
+  branch: string | null;
+  anonymousToken: string | null;
+  changesCount: number;
+  status: SuggestionStatus;
+  error: string | null;
+  entitiesModified: string[];
+  isActive: boolean;
+  startSession: () => Promise<void>;
+  saveToSession: (content: string, entityIri: string, entityLabel: string) => Promise<void>;
+  submitSession: (summary?: string, submitterName?: string, submitterEmail?: string) => Promise<void>;
+  discardSession: () => Promise<void>;
+}
+
+interface UseAnonymousSuggestionOptions {
+  projectId: string;
+  onSubmitted?: (prNumber: number, prUrl: string | null) => void;
+  onError?: (msg: string) => void;
+}
+
+/**
+ * Manages the full anonymous suggestion session lifecycle.
+ *
+ * Mirrors useSuggestionSession but uses anonymous tokens
+ * (X-Anonymous-Token header) instead of Bearer tokens.
+ * The anonymous token is persisted in localStorage via useAnonymousTokenStore
+ * and restored on mount so sessions survive page navigations.
+ *
+ * Only usable when AUTH_MODE is "optional" or "disabled" on the server.
+ */
+export function useAnonymousSuggestion({
+  projectId,
+  onSubmitted,
+  onError,
+}: UseAnonymousSuggestionOptions): UseAnonymousSuggestionReturn {
+  const tokenStore = useAnonymousTokenStore();
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [branch, setBranch] = useState<string | null>(null);
+  const [anonymousToken, setAnonymousToken] = useState<string | null>(null);
+  const [changesCount, setChangesCount] = useState(0);
+  const [status, setStatus] = useState<SuggestionStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [entitiesModified, setEntitiesModified] = useState<string[]>([]);
+
+  const savingRef = useRef(false);
+  const restoredRef = useRef(false);
+
+  // Restore any active session from localStorage on mount
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+
+    const entry = tokenStore.getToken(projectId);
+    if (entry) {
+      setSessionId(entry.sessionId);
+      setBranch(entry.branch);
+      setAnonymousToken(entry.token);
+      setStatus("active");
+    }
+  // Only run once on mount — tokenStore.getToken is stable
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  const startSession = useCallback(async () => {
+    // Don't create a duplicate session if one already exists
+    if (sessionId) return;
+
+    try {
+      const session = await anonymousSuggestionsApi.createSession(projectId);
+
+      // Persist token to localStorage before updating state
+      tokenStore.setToken(projectId, session.anonymous_token, session.session_id, session.branch);
+
+      setSessionId(session.session_id);
+      setBranch(session.branch);
+      setAnonymousToken(session.anonymous_token);
+      setStatus("active");
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to start anonymous suggestion session";
+      setStatus("error");
+      setError(msg);
+      onError?.(msg);
+    }
+  }, [sessionId, projectId, tokenStore, onError]);
+
+  const saveToSession = useCallback(async (
+    content: string,
+    entityIri: string,
+    entityLabel: string,
+  ) => {
+    if (!sessionId || !anonymousToken || savingRef.current) return;
+
+    savingRef.current = true;
+    setStatus("saving");
+    setError(null);
+
+    try {
+      const payload: SuggestionSavePayload = {
+        content,
+        entity_iri: entityIri,
+        entity_label: entityLabel,
+      };
+      const result = await anonymousSuggestionsApi.save(projectId, sessionId, payload, anonymousToken);
+      setChangesCount(result.changes_count);
+
+      // Track modified entities (deduplicated by label)
+      setEntitiesModified((prev) => {
+        if (prev.includes(entityLabel)) return prev;
+        return [...prev, entityLabel];
+      });
+
+      setStatus("active");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to save anonymous suggestion";
+      setStatus("error");
+      setError(msg);
+      onError?.(msg);
+    } finally {
+      savingRef.current = false;
+    }
+  }, [sessionId, anonymousToken, projectId, onError]);
+
+  const submitSession = useCallback(async (
+    summary?: string,
+    submitterName?: string,
+    submitterEmail?: string,
+  ) => {
+    if (!sessionId || !anonymousToken) return;
+
+    setStatus("submitting");
+    setError(null);
+
+    try {
+      const result = await anonymousSuggestionsApi.submit(
+        projectId,
+        sessionId,
+        {
+          summary,
+          submitter_name: submitterName,
+          submitter_email: submitterEmail,
+          website: "", // honeypot — always empty for legitimate users
+        },
+        anonymousToken,
+      );
+
+      // Clear persisted token on successful submit
+      tokenStore.clearToken(projectId);
+
+      setStatus("submitted");
+      onSubmitted?.(result.pr_number, result.pr_url);
+
+      // Reset session state so a new session can start
+      setSessionId(null);
+      setBranch(null);
+      setAnonymousToken(null);
+      setChangesCount(0);
+      setEntitiesModified([]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to submit anonymous suggestions";
+      setStatus("error");
+      setError(msg);
+      onError?.(msg);
+    }
+  }, [sessionId, anonymousToken, projectId, tokenStore, onSubmitted, onError]);
+
+  const discardSession = useCallback(async () => {
+    if (!sessionId || !anonymousToken) return;
+
+    try {
+      await anonymousSuggestionsApi.discard(projectId, sessionId, anonymousToken);
+    } catch {
+      // Best-effort discard — don't block UX on network failure
+    }
+
+    // Clear persisted token regardless of API success
+    tokenStore.clearToken(projectId);
+
+    setSessionId(null);
+    setBranch(null);
+    setAnonymousToken(null);
+    setChangesCount(0);
+    setEntitiesModified([]);
+    setStatus("idle");
+    setError(null);
+  }, [sessionId, anonymousToken, projectId, tokenStore]);
+
+  return {
+    sessionId,
+    branch,
+    anonymousToken,
+    changesCount,
+    status,
+    error,
+    entitiesModified,
+    isActive: status === "active" || status === "saving",
+    startSession,
+    saveToSession,
+    submitSession,
+    discardSession,
+  };
+}

--- a/lib/stores/anonymousCreditStore.ts
+++ b/lib/stores/anonymousCreditStore.ts
@@ -1,0 +1,104 @@
+/**
+ * Anonymous suggestion stores
+ *
+ * Two persisted Zustand stores for anonymous suggestion sessions:
+ *
+ * 1. useAnonymousCreditStore — remembers submitter name/email in localStorage
+ *    so repeat anonymous contributors don't have to retype their info.
+ *
+ * 2. useAnonymousTokenStore — persists the anonymous session token, sessionId,
+ *    and branch per projectId so the session survives page navigations.
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+// --- Credit store ---
+
+interface AnonymousCreditState {
+  name: string | null;
+  email: string | null;
+  setCredit: (name: string | null, email: string | null) => void;
+  clearCredit: () => void;
+  hasCredit: () => boolean;
+}
+
+/**
+ * Persisted store for optional submitter credit info (name + email).
+ * Pre-fills the CreditModal on subsequent submissions.
+ * Stored under localStorage key "ontokit-anonymous-credit".
+ */
+export const useAnonymousCreditStore = create<AnonymousCreditState>()(
+  persist(
+    (set, get) => ({
+      name: null,
+      email: null,
+
+      setCredit: (name, email) => set({ name, email }),
+
+      clearCredit: () => set({ name: null, email: null }),
+
+      hasCredit: () => {
+        const { name, email } = get();
+        return !!(name || email);
+      },
+    }),
+    {
+      name: "ontokit-anonymous-credit",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+// --- Anonymous token store ---
+
+interface AnonymousTokenEntry {
+  token: string;
+  sessionId: string;
+  branch: string;
+}
+
+interface AnonymousTokenState {
+  tokens: Record<string, AnonymousTokenEntry>;
+  setToken: (
+    projectId: string,
+    token: string,
+    sessionId: string,
+    branch: string,
+  ) => void;
+  getToken: (projectId: string) => AnonymousTokenEntry | null;
+  clearToken: (projectId: string) => void;
+}
+
+/**
+ * Persisted store for anonymous session tokens, keyed by projectId.
+ * Allows resuming an in-progress anonymous session after page reload/navigation.
+ * Stored under localStorage key "ontokit-anonymous-token".
+ */
+export const useAnonymousTokenStore = create<AnonymousTokenState>()(
+  persist(
+    (set, get) => ({
+      tokens: {},
+
+      setToken: (projectId, token, sessionId, branch) =>
+        set((state) => ({
+          tokens: {
+            ...state.tokens,
+            [projectId]: { token, sessionId, branch },
+          },
+        })),
+
+      getToken: (projectId) => get().tokens[projectId] ?? null,
+
+      clearToken: (projectId) =>
+        set((state) => {
+          const { [projectId]: _, ...rest } = state.tokens;
+          return { tokens: rest };
+        }),
+    }),
+    {
+      name: "ontokit-anonymous-token",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,8 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NEXT_PUBLIC_WS_URL: process.env.NEXT_PUBLIC_WS_URL,
+    NEXT_PUBLIC_AUTH_MODE: process.env.AUTH_MODE || "required",
+    NEXT_PUBLIC_ZITADEL_CONFIGURED: process.env.ZITADEL_ISSUER ? "true" : "false",
   },
 
   // WSL2: use polling for file watching since inotify doesn't work across the VM boundary


### PR DESCRIPTION
## Summary

### AUTH_MODE (Phase 8)
- `AUTH_MODE=required|optional|disabled` support across the frontend
- `lib/auth-mode.ts` — centralized helpers (`getAuthMode`, `isZitadelConfigured`, `isAuthRequired`)
- Conditional Zitadel provider in NextAuth, env validation, NEXTAUTH_SECRET fallback
- Header sign-in UI hidden when Zitadel not configured
- "Sign in to edit" buttons with `callbackUrl` for return-to-same-page

### Anonymous Suggestions (Phase 10)
- Anonymous API client + `useAnonymousSuggestion` hook + localStorage token/credit stores
- "Propose Edit" button on ClassDetailPanel for anonymous visitors on public projects
- "Want credit for your suggestions?" modal with optional name/email (remembered in localStorage)
- "Sign in for full editing" link alongside Propose Edit when Zitadel configured
- Editor page wiring for anonymous proposal mode (batch edits, submit, discard)
- Review page displays submitter name/email or "Anonymous" badge

### GSD Planning Artifacts
- `.planning/` directory with PROJECT.md, ROADMAP.md, REQUIREMENTS.md, STATE.md
- Phase plans, summaries, and context for phases 7-10

## Test plan

- [ ] `npx tsc --noEmit` — type check passes
- [ ] `npx vitest run` — 95 tests pass
- [ ] `AUTH_MODE=optional` + no Zitadel → anonymous browsing, no sign-in button, "Propose Edit" visible
- [ ] Click "Propose Edit" → edit mode activates → submit shows credit modal
- [ ] `AUTH_MODE=required` → unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional auth modes (required/optional/disabled) with anonymous proposal flow and “Propose Edit” for unauthenticated users.
  * Anonymous suggestion sessions: create/save/submit/discard flows, credit modal, persisted anonymous tokens, and client hook/store support.

* **Improvements**
  * Conditional auth UI: sign-in CTAs, user menu, and header actions respect runtime auth configuration; signIn callbacks restored to return users to the same page.

* **Documentation**
  * Added roadmap, milestones, requirements, deployment and phase planning for v0.3.0 (including anonymous-suggestions and optional-auth).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->