### PR TITLE
feat: show unfiltered project count when search/filter is active

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,6 +66,8 @@ export default function HomePage() {
 
   const projects = data?.pages.flatMap((page) => page.items) ?? [];
   const total = data?.pages.at(-1)?.total ?? 0;
+  const unfilteredTotal = data?.pages.at(-1)?.unfiltered_total ?? 0;
+  const isFiltered = (!!debouncedSearch || filter !== "all") && unfilteredTotal > total;
 
   const [nextPageError, setNextPageError] = useState<string | null>(null);
 
@@ -223,6 +225,11 @@ export default function HomePage() {
                   {debouncedSearch
                     ? `${total} ${total === 1 ? "result" : "results"} for "${debouncedSearch}"`
                     : `${total} ${total === 1 ? "project" : "projects"}`}
+                  {isFiltered && (
+                    <span className="text-slate-400 dark:text-slate-500">
+                      {` (of ${unfilteredTotal})`}
+                    </span>
+                  )}
                 </div>
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                   {projects.map((project) => (

--- a/lib/api/projects.ts
+++ b/lib/api/projects.ts
@@ -56,6 +56,7 @@ export interface Project {
 export interface ProjectListResponse {
   items: Project[];
   total: number;
+  unfiltered_total: number;
   skip: number;
   limit: number;
 }

--- a/lib/sitemap.ts
+++ b/lib/sitemap.ts
@@ -50,6 +50,7 @@ interface ProjectListItem {
 interface ProjectListResponse {
   items: ProjectListItem[];
   total: number;
+  unfiltered_total: number;
 }
 
 function buildUrlEntry(loc: string, lastmod?: string): string {


### PR DESCRIPTION
## Summary

- Add `unfiltered_total` field to `ProjectListResponse` types in `lib/api/projects.ts` and `lib/sitemap.ts`
- Display "(of N)" alongside the filtered count when a search term or filter tab narrows the project list
- Depends on [ontokit-api#40](https://github.com/CatholicOS/ontokit-api/pull/40) which added `unfiltered_total` to the API response

Closes #92

## Test plan

- [ ] Visit project list with no filter — shows "N projects" with no "(of N)" suffix
- [ ] Search for a term — shows `3 results for "foo" (of 42)`
- [ ] Switch to "My Projects" tab — shows `2 projects (of 42)` if user has fewer than total
- [ ] When filter count equals unfiltered count, "(of N)" is not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Results header now displays both the filtered result count and the total unfiltered count when searches or filters are applied, giving users visibility into how many results match their criteria versus the complete dataset available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->