### PR TITLE
fix: remove accessToken from React Query keys to prevent unnecessary refetches

### DIFF
--- a/lib/context/BranchContext.tsx
+++ b/lib/context/BranchContext.tsx
@@ -18,7 +18,7 @@ import {
 // --- Query key factory ---
 
 export const branchQueryKeys = {
-  list: (projectId: string, accessToken?: string) => ["branches", projectId, accessToken] as const,
+  list: (projectId: string, accessToken?: string) => ["branches", projectId, !!accessToken] as const,
 };
 
 // --- sessionStorage helpers ---

--- a/lib/hooks/useCrossReferences.ts
+++ b/lib/hooks/useCrossReferences.ts
@@ -8,7 +8,7 @@ export function useCrossReferences(
   branch?: string
 ) {
   return useQuery({
-    queryKey: ["crossReferences", projectId, entityIri, accessToken, branch],
+    queryKey: ["crossReferences", projectId, entityIri, !!accessToken, branch],
     queryFn: () =>
       qualityApi.getCrossReferences(projectId, entityIri!, accessToken, branch),
     enabled: !!entityIri && !!projectId,

--- a/lib/hooks/useEntityHistory.ts
+++ b/lib/hooks/useEntityHistory.ts
@@ -9,7 +9,7 @@ export function useEntityHistory(
   limit = 50
 ) {
   return useQuery({
-    queryKey: ["entityHistory", projectId, entityIri, accessToken, branch, limit],
+    queryKey: ["entityHistory", projectId, entityIri, !!accessToken, branch, limit],
     queryFn: () =>
       analyticsApi.getEntityHistory(projectId, entityIri!, accessToken, branch, limit),
     enabled: !!entityIri && !!projectId,

--- a/lib/hooks/useProjectAnalytics.ts
+++ b/lib/hooks/useProjectAnalytics.ts
@@ -7,7 +7,7 @@ export function useProjectActivity(
   days = 30
 ) {
   return useQuery({
-    queryKey: ["projectActivity", projectId, accessToken, days],
+    queryKey: ["projectActivity", projectId, !!accessToken, days],
     queryFn: () => analyticsApi.getActivity(projectId, accessToken, days),
     enabled: !!projectId,
     staleTime: 60_000,
@@ -20,7 +20,7 @@ export function useHotEntities(
   limit = 20
 ) {
   return useQuery({
-    queryKey: ["hotEntities", projectId, accessToken, limit],
+    queryKey: ["hotEntities", projectId, !!accessToken, limit],
     queryFn: () => analyticsApi.getHotEntities(projectId, accessToken, limit),
     enabled: !!projectId,
     staleTime: 60_000,
@@ -33,7 +33,7 @@ export function useContributors(
   days = 30
 ) {
   return useQuery({
-    queryKey: ["contributors", projectId, accessToken, days],
+    queryKey: ["contributors", projectId, !!accessToken, days],
     queryFn: () => analyticsApi.getContributors(projectId, accessToken, days),
     enabled: !!projectId,
     staleTime: 60_000,

--- a/lib/hooks/useSemanticSearch.ts
+++ b/lib/hooks/useSemanticSearch.ts
@@ -12,7 +12,7 @@ export function useSemanticSearch(
   limit = 20
 ) {
   return useQuery({
-    queryKey: ["search", mode, projectId, query, accessToken, branch, limit],
+    queryKey: ["search", mode, projectId, query, !!accessToken, branch, limit],
     queryFn: async () => {
       if (mode === "text") {
         const response = await projectOntologyApi.searchEntities(

--- a/lib/hooks/useSimilarEntities.ts
+++ b/lib/hooks/useSimilarEntities.ts
@@ -9,7 +9,7 @@ export function useSimilarEntities(
   limit = 10
 ) {
   return useQuery({
-    queryKey: ["similar", projectId, entityIri, accessToken, branch, limit],
+    queryKey: ["similar", projectId, entityIri, !!accessToken, branch, limit],
     queryFn: () =>
       embeddingsApi.getSimilarEntities(
         projectId,


### PR DESCRIPTION
## Summary

- Replaced raw `accessToken` strings in React Query keys with `!!accessToken` (a stable boolean) across 7 files
- OIDC tokens rotate on refresh, so including the full token string in query keys caused all queries to refetch unnecessarily whenever the token was refreshed
- The token is still passed to query functions via closure for actual API calls

### Files changed
- `app/page.tsx` — projects list query
- `lib/context/BranchContext.tsx` — `branchQueryKeys.list` factory (also affects all `invalidateQueries` call sites in the editor page)
- `lib/hooks/useProjectAnalytics.ts` — 3 analytics hooks
- `lib/hooks/useCrossReferences.ts`
- `lib/hooks/useSimilarEntities.ts`
- `lib/hooks/useEntityHistory.ts`
- `lib/hooks/useSemanticSearch.ts`

Closes #53

## Test plan

- [ ] Verify queries still fire on initial page load (authenticated and unauthenticated)
- [ ] Verify queries do **not** refetch when the OIDC token silently refreshes
- [ ] Verify signing out and back in correctly triggers refetches (boolean flips false→true)
- [ ] Verify branch list, project list, analytics, and search all function normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized query caching behavior to streamline cache key generation across multiple data queries, improving cache efficiency and reducing redundant data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->