### PR TITLE
fix: suppress exhaustive-deps false positive in useProjectViewer

### DIFF
--- a/lib/hooks/useProjectViewer.ts
+++ b/lib/hooks/useProjectViewer.ts
@@ -91,15 +91,16 @@ export function useProjectViewer({
   }, [canEdit, projectId, accessToken]);
 
   // Derive fallback data for the selected node from the tree
+  const { selectedIri, nodes } = tree;
   const selectedNodeFallback = useMemo((): TreeNodeFallback | null => {
-    if (!tree.selectedIri) return null;
+    if (!selectedIri) return null;
     const findInTree = (
-      items: typeof tree.nodes,
+      items: typeof nodes,
       parentIri?: string,
       parentLabel?: string,
     ): TreeNodeFallback | null => {
       for (const node of items) {
-        if (node.iri === tree.selectedIri) {
+        if (node.iri === selectedIri) {
           return { iri: node.iri, label: node.label || "", parentIri, parentLabel };
         }
         const found = findInTree(node.children, node.iri, node.label);
@@ -107,9 +108,8 @@ export function useProjectViewer({
       }
       return null;
     };
-    return findInTree(tree.nodes);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tree.selectedIri, tree.nodes]);
+    return findInTree(nodes);
+  }, [selectedIri, nodes]);
 
   // Load source content
   const loadSourceContent = useCallback(async (isPreload = false) => {

--- a/lib/hooks/useProjectViewer.ts
+++ b/lib/hooks/useProjectViewer.ts
@@ -108,6 +108,7 @@ export function useProjectViewer({
       return null;
     };
     return findInTree(tree.nodes);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tree.selectedIri, tree.nodes]);
 
   // Load source content


### PR DESCRIPTION
## Summary
- Adds an `eslint-disable-next-line react-hooks/exhaustive-deps` comment to the `selectedNodeFallback` useMemo in `useProjectViewer.ts`
- The memo intentionally uses granular deps `[tree.selectedIri, tree.nodes]` instead of `[tree]` to avoid unnecessary recalculations when unrelated tree properties change
- Closes #83

## Test plan
- [ ] Verify `npm run lint` passes with no warnings
- [ ] Verify the viewer page still correctly highlights the selected node in the class tree
- [ ] Verify no regressions in node selection behavior when navigating the ontology tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a linting directive to a hook implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->