### PR TITLE
feat: add share button to copy project permalink

### DIFF
--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -787,7 +787,7 @@ export default function EditorPage() {
               </div>
               {canManage && (
                 <Link href={`/projects/${projectId}/settings`}>
-                  <Button variant="ghost" size="sm">
+                  <Button variant="ghost" size="sm" title="Project settings" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">
                     <Settings className="h-4 w-4" />
                   </Button>
                 </Link>
@@ -993,7 +993,7 @@ export default function EditorPage() {
 
               {canManage && (
                 <Link href={`/projects/${projectId}/settings`}>
-                  <Button variant="ghost" size="sm">
+                  <Button variant="ghost" size="sm" title="Project settings" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">
                     <Settings className="h-4 w-4" />
                   </Button>
                 </Link>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -97,13 +97,13 @@ export default function ProjectViewerPage() {
               <div className="flex items-center gap-2">
                 <ShareButton projectId={projectId} />
                 <Link href={`/projects/${projectId}/dashboard`}>
-                  <Button variant="ghost" size="sm">
+                  <Button variant="ghost" size="sm" title="Project dashboard" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">
                     <LayoutDashboard className="h-4 w-4" />
                   </Button>
                 </Link>
                 {canManage && (
                   <Link href={`/projects/${projectId}/settings`}>
-                    <Button variant="ghost" size="sm">
+                    <Button variant="ghost" size="sm" title="Project settings" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">
                       <Settings className="h-4 w-4" />
                     </Button>
                   </Link>
@@ -251,7 +251,7 @@ function ViewerContent({
 
               {/* Dashboard link */}
               <Link href={`/projects/${projectId}/dashboard`}>
-                <Button variant="ghost" size="sm" title="Project dashboard">
+                <Button variant="ghost" size="sm" title="Project dashboard" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">
                   <LayoutDashboard className="h-4 w-4" />
                 </Button>
               </Link>
@@ -278,7 +278,7 @@ function ViewerContent({
 
               {canManage && (
                 <Link href={`/projects/${projectId}/settings`}>
-                  <Button variant="ghost" size="sm">
+                  <Button variant="ghost" size="sm" title="Project settings" className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white">
                     <Settings className="h-4 w-4" />
                   </Button>
                 </Link>

--- a/components/editor/ShareButton.tsx
+++ b/components/editor/ShareButton.tsx
@@ -69,8 +69,9 @@ export function ShareButton({ projectId, selectedIri, selectedLabel }: ShareButt
       <Button
         variant="ghost"
         size="sm"
-        className="gap-1.5"
+        className="gap-1.5 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
         onClick={() => copyToClipboard(projectUrl)}
+        title="Share project permalink"
         aria-label="Copy project link"
       >
         <Share2 className="h-4 w-4" />
@@ -86,8 +87,9 @@ export function ShareButton({ projectId, selectedIri, selectedLabel }: ShareButt
       <Button
         variant="ghost"
         size="sm"
-        className="gap-1.5 rounded-r-none pr-1.5"
+        className="gap-1.5 rounded-r-none pr-1.5 text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
         onClick={() => copyToClipboard(classUrl, displayLabel || undefined)}
+        title={`Share link to "${displayLabel}"`}
         aria-label={`Copy link to ${displayLabel}`}
       >
         <Share2 className="h-4 w-4" />
@@ -100,8 +102,9 @@ export function ShareButton({ projectId, selectedIri, selectedLabel }: ShareButt
       <Button
         variant="ghost"
         size="sm"
-        className="rounded-l-none border-l border-slate-200 px-1 dark:border-slate-700"
+        className="rounded-l-none border-l border-slate-200 px-1 text-slate-500 hover:text-slate-900 dark:border-slate-700 dark:text-slate-400 dark:hover:text-white"
         onClick={() => setDropdownOpen(!dropdownOpen)}
+        title="More share options"
         aria-label="More share options"
         aria-expanded={dropdownOpen}
         aria-haspopup="menu"

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -11,7 +11,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         className={cn(
-          "inline-flex items-center justify-center rounded-md font-medium transition-colors",
+          "inline-flex items-center justify-center rounded-md font-medium transition-colors cursor-pointer",
           "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900",
           "disabled:pointer-events-none disabled:opacity-50",
           {


### PR DESCRIPTION
## Summary

- Add adaptive `ShareButton` component to viewer and editor toolbars
- **No class selected**: Simple "Share" button → copies project link (`/projects/{id}`)
- **Class selected**: Split button → primary copies class deep link (`/projects/{id}?classIri=...`), dropdown chevron offers "Copy project link" fallback
- Toast feedback: "Copied link to 'ClassName'" or "Copied project link"
- Long class names truncate with ellipsis (24 char max in button label)
- Keyboard accessible: Escape closes dropdown, outside click closes dropdown

Closes #75

## Test plan

- [x] Open viewer without selecting a class — "Share" button copies project link
- [x] Select a class — button becomes split: primary copies class link, dropdown offers project link
- [x] Verify toast shows correct message for each action
- [x] Verify long class names truncate in button label
- [x] Test in dark mode
- [x] Test dropdown closes on outside click and Escape key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a share button in the project editor and viewer interfaces
  * Users can now copy project URLs and direct links to selected ontology classes
  * Added copy-to-clipboard functionality with confirmation feedback
  * Split control design with dropdown menu for flexible sharing options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->