### PR TITLE
refactor: move Tooltip provider to app level for shared usage

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import { useState, type ReactNode } from "react";
 import { ToastProvider } from "@/lib/context/ToastContext";
 import { ToastContainer } from "@/components/ui/toast-container";
 import { ScreenReaderAnnouncerProvider } from "@/components/ui/ScreenReaderAnnouncer";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { SessionGuard } from "@/components/auth/SessionGuard";
 
 // Import the store module to ensure module-level theme sync runs
@@ -34,8 +35,10 @@ export function Providers({ children }: ProvidersProps) {
       <QueryClientProvider client={queryClient}>
         <ScreenReaderAnnouncerProvider>
           <ToastProvider>
-            {children}
-            <ToastContainer />
+            <TooltipPrimitive.Provider delayDuration={200}>
+              {children}
+              <ToastContainer />
+            </TooltipPrimitive.Provider>
           </ToastProvider>
         </ScreenReaderAnnouncerProvider>
       </QueryClientProvider>

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -9,7 +9,6 @@ interface TooltipProps {
   children: ReactNode;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
-  delayDuration?: number;
 }
 
 export function Tooltip({
@@ -17,28 +16,25 @@ export function Tooltip({
   children,
   side = "top",
   align = "center",
-  delayDuration = 200,
 }: TooltipProps) {
   return (
-    <TooltipPrimitive.Provider delayDuration={delayDuration}>
-      <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Portal>
-          <TooltipPrimitive.Content
-            side={side}
-            align={align}
-            sideOffset={5}
-            className={cn(
-              "z-50 max-w-xs rounded-md bg-slate-900 px-3 py-2 text-xs text-slate-50",
-              "shadow-md animate-in fade-in-0 zoom-in-95",
-              "dark:bg-slate-100 dark:text-slate-900",
-            )}
-          >
-            {content}
-            <TooltipPrimitive.Arrow className="fill-slate-900 dark:fill-slate-100" />
-          </TooltipPrimitive.Content>
-        </TooltipPrimitive.Portal>
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+    <TooltipPrimitive.Root>
+      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          side={side}
+          align={align}
+          sideOffset={5}
+          className={cn(
+            "z-50 max-w-xs rounded-md bg-slate-900 px-3 py-2 text-xs text-slate-50",
+            "shadow-md animate-in fade-in-0 zoom-in-95",
+            "dark:bg-slate-100 dark:text-slate-900",
+          )}
+        >
+          {content}
+          <TooltipPrimitive.Arrow className="fill-slate-900 dark:fill-slate-100" />
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
   );
 }


### PR DESCRIPTION
## Summary
- Moves `TooltipPrimitive.Provider` from individual `Tooltip` component instances to `app/providers.tsx`, so all tooltips share a single provider with consistent `delayDuration={200}` behavior. Closes #84.
- Removes the now-unnecessary `delayDuration` prop from the `Tooltip` component interface.

## Test plan
- [ ] Verify tooltips still appear with ~200ms delay on hover throughout the app (e.g., editor toolbar buttons, tree icons)
- [ ] Verify tooltip content renders correctly with proper positioning (`side`, `align`)
- [ ] Verify no console errors related to missing Tooltip provider context
- [ ] Run `npm run type-check` and `npm run lint` with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tooltip configuration moved to the application level for consistent behavior across the UI.
  * Per-tooltip delay setting removed: individual tooltips no longer accept a custom delay, relying on the app-level timing instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->