### PR TITLE
fix: replace window.location.reload() with React Query refetch

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,9 @@ export default function HomePage() {
   const {
     data,
     isLoading,
+    isFetching,
     error,
+    refetch,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -190,9 +192,10 @@ export default function HomePage() {
                 <Button
                   variant="outline"
                   className="mt-4"
-                  onClick={() => window.location.reload()}
+                  onClick={() => refetch()}
+                  disabled={isFetching}
                 >
-                  Try Again
+                  {isFetching ? "Retrying..." : "Try Again"}
                 </Button>
               </div>
             ) : projects.length === 0 ? (


### PR DESCRIPTION
## Summary
- Replace `window.location.reload()` in the error retry button on the home page (`app/page.tsx`) with React Query's `refetch()` function
- This retries only the failed projects query instead of discarding all client-side state and reloading the entire page

Closes #54

## Test plan
- [x] Navigate to the home page
- [x] Simulate or trigger a network error on the projects query
- [x] Click "Try Again" and verify only the query is retried (no full page reload)
- [x] Verify projects load successfully after retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery: the "Try Again" button now re-runs the failed request instead of performing a full page reload, is disabled while the retry is in progress, and shows a "Retrying..." label during refresh for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->