### PR TITLE
feat: replace language tag inputs with searchable BCP 47 picker

### DIFF
--- a/__tests__/components/editor/ClassDetailPanel.test.tsx
+++ b/__tests__/components/editor/ClassDetailPanel.test.tsx
@@ -57,6 +57,20 @@ vi.mock("@/lib/stores/editorModeStore", () => ({
 vi.mock("@/components/editor/LanguageFlag", () => ({
   LanguageFlag: () => null,
 }));
+vi.mock("@/components/editor/LanguagePicker", () => ({
+  LanguagePicker: ({ value, onChange }: { value: string; onChange: (code: string) => void }) => (
+    <select
+      data-testid="lang-picker"
+      aria-label="Language tag"
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+    >
+      <option value="en">en</option>
+      <option value="de">de</option>
+      <option value="fr">fr</option>
+    </select>
+  ),
+}));
 vi.mock("@/components/editor/ParentClassPicker", () => ({
   ParentClassPicker: () => null,
 }));
@@ -638,16 +652,14 @@ describe("ClassDetailPanel", () => {
     await user.click(screen.getByText("Edit Item"));
 
     await waitFor(() => {
-      expect(screen.getAllByTitle("Language tag (e.g. en, de, fr)").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByLabelText("Language tag").length).toBeGreaterThanOrEqual(1);
     });
 
-    // Find the language input (has title "Language tag")
-    const langInputs = screen.getAllByTitle("Language tag (e.g. en, de, fr)");
+    // Find the language picker (mocked as <select>)
+    const langPickers = screen.getAllByLabelText("Language tag");
+    await user.selectOptions(langPickers[0], "de");
 
-    await user.clear(langInputs[0]);
-    await user.type(langInputs[0], "de");
-
-    expect(screen.getByDisplayValue("de")).not.toBeNull();
+    expect((langPickers[0] as HTMLSelectElement).value).toBe("de");
   });
 
   // ── Comment editing ──
@@ -1568,14 +1580,15 @@ describe("ClassDetailPanel", () => {
       expect(screen.getByDisplayValue("A human being")).not.toBeNull();
     });
 
-    // Find language input for comment (title "Language tag")
-    const langInputs = screen.getAllByTitle("Language tag");
-    expect(langInputs.length).toBeGreaterThanOrEqual(1);
+    // Find language pickers (mocked as <select>) — labels come first, then comments
+    const langPickers = screen.getAllByLabelText("Language tag");
+    expect(langPickers.length).toBeGreaterThanOrEqual(2);
 
-    await user.clear(langInputs[0]);
-    await user.type(langInputs[0], "fr");
+    // The comment lang picker is after the label ones
+    const commentLangPicker = langPickers[langPickers.length - 1];
+    await user.selectOptions(commentLangPicker, "fr");
 
-    expect(screen.getByDisplayValue("fr")).not.toBeNull();
+    expect((commentLangPicker as HTMLSelectElement).value).toBe("fr");
   });
 
   // ── Edit mode: definition section with existing values shows annotation rows ──

--- a/__tests__/components/editor/IndividualDetailPanel.test.tsx
+++ b/__tests__/components/editor/IndividualDetailPanel.test.tsx
@@ -873,6 +873,7 @@ describe("IndividualDetailPanel", () => {
   it("allows editing language tag via picker", async () => {
     const user = userEvent.setup();
     const onUpdateIndividual = vi.fn();
+    mockTriggerSave.mockClear();
     render(
       <IndividualDetailPanel
         {...DEFAULT_PROPS}
@@ -885,6 +886,7 @@ describe("IndividualDetailPanel", () => {
     expect(langPickers.length).toBeGreaterThanOrEqual(1);
     await user.selectOptions(langPickers[0], "fr");
     expect((langPickers[0] as HTMLSelectElement).value).toBe("fr");
+    expect(mockTriggerSave).toHaveBeenCalled();
   });
 
   // ── Edit mode with no initial comments ──

--- a/__tests__/components/editor/IndividualDetailPanel.test.tsx
+++ b/__tests__/components/editor/IndividualDetailPanel.test.tsx
@@ -56,7 +56,7 @@ vi.mock("@/components/editor/LanguagePicker", () => ({
       data-testid="lang-picker"
       aria-label="Language tag"
       value={value}
-      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+      onChange={(e) => onChange((e.target as HTMLSelectElement).value)}
     >
       <option value="en">en</option>
       <option value="de">de</option>

--- a/__tests__/components/editor/IndividualDetailPanel.test.tsx
+++ b/__tests__/components/editor/IndividualDetailPanel.test.tsx
@@ -50,6 +50,20 @@ vi.mock("@/lib/hooks/useIriLabels", () => ({
 vi.mock("@/components/editor/LanguageFlag", () => ({
   LanguageFlag: () => null,
 }));
+vi.mock("@/components/editor/LanguagePicker", () => ({
+  LanguagePicker: ({ value, onChange }: { value: string; onChange: (code: string) => void }) => (
+    <select
+      data-testid="lang-picker"
+      aria-label="Language tag"
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+    >
+      <option value="en">en</option>
+      <option value="de">de</option>
+      <option value="fr">fr</option>
+    </select>
+  ),
+}));
 
 let capturedAnnotationRowProps: Array<Record<string, unknown>> = [];
 vi.mock("@/components/editor/standard/AnnotationRow", () => ({
@@ -699,10 +713,10 @@ describe("IndividualDetailPanel", () => {
 
   // ── Language tag input in edit mode ──
 
-  it("renders language tag inputs in edit mode", async () => {
+  it("renders language tag pickers in edit mode", async () => {
     const user = userEvent.setup();
     const onUpdateIndividual = vi.fn();
-    const { container } = render(
+    render(
       <IndividualDetailPanel
         {...DEFAULT_PROPS}
         canEdit={true}
@@ -710,8 +724,8 @@ describe("IndividualDetailPanel", () => {
       />
     );
     await user.click(screen.getByText("Edit Item"));
-    const langInputs = container.querySelectorAll('input[title="Language tag"]');
-    expect(langInputs.length).toBeGreaterThanOrEqual(1);
+    const langPickers = screen.getAllByLabelText("Language tag");
+    expect(langPickers.length).toBeGreaterThanOrEqual(1);
   });
 
   // ── triggerSave on blur of label input ──
@@ -856,10 +870,10 @@ describe("IndividualDetailPanel", () => {
 
   // ── Language tag editing in edit mode ──
 
-  it("allows editing language tag input", async () => {
+  it("allows editing language tag via picker", async () => {
     const user = userEvent.setup();
     const onUpdateIndividual = vi.fn();
-    const { container } = render(
+    render(
       <IndividualDetailPanel
         {...DEFAULT_PROPS}
         canEdit={true}
@@ -867,11 +881,10 @@ describe("IndividualDetailPanel", () => {
       />
     );
     await user.click(screen.getByText("Edit Item"));
-    const langInput = container.querySelector('input[title="Language tag"]') as HTMLInputElement;
-    expect(langInput).not.toBeNull();
-    await user.clear(langInput);
-    await user.type(langInput, "fr");
-    expect(langInput.value).toBe("fr");
+    const langPickers = screen.getAllByLabelText("Language tag");
+    expect(langPickers.length).toBeGreaterThanOrEqual(1);
+    await user.selectOptions(langPickers[0], "fr");
+    expect((langPickers[0] as HTMLSelectElement).value).toBe("fr");
   });
 
   // ── Edit mode with no initial comments ──

--- a/__tests__/components/editor/LanguagePicker.test.tsx
+++ b/__tests__/components/editor/LanguagePicker.test.tsx
@@ -1,7 +1,10 @@
-import { describe, expect, it, vi, beforeAll } from "vitest";
+import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 // cmdk uses ResizeObserver and scrollIntoView which jsdom doesn't provide
+const _origResizeObserver = global.ResizeObserver;
+const _origScrollIntoView = Element.prototype.scrollIntoView;
+
 beforeAll(() => {
   global.ResizeObserver = class {
     observe() {}
@@ -9,6 +12,12 @@ beforeAll(() => {
     disconnect() {}
   };
   Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterAll(() => {
+  global.ResizeObserver = _origResizeObserver;
+  Element.prototype.scrollIntoView = _origScrollIntoView;
+  vi.restoreAllMocks();
 });
 
 // langToFlag needs the utils module
@@ -73,6 +82,11 @@ describe("LanguagePicker", () => {
     }
 
     expect(onChange).toHaveBeenCalledWith("fr");
+    // Verify the menu closed
+    const btn = screen.getByLabelText("Language tag");
+    await waitFor(() => {
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+    });
   });
 
   it("does not open when disabled", () => {
@@ -132,9 +146,12 @@ describe("LanguagePicker", () => {
     const btn = screen.getByLabelText("Language tag");
     fireEvent.click(btn);
     await waitFor(() => {
-      const controlsId = btn.getAttribute("aria-controls");
-      expect(controlsId).toBeTruthy();
-      expect(document.getElementById(controlsId!)).toBeDefined();
+      expect(btn.getAttribute("aria-expanded")).toBe("true");
     });
+    const controlsId = btn.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    // Verify a listbox element with the matching id exists
+    const list = screen.getByRole("listbox");
+    expect(list.getAttribute("id")).toBe(controlsId);
   });
 });

--- a/__tests__/components/editor/LanguagePicker.test.tsx
+++ b/__tests__/components/editor/LanguagePicker.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// cmdk uses ResizeObserver and scrollIntoView which jsdom doesn't provide
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+// langToFlag needs the utils module
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    langToFlag: (lang: string) => (lang === "en" ? "🇺🇸" : lang === "fr" ? "🇫🇷" : null),
+  };
+});
+
+import { LanguagePicker } from "@/components/editor/LanguagePicker";
+
+describe("LanguagePicker", () => {
+  it("renders a trigger button with the current language code", () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    expect(btn).toBeDefined();
+    expect(btn.textContent).toContain("en");
+  });
+
+  it("shows aria-expanded=false when closed", () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(btn.getAttribute("aria-haspopup")).toBe("listbox");
+  });
+
+  it("opens the dropdown and sets aria-expanded=true on click", async () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(btn.getAttribute("aria-expanded")).toBe("true");
+    });
+    // Should render the search input
+    expect(screen.getByPlaceholderText("Search languages...")).toBeDefined();
+  });
+
+  it("shows 'Frequently used' and 'All languages' groups when open", async () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Language tag"));
+    await waitFor(() => {
+      expect(screen.getByText("Frequently used")).toBeDefined();
+      expect(screen.getByText("All languages")).toBeDefined();
+    });
+  });
+
+  it("calls onChange and closes when a language is selected", async () => {
+    const onChange = vi.fn();
+    render(<LanguagePicker value="en" onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText("Language tag"));
+
+    await waitFor(() => {
+      expect(screen.getByText("French")).toBeDefined();
+    });
+
+    // Click the French option
+    const frenchItem = screen.getByText("French").closest("[cmdk-item]");
+    if (frenchItem) {
+      fireEvent.click(frenchItem);
+    }
+
+    expect(onChange).toHaveBeenCalledWith("fr");
+  });
+
+  it("does not open when disabled", () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} disabled />);
+    const btn = screen.getByLabelText("Language tag");
+    fireEvent.click(btn);
+    expect(screen.queryByPlaceholderText("Search languages...")).toBeNull();
+  });
+
+  it("closes on Escape key", async () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(btn.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
+  it("closes on outside click", async () => {
+    render(
+      <div>
+        <span data-testid="outside">outside</span>
+        <LanguagePicker value="en" onChange={vi.fn()} />
+      </div>
+    );
+    const btn = screen.getByLabelText("Language tag");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(btn.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    await waitFor(() => {
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
+  it("displays flag emoji for known language codes", () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    expect(btn.textContent).toContain("🇺🇸");
+  });
+
+  it("shows 'lang' placeholder when value is empty", () => {
+    render(<LanguagePicker value="" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    expect(btn.textContent).toContain("lang");
+  });
+
+  it("sets aria-controls to the list id when open", async () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      const controlsId = btn.getAttribute("aria-controls");
+      expect(controlsId).toBeTruthy();
+      expect(document.getElementById(controlsId!)).toBeDefined();
+    });
+  });
+});

--- a/__tests__/components/editor/LanguagePicker.test.tsx
+++ b/__tests__/components/editor/LanguagePicker.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 // cmdk uses ResizeObserver and scrollIntoView which jsdom doesn't provide
 const _origResizeObserver = global.ResizeObserver;
@@ -25,7 +26,7 @@ vi.mock("@/lib/utils", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
-    langToFlag: (lang: string) => (lang === "en" ? "🇺🇸" : lang === "fr" ? "🇫🇷" : null),
+    langToFlag: (lang: string) => (lang === "en" ? "\u{1F1FA}\u{1F1F8}" : lang === "fr" ? "\u{1F1EB}\u{1F1F7}" : null),
   };
 });
 
@@ -132,7 +133,7 @@ describe("LanguagePicker", () => {
   it("displays flag emoji for known language codes", () => {
     render(<LanguagePicker value="en" onChange={vi.fn()} />);
     const btn = screen.getByLabelText("Language tag");
-    expect(btn.textContent).toContain("🇺🇸");
+    expect(btn.textContent).toContain("\u{1F1FA}\u{1F1F8}");
   });
 
   it("shows 'lang' placeholder when value is empty", () => {
@@ -153,5 +154,99 @@ describe("LanguagePicker", () => {
     // Verify a listbox element with the matching id exists
     const list = screen.getByRole("listbox");
     expect(list.getAttribute("id")).toBe(controlsId);
+  });
+
+  it("restores focus to trigger button after selecting a language", async () => {
+    const onChange = vi.fn();
+    render(<LanguagePicker value="en" onChange={onChange} />);
+    const btn = screen.getByLabelText("Language tag");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByText("French")).toBeDefined();
+    });
+
+    const frenchItem = screen.getByText("French").closest("[cmdk-item]");
+    if (frenchItem) fireEvent.click(frenchItem);
+
+    // Wait for requestAnimationFrame focus restore
+    await waitFor(() => {
+      expect(document.activeElement).toBe(btn);
+    });
+  });
+
+  it("restores focus to trigger button after Escape", async () => {
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    const btn = screen.getByLabelText("Language tag");
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(btn.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(btn);
+    });
+  });
+
+  it("shows 'Use custom code' option when search doesn't match a known language", async () => {
+    const user = userEvent.setup();
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Language tag"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search languages...")).toBeDefined();
+    });
+
+    const input = screen.getByPlaceholderText("Search languages...");
+    await user.type(input, "grc");
+
+    await waitFor(() => {
+      expect(screen.getByText(/Use custom code/)).toBeDefined();
+      expect(screen.getByText(/grc/)).toBeDefined();
+    });
+  });
+
+  it("calls onChange with custom code when 'Use custom code' is selected", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<LanguagePicker value="en" onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText("Language tag"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search languages...")).toBeDefined();
+    });
+
+    const input = screen.getByPlaceholderText("Search languages...");
+    await user.type(input, "cu");
+
+    await waitFor(() => {
+      expect(screen.getByText(/Use custom code/)).toBeDefined();
+    });
+
+    const customItem = screen.getByText(/Use custom code/).closest("[cmdk-item]");
+    if (customItem) fireEvent.click(customItem);
+
+    expect(onChange).toHaveBeenCalledWith("cu");
+  });
+
+  it("does not show custom code option when search matches a known language", async () => {
+    const user = userEvent.setup();
+    render(<LanguagePicker value="en" onChange={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Language tag"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search languages...")).toBeDefined();
+    });
+
+    const input = screen.getByPlaceholderText("Search languages...");
+    await user.type(input, "fr");
+
+    await waitFor(() => {
+      expect(screen.getByText("French")).toBeDefined();
+    });
+
+    expect(screen.queryByText(/Use custom code/)).toBeNull();
   });
 });

--- a/__tests__/components/editor/PropertyDetailPanel.test.tsx
+++ b/__tests__/components/editor/PropertyDetailPanel.test.tsx
@@ -59,6 +59,20 @@ vi.mock("@/lib/hooks/useIriLabels", () => ({
 vi.mock("@/components/editor/LanguageFlag", () => ({
   LanguageFlag: () => null,
 }));
+vi.mock("@/components/editor/LanguagePicker", () => ({
+  LanguagePicker: ({ value, onChange }: { value: string; onChange: (code: string) => void }) => (
+    <select
+      data-testid="lang-picker"
+      aria-label="Language tag"
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value)}
+    >
+      <option value="en">en</option>
+      <option value="de">de</option>
+      <option value="fr">fr</option>
+    </select>
+  ),
+}));
 
 let capturedAnnotationRowProps: Array<Record<string, unknown>> = [];
 vi.mock("@/components/editor/standard/AnnotationRow", () => ({
@@ -776,10 +790,10 @@ describe("PropertyDetailPanel", () => {
 
   // ── Language tag input in edit mode ──
 
-  it("renders language tag inputs in edit mode", async () => {
+  it("renders language tag pickers in edit mode", async () => {
     const user = userEvent.setup();
     const onUpdateProperty = vi.fn();
-    const { container } = render(
+    render(
       <PropertyDetailPanel
         {...DEFAULT_PROPS}
         canEdit={true}
@@ -787,8 +801,8 @@ describe("PropertyDetailPanel", () => {
       />
     );
     await user.click(screen.getByText("Edit Item"));
-    const langInputs = container.querySelectorAll('input[title="Language tag"]');
-    expect(langInputs.length).toBeGreaterThanOrEqual(1);
+    const langPickers = screen.getAllByLabelText("Language tag");
+    expect(langPickers.length).toBeGreaterThanOrEqual(1);
   });
 
   // ── triggerSave on blur of label input ──
@@ -889,10 +903,10 @@ describe("PropertyDetailPanel", () => {
 
   // ── Language tag editing in edit mode ──
 
-  it("allows editing language tag input", async () => {
+  it("allows editing language tag via picker", async () => {
     const user = userEvent.setup();
     const onUpdateProperty = vi.fn();
-    const { container } = render(
+    render(
       <PropertyDetailPanel
         {...DEFAULT_PROPS}
         canEdit={true}
@@ -900,11 +914,10 @@ describe("PropertyDetailPanel", () => {
       />
     );
     await user.click(screen.getByText("Edit Item"));
-    const langInput = container.querySelector('input[title="Language tag"]') as HTMLInputElement;
-    expect(langInput).not.toBeNull();
-    await user.clear(langInput);
-    await user.type(langInput, "fr");
-    expect(langInput.value).toBe("fr");
+    const langPickers = screen.getAllByLabelText("Language tag");
+    expect(langPickers.length).toBeGreaterThanOrEqual(1);
+    await user.selectOptions(langPickers[0], "fr");
+    expect((langPickers[0] as HTMLSelectElement).value).toBe("fr");
   });
 
   // ── Edit mode with no initial comments ──

--- a/__tests__/components/editor/PropertyDetailPanel.test.tsx
+++ b/__tests__/components/editor/PropertyDetailPanel.test.tsx
@@ -906,6 +906,7 @@ describe("PropertyDetailPanel", () => {
   it("allows editing language tag via picker", async () => {
     const user = userEvent.setup();
     const onUpdateProperty = vi.fn();
+    mockTriggerSave.mockClear();
     render(
       <PropertyDetailPanel
         {...DEFAULT_PROPS}
@@ -918,6 +919,7 @@ describe("PropertyDetailPanel", () => {
     expect(langPickers.length).toBeGreaterThanOrEqual(1);
     await user.selectOptions(langPickers[0], "fr");
     expect((langPickers[0] as HTMLSelectElement).value).toBe("fr");
+    expect(mockTriggerSave).toHaveBeenCalled();
   });
 
   // ── Edit mode with no initial comments ──

--- a/__tests__/components/editor/standard/AnnotationRow.test.tsx
+++ b/__tests__/components/editor/standard/AnnotationRow.test.tsx
@@ -87,12 +87,6 @@ describe("AnnotationRow", () => {
     expect(chip.getAttribute("title")).toBe("rdfs:label");
   });
 
-  it("renders the LanguagePicker with the correct lang", () => {
-    render(<AnnotationRow {...defaultProps} />);
-    const picker = screen.getByTestId("lang-picker") as HTMLSelectElement;
-    expect(picker.value).toBe("en");
-  });
-
   it("renders the language picker with correct value", () => {
     render(<AnnotationRow {...defaultProps} />);
     const langPicker = screen.getByLabelText("Language tag") as HTMLSelectElement;
@@ -156,12 +150,14 @@ describe("AnnotationRow", () => {
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
-  it("does not crash when language picker is present (onBlur only on value input)", () => {
+  it("calls onBlur after language picker changes to trigger auto-save", () => {
     const onBlur = vi.fn();
-    render(<AnnotationRow {...defaultProps} onBlur={onBlur} />);
-    // The LanguagePicker is a combobox, not a plain input, so onBlur
-    // is only triggered on the value input. Verify the picker renders.
-    expect(screen.getByTestId("lang-picker")).toBeDefined();
+    const onLangChange = vi.fn();
+    render(<AnnotationRow {...defaultProps} onBlur={onBlur} onLangChange={onLangChange} />);
+    const langPicker = screen.getByLabelText("Language tag");
+    fireEvent.change(langPicker, { target: { value: "fr" } });
+    expect(onLangChange).toHaveBeenCalledWith("fr");
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   it("uses custom placeholder when provided", () => {

--- a/__tests__/components/editor/standard/AnnotationRow.test.tsx
+++ b/__tests__/components/editor/standard/AnnotationRow.test.tsx
@@ -16,9 +16,26 @@ vi.mock("@/lib/ontology/annotationProperties", () => ({
   }),
 }));
 
-vi.mock("@/components/editor/LanguageFlag", () => ({
-  LanguageFlag: ({ lang }: { lang: string }) => (
-    <span data-testid="lang-flag">{lang}</span>
+vi.mock("@/components/editor/LanguagePicker", () => ({
+  LanguagePicker: ({
+    value,
+    onChange,
+    disabled,
+  }: {
+    value: string;
+    onChange: (code: string) => void;
+    disabled?: boolean;
+  }) => (
+    <select
+      data-testid="lang-picker"
+      aria-label="Language tag"
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="en">en</option>
+      <option value="fr">fr</option>
+    </select>
   ),
 }));
 
@@ -70,15 +87,16 @@ describe("AnnotationRow", () => {
     expect(chip.getAttribute("title")).toBe("rdfs:label");
   });
 
-  it("renders the LanguageFlag with the correct lang", () => {
+  it("renders the LanguagePicker with the correct lang", () => {
     render(<AnnotationRow {...defaultProps} />);
-    expect(screen.getByTestId("lang-flag").textContent).toBe("en");
+    const picker = screen.getByTestId("lang-picker") as HTMLSelectElement;
+    expect(picker.value).toBe("en");
   });
 
-  it("renders the language tag input with correct value", () => {
+  it("renders the language picker with correct value", () => {
     render(<AnnotationRow {...defaultProps} />);
-    const langInput = screen.getByLabelText("Language tag") as HTMLInputElement;
-    expect(langInput.value).toBe("en");
+    const langPicker = screen.getByLabelText("Language tag") as HTMLSelectElement;
+    expect(langPicker.value).toBe("en");
   });
 
   it("calls onValueChange when the value input changes", () => {
@@ -100,11 +118,11 @@ describe("AnnotationRow", () => {
     expect(onValueChange).toHaveBeenCalledWith("Changed");
   });
 
-  it("calls onLangChange when the language input changes", () => {
+  it("calls onLangChange when the language picker changes", () => {
     const onLangChange = vi.fn();
     render(<AnnotationRow {...defaultProps} onLangChange={onLangChange} />);
-    const langInput = screen.getByLabelText("Language tag");
-    fireEvent.change(langInput, { target: { value: "fr" } });
+    const langPicker = screen.getByLabelText("Language tag");
+    fireEvent.change(langPicker, { target: { value: "fr" } });
     expect(onLangChange).toHaveBeenCalledWith("fr");
   });
 
@@ -138,12 +156,12 @@ describe("AnnotationRow", () => {
     expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onBlur when language input loses focus", () => {
+  it("does not crash when language picker is present (onBlur only on value input)", () => {
     const onBlur = vi.fn();
     render(<AnnotationRow {...defaultProps} onBlur={onBlur} />);
-    const langInput = screen.getByLabelText("Language tag");
-    fireEvent.blur(langInput);
-    expect(onBlur).toHaveBeenCalledTimes(1);
+    // The LanguagePicker is a combobox, not a plain input, so onBlur
+    // is only triggered on the value input. Verify the picker renders.
+    expect(screen.getByTestId("lang-picker")).toBeDefined();
   });
 
   it("uses custom placeholder when provided", () => {

--- a/__tests__/components/editor/standard/InlineAnnotationAdder.test.tsx
+++ b/__tests__/components/editor/standard/InlineAnnotationAdder.test.tsx
@@ -28,11 +28,29 @@ const { mockRdfsLabel, mockSkosPrefLabel, mockSkosDefinition } = vi.hoisted(() =
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  langToFlag: () => null,
 }));
 
-vi.mock("@/components/editor/LanguageFlag", () => ({
-  LanguageFlag: ({ lang }: { lang: string }) => (
-    <span data-testid="lang-flag">{lang}</span>
+vi.mock("@/components/editor/LanguagePicker", () => ({
+  LanguagePicker: ({
+    value,
+    onChange,
+    disabled,
+  }: {
+    value: string;
+    onChange: (code: string) => void;
+    disabled?: boolean;
+  }) => (
+    <select
+      data-testid="lang-picker"
+      aria-label="Language tag"
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="en">en</option>
+      <option value="fr">fr</option>
+    </select>
   ),
 }));
 
@@ -70,10 +88,10 @@ describe("InlineAnnotationAdder", () => {
     expect(valueInput.placeholder).toBe("Select a property first");
   });
 
-  it("renders language input defaulting to 'en'", () => {
+  it("renders language picker defaulting to 'en'", () => {
     render(<InlineAnnotationAdder {...defaultProps} />);
-    const langInput = screen.getByLabelText("Language tag") as HTMLInputElement;
-    expect(langInput.value).toBe("en");
+    const langPicker = screen.getByLabelText("Language tag") as HTMLSelectElement;
+    expect(langPicker.value).toBe("en");
   });
 
   it("opens dropdown when property input is focused", () => {
@@ -142,7 +160,7 @@ describe("InlineAnnotationAdder", () => {
     fireEvent.click(screen.getByText("Definition"));
 
     expect((screen.getByLabelText("Annotation value") as HTMLInputElement).disabled).toBe(false);
-    expect((screen.getByLabelText("Language tag") as HTMLInputElement).disabled).toBe(false);
+    expect((screen.getByLabelText("Language tag") as HTMLSelectElement).disabled).toBe(false);
   });
 
   it("calls onAdd when Enter is pressed with a value", async () => {

--- a/__tests__/lib/i18n/languageCodes.test.ts
+++ b/__tests__/lib/i18n/languageCodes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  FREQUENT_LANGUAGES,
+  ALL_LANGUAGES,
+  findLanguageByCode,
+} from "@/lib/i18n/languageCodes";
+
+describe("languageCodes", () => {
+  it("exports a non-empty FREQUENT_LANGUAGES array", () => {
+    expect(FREQUENT_LANGUAGES.length).toBeGreaterThan(0);
+  });
+
+  it("ALL_LANGUAGES includes all frequent languages", () => {
+    const allCodes = new Set(ALL_LANGUAGES.map((l) => l.code));
+    for (const lang of FREQUENT_LANGUAGES) {
+      expect(allCodes.has(lang.code)).toBe(true);
+    }
+  });
+
+  it("ALL_LANGUAGES has no duplicate codes", () => {
+    const codes = ALL_LANGUAGES.map((l) => l.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("every entry has code, name, and nativeName", () => {
+    for (const lang of ALL_LANGUAGES) {
+      expect(lang.code).toBeTruthy();
+      expect(lang.name).toBeTruthy();
+      expect(lang.nativeName).toBeTruthy();
+    }
+  });
+
+  describe("findLanguageByCode", () => {
+    it("finds 'en' case-insensitively", () => {
+      expect(findLanguageByCode("en")?.name).toBe("English");
+      expect(findLanguageByCode("EN")?.name).toBe("English");
+    });
+
+    it("finds regional variants like 'pt-BR'", () => {
+      expect(findLanguageByCode("pt-BR")?.name).toBe("Portuguese (Brazil)");
+    });
+
+    it("returns undefined for unknown codes", () => {
+      expect(findLanguageByCode("xyz")).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/lib/i18n/languageCodes.test.ts
+++ b/__tests__/lib/i18n/languageCodes.test.ts
@@ -17,8 +17,8 @@ describe("languageCodes", () => {
     }
   });
 
-  it("ALL_LANGUAGES has no duplicate codes", () => {
-    const codes = ALL_LANGUAGES.map((l) => l.code);
+  it("ALL_LANGUAGES has no duplicate codes (case-insensitive)", () => {
+    const codes = ALL_LANGUAGES.map((l) => l.code.toLowerCase());
     expect(new Set(codes).size).toBe(codes.length);
   });
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,7 +22,10 @@
 
   --font-sans: var(--font-inter), system-ui, sans-serif;
   --font-mono: var(--font-jetbrains-mono), monospace;
-  --font-emoji: var(--font-noto-emoji), "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+}
+
+@utility font-emoji {
+  font-family: var(--font-noto-emoji, "Noto Color Emoji"), "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
 }
 
 /*

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,6 +22,7 @@
 
   --font-sans: var(--font-inter), system-ui, sans-serif;
   --font-mono: var(--font-jetbrains-mono), monospace;
+  --font-emoji: var(--font-noto-emoji), "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
 }
 
 /*

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,7 +25,7 @@
 }
 
 @utility font-emoji {
-  font-family: var(--font-noto-emoji, "Noto Color Emoji"), "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
 }
 
 /*

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,7 +25,7 @@
 }
 
 @utility font-emoji {
-  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+  font-family: var(--font-noto-emoji, "Noto Color Emoji"), "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
 }
 
 /*

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Script from "next/script";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono, Noto_Color_Emoji } from "next/font/google";
 
 import "./globals.css";
 import { Providers } from "./providers";
@@ -13,6 +13,12 @@ const inter = Inter({
 const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-jetbrains-mono",
+});
+
+const notoColorEmoji = Noto_Color_Emoji({
+  subsets: ["emoji"],
+  weight: "400",
+  variable: "--font-noto-emoji",
 });
 
 export const metadata: Metadata = {
@@ -34,7 +40,7 @@ export default function RootLayout({
           {`(function(){try{var s=JSON.parse(localStorage.getItem("ontokit-editor-preferences")||"{}");var t=(s.state&&s.state.theme)||"system";if(t==="dark")document.documentElement.classList.add("dark");else if(t==="system"&&window.matchMedia("(prefers-color-scheme: dark)").matches)document.documentElement.classList.add("dark")}catch(e){}})()`}
         </Script>
       </head>
-      <body className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}>
+      <body className={`${inter.variable} ${jetbrainsMono.variable} ${notoColorEmoji.variable} font-sans antialiased`}>
         <a href="#main-content" className="skip-link">Skip to main content</a>
         <Providers>{children}</Providers>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Script from "next/script";
-import { Inter, JetBrains_Mono, Noto_Color_Emoji } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
 
 import "./globals.css";
 import { Providers } from "./providers";
@@ -13,12 +13,6 @@ const inter = Inter({
 const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   variable: "--font-jetbrains-mono",
-});
-
-const notoColorEmoji = Noto_Color_Emoji({
-  subsets: ["emoji"],
-  weight: "400",
-  variable: "--font-noto-emoji",
 });
 
 export const metadata: Metadata = {
@@ -40,7 +34,7 @@ export default function RootLayout({
           {`(function(){try{var s=JSON.parse(localStorage.getItem("ontokit-editor-preferences")||"{}");var t=(s.state&&s.state.theme)||"system";if(t==="dark")document.documentElement.classList.add("dark");else if(t==="system"&&window.matchMedia("(prefers-color-scheme: dark)").matches)document.documentElement.classList.add("dark")}catch(e){}})()`}
         </Script>
       </head>
-      <body className={`${inter.variable} ${jetbrainsMono.variable} ${notoColorEmoji.variable} font-sans antialiased`}>
+      <body className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}>
         <a href="#main-content" className="skip-link">Skip to main content</a>
         <Providers>{children}</Providers>
       </body>

--- a/components/editor/ClassDetailPanel.tsx
+++ b/components/editor/ClassDetailPanel.tsx
@@ -33,6 +33,7 @@ import type { LocalizedString } from "@/lib/api/client";
 import { lintApi, type LintIssue } from "@/lib/api/lint";
 import { cn, getLocalName, getPreferredLabel } from "@/lib/utils";
 import { LanguageFlag } from "@/components/editor/LanguageFlag";
+import { LanguagePicker } from "@/components/editor/LanguagePicker";
 import { ParentClassPicker } from "@/components/editor/ParentClassPicker";
 import { AnnotationRow } from "@/components/editor/standard/AnnotationRow";
 import { InlineAnnotationAdder } from "@/components/editor/standard/InlineAnnotationAdder";
@@ -679,14 +680,12 @@ export function ClassDetailPanel({
                       placeholder="Label text"
                       className="flex-1 rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
                     />
-                    <LanguageFlag lang={label.lang} />
-                    <input
-                      type="text"
+                    <LanguagePicker
                       value={label.lang}
-                      onChange={(e) => updateLabel(index, "lang", e.target.value)}
-                      onBlur={() => triggerSave()}
-                      className="w-14 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-center text-xs focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
-                      title="Language tag (e.g. en, de, fr)"
+                      onChange={(code) => {
+                        updateLabel(index, "lang", code);
+                        triggerSave();
+                      }}
                     />
                     {editLabels.length > 1 ? (
                       <button
@@ -785,16 +784,14 @@ export function ClassDetailPanel({
                         className="flex-1 rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
                       />
                       <div className="mt-1 shrink-0">
-                        <LanguageFlag lang={comment.lang} />
+                        <LanguagePicker
+                          value={comment.lang}
+                          onChange={(code) => {
+                            updateComment(index, "lang", code);
+                            triggerSave();
+                          }}
+                        />
                       </div>
-                      <input
-                        type="text"
-                        value={comment.lang}
-                        onChange={(e) => updateComment(index, "lang", e.target.value)}
-                        onBlur={() => triggerSave()}
-                        className="w-14 shrink-0 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-center text-xs focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
-                        title="Language tag"
-                      />
                       {!isGhost ? (
                         <button
                           onClick={() => removeComment(index)}

--- a/components/editor/IndividualDetailPanel.tsx
+++ b/components/editor/IndividualDetailPanel.tsx
@@ -21,6 +21,7 @@ import {
 import type { LocalizedString, AnnotationUpdate } from "@/lib/api/client";
 import { cn, getLocalName } from "@/lib/utils";
 import { LanguageFlag } from "@/components/editor/LanguageFlag";
+import { LanguagePicker } from "@/components/editor/LanguagePicker";
 import { AnnotationRow } from "@/components/editor/standard/AnnotationRow";
 import { InlineAnnotationAdder } from "@/components/editor/standard/InlineAnnotationAdder";
 import { RelationshipSection, type RelationshipGroup, type RelationshipTarget } from "@/components/editor/standard/RelationshipSection";
@@ -463,8 +464,7 @@ export function IndividualDetailPanel({
                 {editLabels.map((label, index) => (
                   <div key={index} className="flex items-center gap-2">
                     <input type="text" value={label.value} onChange={(e) => updateLabel(index, "value", e.target.value)} onBlur={() => triggerSave()} placeholder="Label text" className="flex-1 rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white" />
-                    <LanguageFlag lang={label.lang} />
-                    <input type="text" value={label.lang} onChange={(e) => updateLabel(index, "lang", e.target.value)} onBlur={() => triggerSave()} className="w-14 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-center text-xs focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white" title="Language tag" />
+                    <LanguagePicker value={label.lang} onChange={(code) => { updateLabel(index, "lang", code); triggerSave(); }} />
                     {editLabels.length > 1 ? (
                       <button onClick={() => removeLabel(index)} className="rounded-sm p-1 text-slate-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"><Trash2 className="h-3.5 w-3.5" /></button>
                     ) : <div className="rounded-sm p-1"><div className="h-3.5 w-3.5" /></div>}

--- a/components/editor/LanguageFlag.tsx
+++ b/components/editor/LanguageFlag.tsx
@@ -18,7 +18,7 @@ export function LanguageFlag({ lang, className }: LanguageFlagProps) {
       aria-label={flag ? `Language: ${lang}` : undefined}
       aria-hidden={!flag ? true : undefined}
       title={lang || undefined}
-      className={className ?? "inline-flex h-5 w-5 shrink-0 items-center justify-center text-sm leading-none"}
+      className={className ?? "inline-flex h-5 w-5 shrink-0 items-center justify-center font-emoji text-sm leading-none"}
     >
       {flag}
     </span>

--- a/components/editor/LanguagePicker.tsx
+++ b/components/editor/LanguagePicker.tsx
@@ -25,21 +25,32 @@ const OTHER_LANGUAGES: LanguageOption[] = ALL_LANGUAGES.filter(
   (l) => !FREQUENT_CODES.has(l.code)
 );
 
-/** Strip diacritics for accent-insensitive search (e.g. "francais" matches "Français") */
+/** O(1) lookup map for the cmdk filter function */
+const LANG_BY_CODE = new Map(ALL_LANGUAGES.map((l) => [l.code, l]));
+
+/** Strip diacritics for accent-insensitive search (e.g. "francais" matches "Francais") */
 function stripDiacritics(s: string): string {
   return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 }
+
+/** Shared styles for cmdk group headings */
+const GROUP_HEADING_CLASS =
+  "[&>[cmdk-group-heading]]:px-2 [&>[cmdk-group-heading]]:py-0.5 [&>[cmdk-group-heading]]:text-[9px] [&>[cmdk-group-heading]]:font-semibold [&>[cmdk-group-heading]]:uppercase [&>[cmdk-group-heading]]:tracking-wider [&>[cmdk-group-heading]]:text-slate-400 dark:[&>[cmdk-group-heading]]:text-slate-500";
 
 /**
  * Compact searchable combobox for selecting a BCP 47 language tag.
  *
  * Uses `cmdk` for keyboard-accessible filtering. The trigger button shows
  * the country flag emoji + language code, matching the width of the previous
- * plain `<input>` it replaces.
+ * plain `<input>` it replaces. When the search text doesn't match any known
+ * language, a "Use custom code" option appears so users can enter arbitrary
+ * BCP 47 tags (e.g. `grc`, `cu`, `sga`).
  */
 export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProps) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const [listboxId, setListboxId] = useState<string | undefined>();
 
   // Capture the cmdk-generated listbox id via ref callback
@@ -50,27 +61,34 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
     }
   }, []);
 
+  const closeAndRestoreFocus = useCallback(() => {
+    setOpen(false);
+    setSearch("");
+    // Return focus to trigger after the dropdown unmounts
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, []);
+
   // Close on outside click
   useEffect(() => {
     if (!open) return;
     const handleClickOutside = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
+        closeAndRestoreFocus();
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [open]);
+  }, [open, closeAndRestoreFocus]);
 
   // Close on Escape
   useEffect(() => {
     if (!open) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") closeAndRestoreFocus();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open]);
+  }, [open, closeAndRestoreFocus]);
 
   const flag = langToFlag(value);
   const langInfo = findLanguageByCode(value);
@@ -80,12 +98,20 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
 
   const handleSelect = (code: string) => {
     onChange(code);
+    setSearch("");
     setOpen(false);
+    requestAnimationFrame(() => triggerRef.current?.focus());
   };
+
+  // Show "Use custom code" when search text is non-empty and doesn't exactly match a known code
+  const trimmedSearch = search.trim();
+  const showCustomOption =
+    trimmedSearch.length > 0 && !findLanguageByCode(trimmedSearch);
 
   return (
     <div ref={containerRef} className="relative shrink-0">
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => !disabled && setOpen((prev) => !prev)}
         disabled={disabled}
@@ -105,7 +131,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
         <div ref={listRefCallback} className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-600 dark:bg-slate-700">
           <Command
             filter={(value, search) => {
-              const lang = ALL_LANGUAGES.find((l) => l.code === value);
+              const lang = LANG_BY_CODE.get(value);
               if (!lang) return 0;
               const q = stripDiacritics(search.toLowerCase());
               if (stripDiacritics(lang.code.toLowerCase()).includes(q)) return 1;
@@ -118,18 +144,36 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
               <Command.Input
                 placeholder="Search languages..."
                 autoFocus
+                value={search}
+                onValueChange={setSearch}
                 className="w-full bg-transparent text-xs text-slate-900 placeholder:text-slate-400 focus:outline-hidden dark:text-white dark:placeholder:text-slate-500"
               />
             </div>
             <Command.List className="max-h-60 overflow-y-auto py-1">
               <Command.Empty className="py-3 text-center text-xs text-slate-500 dark:text-slate-400">
-                No matching languages
+                {showCustomOption ? "" : "No matching languages"}
               </Command.Empty>
 
-              <Command.Group
-                heading="Frequently used"
-                className="[&>[cmdk-group-heading]]:px-2 [&>[cmdk-group-heading]]:py-0.5 [&>[cmdk-group-heading]]:text-[9px] [&>[cmdk-group-heading]]:font-semibold [&>[cmdk-group-heading]]:uppercase [&>[cmdk-group-heading]]:tracking-wider [&>[cmdk-group-heading]]:text-slate-400 dark:[&>[cmdk-group-heading]]:text-slate-500"
-              >
+              {showCustomOption && (
+                <Command.Group heading="Custom" className={GROUP_HEADING_CLASS}>
+                  <Command.Item
+                    value={`__custom__${trimmedSearch}`}
+                    onSelect={() => handleSelect(trimmedSearch)}
+                    className="flex cursor-pointer items-center gap-2 px-2 py-1 text-xs aria-selected:bg-slate-100 dark:aria-selected:bg-slate-600"
+                    forceMount
+                  >
+                    <span className="inline-flex w-5 shrink-0 items-center justify-center text-sm leading-none text-slate-400">
+                      +
+                    </span>
+                    <span className="text-slate-700 dark:text-slate-200">
+                      Use custom code{" "}
+                      <span className="font-medium">&ldquo;{trimmedSearch}&rdquo;</span>
+                    </span>
+                  </Command.Item>
+                </Command.Group>
+              )}
+
+              <Command.Group heading="Frequently used" className={GROUP_HEADING_CLASS}>
                 {FREQUENT_LANGUAGES.map((lang) => (
                   <LanguageItem
                     key={lang.code}
@@ -140,10 +184,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
                 ))}
               </Command.Group>
 
-              <Command.Group
-                heading="All languages"
-                className="[&>[cmdk-group-heading]]:px-2 [&>[cmdk-group-heading]]:py-0.5 [&>[cmdk-group-heading]]:text-[9px] [&>[cmdk-group-heading]]:font-semibold [&>[cmdk-group-heading]]:uppercase [&>[cmdk-group-heading]]:tracking-wider [&>[cmdk-group-heading]]:text-slate-400 dark:[&>[cmdk-group-heading]]:text-slate-500"
-              >
+              <Command.Group heading="All languages" className={GROUP_HEADING_CLASS}>
                 {OTHER_LANGUAGES.map((lang) => (
                   <LanguageItem
                     key={lang.code}

--- a/components/editor/LanguagePicker.tsx
+++ b/components/editor/LanguagePicker.tsx
@@ -74,7 +74,9 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
 
   const flag = langToFlag(value);
   const langInfo = findLanguageByCode(value);
-  const displayLabel = langInfo ? langInfo.code : value || "lang";
+  // Use canonical code from lookup for display and comparison (handles legacy "EN", "pt-br", etc.)
+  const canonicalCode = langInfo?.code ?? value;
+  const displayLabel = canonicalCode || "lang";
 
   const handleSelect = (code: string) => {
     onChange(code);
@@ -132,7 +134,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
                   <LanguageItem
                     key={lang.code}
                     lang={lang}
-                    selected={lang.code === value}
+                    selected={lang.code === canonicalCode}
                     onSelect={handleSelect}
                   />
                 ))}
@@ -146,7 +148,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
                   <LanguageItem
                     key={lang.code}
                     lang={lang}
-                    selected={lang.code === value}
+                    selected={lang.code === canonicalCode}
                     onSelect={handleSelect}
                   />
                 ))}

--- a/components/editor/LanguagePicker.tsx
+++ b/components/editor/LanguagePicker.tsx
@@ -94,7 +94,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
         title={langInfo ? `${langInfo.name} (${langInfo.nativeName})` : value || "Select language"}
         className="flex w-14 items-center justify-center gap-0.5 rounded-md border border-slate-300 bg-white px-1 py-1.5 text-xs text-slate-700 hover:border-slate-400 focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:border-slate-500"
       >
-        {flag && <span className="text-sm leading-none">{flag}</span>}
+        {flag && <span className="font-emoji text-sm leading-none">{flag}</span>}
         <span className="truncate">{displayLabel}</span>
         <ChevronDown className="h-2.5 w-2.5 shrink-0 text-slate-400" />
       </button>
@@ -176,7 +176,7 @@ function LanguageItem({
       onSelect={() => onSelect(lang.code)}
       className="flex cursor-pointer items-center gap-2 px-2 py-1 text-xs aria-selected:bg-slate-100 dark:aria-selected:bg-slate-600"
     >
-      <span className="inline-flex w-5 shrink-0 items-center justify-center text-sm leading-none">
+      <span className="inline-flex w-5 shrink-0 items-center justify-center font-emoji text-sm leading-none">
         {flag}
       </span>
       <span className="font-medium text-slate-700 dark:text-slate-200">{lang.name}</span>

--- a/components/editor/LanguagePicker.tsx
+++ b/components/editor/LanguagePicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useId } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Command } from "cmdk";
 import { ChevronDown } from "lucide-react";
 import { langToFlag } from "@/lib/utils";
@@ -40,7 +40,15 @@ function stripDiacritics(s: string): string {
 export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const listId = useId();
+  const [listboxId, setListboxId] = useState<string | undefined>();
+
+  // Capture the cmdk-generated listbox id via ref callback
+  const listRefCallback = useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      const listbox = node.querySelector('[role="listbox"]');
+      setListboxId(listbox?.id || undefined);
+    }
+  }, []);
 
   // Close on outside click
   useEffect(() => {
@@ -82,7 +90,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
         aria-label="Language tag"
         aria-expanded={open}
         aria-haspopup="listbox"
-        aria-controls={open ? listId : undefined}
+        aria-controls={open ? listboxId : undefined}
         title={langInfo ? `${langInfo.name} (${langInfo.nativeName})` : value || "Select language"}
         className="flex w-14 items-center justify-center gap-0.5 rounded-md border border-slate-300 bg-white px-1 py-1.5 text-xs text-slate-700 hover:border-slate-400 focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:border-slate-500"
       >
@@ -92,7 +100,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-600 dark:bg-slate-700">
+        <div ref={listRefCallback} className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-600 dark:bg-slate-700">
           <Command
             filter={(value, search) => {
               const lang = ALL_LANGUAGES.find((l) => l.code === value);
@@ -111,7 +119,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
                 className="w-full bg-transparent text-xs text-slate-900 placeholder:text-slate-400 focus:outline-hidden dark:text-white dark:placeholder:text-slate-500"
               />
             </div>
-            <Command.List id={listId} role="listbox" className="max-h-60 overflow-y-auto py-1">
+            <Command.List className="max-h-60 overflow-y-auto py-1">
               <Command.Empty className="py-3 text-center text-xs text-slate-500 dark:text-slate-400">
                 No matching languages
               </Command.Empty>

--- a/components/editor/LanguagePicker.tsx
+++ b/components/editor/LanguagePicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useId } from "react";
 import { Command } from "cmdk";
 import { ChevronDown } from "lucide-react";
 import { langToFlag } from "@/lib/utils";
@@ -25,6 +25,11 @@ const OTHER_LANGUAGES: LanguageOption[] = ALL_LANGUAGES.filter(
   (l) => !FREQUENT_CODES.has(l.code)
 );
 
+/** Strip diacritics for accent-insensitive search (e.g. "francais" matches "Français") */
+function stripDiacritics(s: string): string {
+  return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
 /**
  * Compact searchable combobox for selecting a BCP 47 language tag.
  *
@@ -35,6 +40,7 @@ const OTHER_LANGUAGES: LanguageOption[] = ALL_LANGUAGES.filter(
 export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
 
   // Close on outside click
   useEffect(() => {
@@ -74,6 +80,9 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
         onClick={() => !disabled && setOpen((prev) => !prev)}
         disabled={disabled}
         aria-label="Language tag"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-controls={open ? listId : undefined}
         title={langInfo ? `${langInfo.name} (${langInfo.nativeName})` : value || "Select language"}
         className="flex w-14 items-center justify-center gap-0.5 rounded-md border border-slate-300 bg-white px-1 py-1.5 text-xs text-slate-700 hover:border-slate-400 focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:border-slate-500"
       >
@@ -88,10 +97,10 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
             filter={(value, search) => {
               const lang = ALL_LANGUAGES.find((l) => l.code === value);
               if (!lang) return 0;
-              const q = search.toLowerCase();
-              if (lang.code.toLowerCase().includes(q)) return 1;
-              if (lang.name.toLowerCase().includes(q)) return 1;
-              if (lang.nativeName.toLowerCase().includes(q)) return 1;
+              const q = stripDiacritics(search.toLowerCase());
+              if (stripDiacritics(lang.code.toLowerCase()).includes(q)) return 1;
+              if (stripDiacritics(lang.name.toLowerCase()).includes(q)) return 1;
+              if (stripDiacritics(lang.nativeName.toLowerCase()).includes(q)) return 1;
               return 0;
             }}
           >
@@ -102,7 +111,7 @@ export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProp
                 className="w-full bg-transparent text-xs text-slate-900 placeholder:text-slate-400 focus:outline-hidden dark:text-white dark:placeholder:text-slate-500"
               />
             </div>
-            <Command.List className="max-h-60 overflow-y-auto py-1">
+            <Command.List id={listId} role="listbox" className="max-h-60 overflow-y-auto py-1">
               <Command.Empty className="py-3 text-center text-xs text-slate-500 dark:text-slate-400">
                 No matching languages
               </Command.Empty>

--- a/components/editor/LanguagePicker.tsx
+++ b/components/editor/LanguagePicker.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Command } from "cmdk";
+import { ChevronDown } from "lucide-react";
+import { langToFlag } from "@/lib/utils";
+import {
+  FREQUENT_LANGUAGES,
+  ALL_LANGUAGES,
+  findLanguageByCode,
+  type LanguageOption,
+} from "@/lib/i18n/languageCodes";
+
+interface LanguagePickerProps {
+  value: string;
+  onChange: (code: string) => void;
+  disabled?: boolean;
+}
+
+/** Set of codes that appear in the "Frequently used" group */
+const FREQUENT_CODES = new Set(FREQUENT_LANGUAGES.map((l) => l.code));
+
+/** Languages that only appear in the "All languages" group */
+const OTHER_LANGUAGES: LanguageOption[] = ALL_LANGUAGES.filter(
+  (l) => !FREQUENT_CODES.has(l.code)
+);
+
+/**
+ * Compact searchable combobox for selecting a BCP 47 language tag.
+ *
+ * Uses `cmdk` for keyboard-accessible filtering. The trigger button shows
+ * the country flag emoji + language code, matching the width of the previous
+ * plain `<input>` it replaces.
+ */
+export function LanguagePicker({ value, onChange, disabled }: LanguagePickerProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  const flag = langToFlag(value);
+  const langInfo = findLanguageByCode(value);
+  const displayLabel = langInfo ? langInfo.code : value || "lang";
+
+  const handleSelect = (code: string) => {
+    onChange(code);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <button
+        type="button"
+        onClick={() => !disabled && setOpen((prev) => !prev)}
+        disabled={disabled}
+        aria-label="Language tag"
+        title={langInfo ? `${langInfo.name} (${langInfo.nativeName})` : value || "Select language"}
+        className="flex w-14 items-center justify-center gap-0.5 rounded-md border border-slate-300 bg-white px-1 py-1.5 text-xs text-slate-700 hover:border-slate-400 focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 dark:hover:border-slate-500"
+      >
+        {flag && <span className="text-sm leading-none">{flag}</span>}
+        <span className="truncate">{displayLabel}</span>
+        <ChevronDown className="h-2.5 w-2.5 shrink-0 text-slate-400" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-600 dark:bg-slate-700">
+          <Command
+            filter={(value, search) => {
+              const lang = ALL_LANGUAGES.find((l) => l.code === value);
+              if (!lang) return 0;
+              const q = search.toLowerCase();
+              if (lang.code.toLowerCase().includes(q)) return 1;
+              if (lang.name.toLowerCase().includes(q)) return 1;
+              if (lang.nativeName.toLowerCase().includes(q)) return 1;
+              return 0;
+            }}
+          >
+            <div className="border-b border-slate-200 px-2 py-1.5 dark:border-slate-600">
+              <Command.Input
+                placeholder="Search languages..."
+                autoFocus
+                className="w-full bg-transparent text-xs text-slate-900 placeholder:text-slate-400 focus:outline-hidden dark:text-white dark:placeholder:text-slate-500"
+              />
+            </div>
+            <Command.List className="max-h-60 overflow-y-auto py-1">
+              <Command.Empty className="py-3 text-center text-xs text-slate-500 dark:text-slate-400">
+                No matching languages
+              </Command.Empty>
+
+              <Command.Group
+                heading="Frequently used"
+                className="[&>[cmdk-group-heading]]:px-2 [&>[cmdk-group-heading]]:py-0.5 [&>[cmdk-group-heading]]:text-[9px] [&>[cmdk-group-heading]]:font-semibold [&>[cmdk-group-heading]]:uppercase [&>[cmdk-group-heading]]:tracking-wider [&>[cmdk-group-heading]]:text-slate-400 dark:[&>[cmdk-group-heading]]:text-slate-500"
+              >
+                {FREQUENT_LANGUAGES.map((lang) => (
+                  <LanguageItem
+                    key={lang.code}
+                    lang={lang}
+                    selected={lang.code === value}
+                    onSelect={handleSelect}
+                  />
+                ))}
+              </Command.Group>
+
+              <Command.Group
+                heading="All languages"
+                className="[&>[cmdk-group-heading]]:px-2 [&>[cmdk-group-heading]]:py-0.5 [&>[cmdk-group-heading]]:text-[9px] [&>[cmdk-group-heading]]:font-semibold [&>[cmdk-group-heading]]:uppercase [&>[cmdk-group-heading]]:tracking-wider [&>[cmdk-group-heading]]:text-slate-400 dark:[&>[cmdk-group-heading]]:text-slate-500"
+              >
+                {OTHER_LANGUAGES.map((lang) => (
+                  <LanguageItem
+                    key={lang.code}
+                    lang={lang}
+                    selected={lang.code === value}
+                    onSelect={handleSelect}
+                  />
+                ))}
+              </Command.Group>
+            </Command.List>
+          </Command>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LanguageItem({
+  lang,
+  selected,
+  onSelect,
+}: {
+  lang: LanguageOption;
+  selected: boolean;
+  onSelect: (code: string) => void;
+}) {
+  const flag = langToFlag(lang.code);
+
+  return (
+    <Command.Item
+      value={lang.code}
+      onSelect={() => onSelect(lang.code)}
+      className="flex cursor-pointer items-center gap-2 px-2 py-1 text-xs aria-selected:bg-slate-100 dark:aria-selected:bg-slate-600"
+    >
+      <span className="inline-flex w-5 shrink-0 items-center justify-center text-sm leading-none">
+        {flag}
+      </span>
+      <span className="font-medium text-slate-700 dark:text-slate-200">{lang.name}</span>
+      {lang.nativeName !== lang.name && (
+        <span className="text-slate-400 dark:text-slate-500">{lang.nativeName}</span>
+      )}
+      <span className="ml-auto text-[10px] text-slate-400 dark:text-slate-500">{lang.code}</span>
+      {selected && (
+        <span className="text-primary-500" aria-label="Selected">
+          &#10003;
+        </span>
+      )}
+    </Command.Item>
+  );
+}

--- a/components/editor/PropertyDetailPanel.tsx
+++ b/components/editor/PropertyDetailPanel.tsx
@@ -22,6 +22,7 @@ import {
 import type { LocalizedString, AnnotationUpdate } from "@/lib/api/client";
 import { cn, getLocalName } from "@/lib/utils";
 import { LanguageFlag } from "@/components/editor/LanguageFlag";
+import { LanguagePicker } from "@/components/editor/LanguagePicker";
 import { AnnotationRow } from "@/components/editor/standard/AnnotationRow";
 import { InlineAnnotationAdder } from "@/components/editor/standard/InlineAnnotationAdder";
 import { RelationshipSection, type RelationshipGroup, type RelationshipTarget } from "@/components/editor/standard/RelationshipSection";
@@ -512,8 +513,7 @@ export function PropertyDetailPanel({
                 {editLabels.map((label, index) => (
                   <div key={index} className="flex items-center gap-2">
                     <input type="text" value={label.value} onChange={(e) => updateLabel(index, "value", e.target.value)} onBlur={() => triggerSave()} placeholder="Label text" className="flex-1 rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white" />
-                    <LanguageFlag lang={label.lang} />
-                    <input type="text" value={label.lang} onChange={(e) => updateLabel(index, "lang", e.target.value)} onBlur={() => triggerSave()} className="w-14 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-center text-xs focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white" title="Language tag" />
+                    <LanguagePicker value={label.lang} onChange={(code) => { updateLabel(index, "lang", code); triggerSave(); }} />
                     {editLabels.length > 1 ? (
                       <button onClick={() => removeLabel(index)} className="rounded-sm p-1 text-slate-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400" title="Remove"><Trash2 className="h-3.5 w-3.5" /></button>
                     ) : (

--- a/components/editor/standard/AnnotationRow.tsx
+++ b/components/editor/standard/AnnotationRow.tsx
@@ -64,7 +64,13 @@ export function AnnotationRow({
           className="flex-1 rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
         />
       )}
-      <LanguagePicker value={lang} onChange={onLangChange} />
+      <LanguagePicker
+        value={lang}
+        onChange={(code) => {
+          onLangChange(code);
+          onBlur?.();
+        }}
+      />
       {onRemove ? (
         <button
           onClick={onRemove}

--- a/components/editor/standard/AnnotationRow.tsx
+++ b/components/editor/standard/AnnotationRow.tsx
@@ -2,7 +2,7 @@
 
 import { Trash2 } from "lucide-react";
 import { getAnnotationPropertyInfo } from "@/lib/ontology/annotationProperties";
-import { LanguageFlag } from "@/components/editor/LanguageFlag";
+import { LanguagePicker } from "@/components/editor/LanguagePicker";
 
 interface AnnotationRowProps {
   propertyIri: string;
@@ -64,18 +64,7 @@ export function AnnotationRow({
           className="flex-1 rounded-md border border-slate-300 bg-white px-2.5 py-1.5 text-sm focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
         />
       )}
-      <div className="mt-1 shrink-0">
-        <LanguageFlag lang={lang} />
-      </div>
-      <input
-        type="text"
-        value={lang}
-        onChange={(e) => onLangChange(e.target.value)}
-        onBlur={onBlur}
-        className="w-14 shrink-0 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-center text-xs focus:border-primary-500 focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
-        aria-label="Language tag"
-        placeholder="lang"
-      />
+      <LanguagePicker value={lang} onChange={onLangChange} />
       {onRemove ? (
         <button
           onClick={onRemove}

--- a/components/editor/standard/InlineAnnotationAdder.tsx
+++ b/components/editor/standard/InlineAnnotationAdder.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { ChevronDown, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { LanguageFlag } from "@/components/editor/LanguageFlag";
+import { LanguagePicker } from "@/components/editor/LanguagePicker";
 import {
   ANNOTATION_PROPERTIES,
   getAnnotationPropertiesByVocabulary,
@@ -197,18 +197,7 @@ export function InlineAnnotationAdder({ excludeIris, onAdd, onSaveNeeded }: Inli
                 : "border-dashed border-slate-200 bg-slate-50 text-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500"
             )}
           />
-          <div className="mt-1 shrink-0">
-            <LanguageFlag lang={lang} />
-          </div>
-          <input
-            type="text"
-            value={lang}
-            onChange={(e) => setLang(e.target.value)}
-            className="w-14 shrink-0 rounded-md border border-dashed border-slate-300 bg-white px-2 py-1.5 text-center text-xs focus:border-primary-500 focus:border-solid focus:outline-hidden focus:ring-1 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700 dark:text-white"
-            aria-label="Language tag"
-            placeholder="lang"
-            disabled={!selectedProperty}
-          />
+          <LanguagePicker value={lang} onChange={setLang} disabled={!selectedProperty} />
           {/* Invisible placeholder to align with delete buttons above */}
           <div className="shrink-0 rounded-sm p-1">
             <div className="h-3.5 w-3.5" />

--- a/lib/i18n/languageCodes.ts
+++ b/lib/i18n/languageCodes.ts
@@ -129,8 +129,10 @@ export const ALL_LANGUAGES: LanguageOption[] = [
   ...ADDITIONAL_LANGUAGES.filter((l) => !FREQUENT_CODES.has(l.code)),
 ];
 
+/** O(1) lookup map keyed by lowercase BCP 47 code. */
+const LANG_BY_CODE = new Map(ALL_LANGUAGES.map((l) => [l.code.toLowerCase(), l]));
+
 /** Look up a language option by its BCP 47 code (case-insensitive). */
 export function findLanguageByCode(code: string): LanguageOption | undefined {
-  const lower = code.toLowerCase();
-  return ALL_LANGUAGES.find((l) => l.code.toLowerCase() === lower);
+  return LANG_BY_CODE.get(code.toLowerCase());
 }

--- a/lib/i18n/languageCodes.ts
+++ b/lib/i18n/languageCodes.ts
@@ -1,0 +1,136 @@
+/**
+ * Curated list of BCP 47 language codes for the language picker.
+ *
+ * Codes are split into a "frequently used" group (shown first in the picker)
+ * and a comprehensive list that covers ~100 codes including major regional
+ * variants.
+ */
+
+export interface LanguageOption {
+  /** BCP 47 language tag, e.g. "en", "pt-BR" */
+  code: string;
+  /** English name */
+  name: string;
+  /** Name in the language itself */
+  nativeName: string;
+}
+
+/**
+ * Languages shown at the top of the picker for quick access.
+ * These are the most common ontology-authoring languages.
+ */
+export const FREQUENT_LANGUAGES: LanguageOption[] = [
+  { code: "en", name: "English", nativeName: "English" },
+  { code: "fr", name: "French", nativeName: "Fran\u00e7ais" },
+  { code: "de", name: "German", nativeName: "Deutsch" },
+  { code: "es", name: "Spanish", nativeName: "Espa\u00f1ol" },
+  { code: "it", name: "Italian", nativeName: "Italiano" },
+  { code: "pt", name: "Portuguese", nativeName: "Portugu\u00eas" },
+  { code: "la", name: "Latin", nativeName: "Latina" },
+  { code: "nl", name: "Dutch", nativeName: "Nederlands" },
+  { code: "ru", name: "Russian", nativeName: "\u0420\u0443\u0441\u0441\u043a\u0438\u0439" },
+  { code: "zh", name: "Chinese", nativeName: "\u4e2d\u6587" },
+  { code: "ja", name: "Japanese", nativeName: "\u65e5\u672c\u8a9e" },
+  { code: "ko", name: "Korean", nativeName: "\ud55c\uad6d\uc5b4" },
+  { code: "ar", name: "Arabic", nativeName: "\u0627\u0644\u0639\u0631\u0628\u064a\u0629" },
+  { code: "pl", name: "Polish", nativeName: "Polski" },
+];
+
+const FREQUENT_CODES = new Set(FREQUENT_LANGUAGES.map((l) => l.code));
+
+/**
+ * Full list of supported languages (alphabetical by English name).
+ * Includes regional variants like en-GB, pt-BR, zh-CN, etc.
+ */
+const ADDITIONAL_LANGUAGES: LanguageOption[] = [
+  { code: "af", name: "Afrikaans", nativeName: "Afrikaans" },
+  { code: "sq", name: "Albanian", nativeName: "Shqip" },
+  { code: "am", name: "Amharic", nativeName: "\u12a0\u121b\u122d\u129b" },
+  { code: "hy", name: "Armenian", nativeName: "\u0540\u0561\u0575\u0565\u0580\u0565\u0576" },
+  { code: "az", name: "Azerbaijani", nativeName: "Az\u0259rbaycan" },
+  { code: "eu", name: "Basque", nativeName: "Euskara" },
+  { code: "be", name: "Belarusian", nativeName: "\u0411\u0435\u043b\u0430\u0440\u0443\u0441\u043a\u0430\u044f" },
+  { code: "bn", name: "Bengali", nativeName: "\u09ac\u09be\u0982\u09b2\u09be" },
+  { code: "bs", name: "Bosnian", nativeName: "Bosanski" },
+  { code: "bg", name: "Bulgarian", nativeName: "\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438" },
+  { code: "my", name: "Burmese", nativeName: "\u1019\u103c\u1014\u103a\u1019\u102c" },
+  { code: "ca", name: "Catalan", nativeName: "Catal\u00e0" },
+  { code: "zh-CN", name: "Chinese (Simplified)", nativeName: "\u7b80\u4f53\u4e2d\u6587" },
+  { code: "zh-TW", name: "Chinese (Traditional)", nativeName: "\u7e41\u9ad4\u4e2d\u6587" },
+  { code: "hr", name: "Croatian", nativeName: "Hrvatski" },
+  { code: "cs", name: "Czech", nativeName: "\u010ce\u0161tina" },
+  { code: "da", name: "Danish", nativeName: "Dansk" },
+  { code: "en-AU", name: "English (Australia)", nativeName: "English (Australia)" },
+  { code: "en-CA", name: "English (Canada)", nativeName: "English (Canada)" },
+  { code: "en-GB", name: "English (UK)", nativeName: "English (UK)" },
+  { code: "en-US", name: "English (US)", nativeName: "English (US)" },
+  { code: "et", name: "Estonian", nativeName: "Eesti" },
+  { code: "fi", name: "Finnish", nativeName: "Suomi" },
+  { code: "fr-CA", name: "French (Canada)", nativeName: "Fran\u00e7ais (Canada)" },
+  { code: "fr-FR", name: "French (France)", nativeName: "Fran\u00e7ais (France)" },
+  { code: "gl", name: "Galician", nativeName: "Galego" },
+  { code: "ka", name: "Georgian", nativeName: "\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8" },
+  { code: "de-AT", name: "German (Austria)", nativeName: "Deutsch (\u00d6sterreich)" },
+  { code: "de-CH", name: "German (Switzerland)", nativeName: "Deutsch (Schweiz)" },
+  { code: "el", name: "Greek", nativeName: "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac" },
+  { code: "gu", name: "Gujarati", nativeName: "\u0a97\u0ac1\u0a9c\u0ab0\u0abe\u0aa4\u0ac0" },
+  { code: "ha", name: "Hausa", nativeName: "Hausa" },
+  { code: "he", name: "Hebrew", nativeName: "\u05e2\u05d1\u05e8\u05d9\u05ea" },
+  { code: "hi", name: "Hindi", nativeName: "\u0939\u093f\u0928\u094d\u0926\u0940" },
+  { code: "hu", name: "Hungarian", nativeName: "Magyar" },
+  { code: "is", name: "Icelandic", nativeName: "\u00cdslenska" },
+  { code: "id", name: "Indonesian", nativeName: "Bahasa Indonesia" },
+  { code: "ga", name: "Irish", nativeName: "Gaeilge" },
+  { code: "kn", name: "Kannada", nativeName: "\u0c95\u0ca8\u0ccd\u0ca8\u0ca1" },
+  { code: "kk", name: "Kazakh", nativeName: "\u049a\u0430\u0437\u0430\u049b" },
+  { code: "km", name: "Khmer", nativeName: "\u1781\u17d2\u1798\u17c2\u179a" },
+  { code: "lv", name: "Latvian", nativeName: "Latvie\u0161u" },
+  { code: "lt", name: "Lithuanian", nativeName: "Lietuvi\u0173" },
+  { code: "mk", name: "Macedonian", nativeName: "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0441\u043a\u0438" },
+  { code: "ms", name: "Malay", nativeName: "Bahasa Melayu" },
+  { code: "ml", name: "Malayalam", nativeName: "\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02" },
+  { code: "mt", name: "Maltese", nativeName: "Malti" },
+  { code: "mr", name: "Marathi", nativeName: "\u092e\u0930\u093e\u0920\u0940" },
+  { code: "mn", name: "Mongolian", nativeName: "\u041c\u043e\u043d\u0433\u043e\u043b" },
+  { code: "ne", name: "Nepali", nativeName: "\u0928\u0947\u092a\u093e\u0932\u0940" },
+  { code: "nb", name: "Norwegian Bokm\u00e5l", nativeName: "Norsk bokm\u00e5l" },
+  { code: "nn", name: "Norwegian Nynorsk", nativeName: "Norsk nynorsk" },
+  { code: "fa", name: "Persian", nativeName: "\u0641\u0627\u0631\u0633\u06cc" },
+  { code: "pt-BR", name: "Portuguese (Brazil)", nativeName: "Portugu\u00eas (Brasil)" },
+  { code: "pt-PT", name: "Portuguese (Portugal)", nativeName: "Portugu\u00eas (Portugal)" },
+  { code: "pa", name: "Punjabi", nativeName: "\u0a2a\u0a70\u0a1c\u0a3e\u0a2c\u0a40" },
+  { code: "ro", name: "Romanian", nativeName: "Rom\u00e2n\u0103" },
+  { code: "gd", name: "Scottish Gaelic", nativeName: "G\u00e0idhlig" },
+  { code: "sr", name: "Serbian", nativeName: "\u0421\u0440\u043f\u0441\u043a\u0438" },
+  { code: "si", name: "Sinhala", nativeName: "\u0dc3\u0dd2\u0d82\u0dc4\u0dbd" },
+  { code: "sk", name: "Slovak", nativeName: "Sloven\u010dina" },
+  { code: "sl", name: "Slovenian", nativeName: "Sloven\u0161\u010dina" },
+  { code: "es-MX", name: "Spanish (Mexico)", nativeName: "Espa\u00f1ol (M\u00e9xico)" },
+  { code: "es-ES", name: "Spanish (Spain)", nativeName: "Espa\u00f1ol (Espa\u00f1a)" },
+  { code: "sw", name: "Swahili", nativeName: "Kiswahili" },
+  { code: "sv", name: "Swedish", nativeName: "Svenska" },
+  { code: "tl", name: "Tagalog", nativeName: "Tagalog" },
+  { code: "ta", name: "Tamil", nativeName: "\u0ba4\u0bae\u0bbf\u0bb4\u0bcd" },
+  { code: "te", name: "Telugu", nativeName: "\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41" },
+  { code: "th", name: "Thai", nativeName: "\u0e44\u0e17\u0e22" },
+  { code: "tr", name: "Turkish", nativeName: "T\u00fcrk\u00e7e" },
+  { code: "uk", name: "Ukrainian", nativeName: "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430" },
+  { code: "ur", name: "Urdu", nativeName: "\u0627\u0631\u062f\u0648" },
+  { code: "uz", name: "Uzbek", nativeName: "O\u02bbzbek" },
+  { code: "vi", name: "Vietnamese", nativeName: "Ti\u1ebfng Vi\u1ec7t" },
+  { code: "cy", name: "Welsh", nativeName: "Cymraeg" },
+  { code: "yi", name: "Yiddish", nativeName: "\u05d9\u05d9\u05d3\u05d9\u05e9" },
+  { code: "zu", name: "Zulu", nativeName: "isiZulu" },
+];
+
+/** All available languages: frequent ones first, then the rest alphabetically. */
+export const ALL_LANGUAGES: LanguageOption[] = [
+  ...FREQUENT_LANGUAGES,
+  ...ADDITIONAL_LANGUAGES.filter((l) => !FREQUENT_CODES.has(l.code)),
+];
+
+/** Look up a language option by its BCP 47 code (case-insensitive). */
+export function findLanguageByCode(code: string): LanguageOption | undefined {
+  const lower = code.toLowerCase();
+  return ALL_LANGUAGES.find((l) => l.code.toLowerCase() === lower);
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -106,6 +106,7 @@ export function debounce<T extends (...args: unknown[]) => unknown>(
 /** Map bare language codes to their default country code for flag rendering */
 const LANG_TO_COUNTRY: Record<string, string> = {
   en: "US",
+  la: "VA",
   ja: "JP",
   ko: "KR",
   zh: "CN",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@tanstack/react-query": "^5.99.0",
         "@xyflow/react": "^12.10.1",
         "clsx": "^2.1.0",
+        "cmdk": "^1.1.1",
         "d3": "^7.9.0",
         "elkjs": "^0.11.0",
         "lucide-react": "^1.8.0",
@@ -8339,6 +8340,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {
@@ -16903,9 +16920,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.106.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.0.tgz",
-      "integrity": "sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==",
+      "version": "5.106.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
+      "integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-query": "^5.99.0",
     "@xyflow/react": "^12.10.1",
     "clsx": "^2.1.0",
+    "cmdk": "^1.1.1",
     "d3": "^7.9.0",
     "elkjs": "^0.11.0",
     "lucide-react": "^1.8.0",


### PR DESCRIPTION
## Summary

- Add `LanguagePicker` combobox component using `cmdk` with searchable dropdown of ~90 BCP 47 language codes
- Replace free-text `<input>` fields in `AnnotationRow` and `InlineAnnotationAdder` with the new picker
- Add `lib/i18n/languageCodes.ts` data module with frequently-used and full language lists (code, English name, native name)
- Flag emoji displayed alongside codes using existing `langToFlag()` utility

Closes #97

## Test plan

- [ ] Language picker opens on click, shows "Frequently used" group pinned to top
- [ ] Search filters by code (`en`), English name (`English`), and native name (`Français`)
- [ ] Keyboard navigation works: arrow keys, Enter to select, Escape to close
- [ ] Selecting a language updates the annotation's language tag
- [ ] Existing annotations with valid language codes display correctly
- [ ] Compact trigger fits in the same layout space as the old text input
- [ ] Dark mode styling is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable, keyboard-accessible language picker with grouped "Frequently used" and "All languages", custom-code entry, outside-click and Escape dismissal.

* **Updates**
  * Editors, panels, and inline adder now use the picker; language changes apply immediately and trigger save (no longer blur-driven).
  * Centralized canonical language list with case-insensitive lookup for consistent language metadata.

* **Style**
  * Emoji font utility added and applied to language flags.

* **Tests**
  * New picker and language-data tests; many editor tests updated to use picker mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->