### PR TITLE
feat: migrate data fetching to React Query hooks

### DIFF
--- a/__tests__/lib/hooks/useProjectViewer.test.ts
+++ b/__tests__/lib/hooks/useProjectViewer.test.ts
@@ -47,37 +47,26 @@ vi.mock("@/lib/hooks/useCollaborationStatus", () => ({
   }),
 }));
 
-vi.mock("@/lib/api/pullRequests", () => ({
-  pullRequestsApi: {
-    list: vi.fn().mockResolvedValue({ total: 3, items: [] }),
-  },
+// Mock the new React Query hooks used by useProjectViewer
+const mockUseOpenPRCount = vi.fn();
+const mockUseLintSummary = vi.fn();
+const mockUseNormalizationStatus = vi.fn();
+const mockUsePendingSuggestionCount = vi.fn();
+
+vi.mock("@/lib/hooks/useOpenPRCount", () => ({
+  useOpenPRCount: (...args: unknown[]) => mockUseOpenPRCount(...args),
 }));
 
-vi.mock("@/lib/api/lint", () => ({
-  lintApi: {
-    getStatus: vi.fn().mockResolvedValue({
-      project_id: "p1",
-      last_run: null,
-      error_count: 1,
-      warning_count: 2,
-      info_count: 0,
-      total_issues: 3,
-    }),
-  },
+vi.mock("@/lib/hooks/useLintSummary", () => ({
+  useLintSummary: (...args: unknown[]) => mockUseLintSummary(...args),
 }));
 
-vi.mock("@/lib/api/normalization", () => ({
-  normalizationApi: {
-    getStatus: vi.fn().mockResolvedValue({
-      needs_normalization: false,
-      last_run: null,
-      last_run_id: null,
-      last_check: null,
-      preview_report: null,
-      checking: false,
-      error: null,
-    }),
-  },
+vi.mock("@/lib/hooks/useNormalizationStatus", () => ({
+  useNormalizationStatus: (...args: unknown[]) => mockUseNormalizationStatus(...args),
+}));
+
+vi.mock("@/lib/hooks/usePendingSuggestionCount", () => ({
+  usePendingSuggestionCount: (...args: unknown[]) => mockUsePendingSuggestionCount(...args),
 }));
 
 vi.mock("@/lib/api/revisions", () => ({
@@ -86,17 +75,7 @@ vi.mock("@/lib/api/revisions", () => ({
   },
 }));
 
-vi.mock("@/lib/api/suggestions", () => ({
-  suggestionsApi: {
-    listPending: vi.fn().mockResolvedValue({ items: [{ id: "s1" }] }),
-  },
-}));
-
 import { useProjectViewer } from "@/lib/hooks/useProjectViewer";
-import { pullRequestsApi } from "@/lib/api/pullRequests";
-import { lintApi } from "@/lib/api/lint";
-import { normalizationApi } from "@/lib/api/normalization";
-import { suggestionsApi } from "@/lib/api/suggestions";
 import { revisionsApi, type RevisionFileResponse } from "@/lib/api/revisions";
 import { useOntologyTree } from "@/lib/hooks/useOntologyTree";
 
@@ -140,6 +119,31 @@ describe("useProjectViewer", () => {
       errorKind: null,
     });
     mockDerivePermissions.mockReturnValue(defaultPermissions());
+
+    // Default mock return values for React Query hooks
+    mockUseOpenPRCount.mockReturnValue({ data: 3 });
+    mockUseLintSummary.mockReturnValue({
+      data: {
+        project_id: "p1",
+        last_run: null,
+        error_count: 1,
+        warning_count: 2,
+        info_count: 0,
+        total_issues: 3,
+      },
+    });
+    mockUseNormalizationStatus.mockReturnValue({
+      data: {
+        needs_normalization: false,
+        last_run: null,
+        last_run_id: null,
+        last_check: null,
+        preview_report: null,
+        checking: false,
+        error: null,
+      },
+    });
+    mockUsePendingSuggestionCount.mockReturnValue({ data: 1 });
   });
 
   it("returns loading state initially", () => {
@@ -251,7 +255,7 @@ describe("useProjectViewer", () => {
     expect(result.current.hasValidAccess).toBe(false);
   });
 
-  it("fetches secondary data (openPRCount, lintSummary) when project loads", async () => {
+  it("returns secondary data (openPRCount, lintSummary) from React Query hooks", () => {
     const project = makeProject();
     mockUseProject.mockReturnValue({
       project,
@@ -269,20 +273,16 @@ describe("useProjectViewer", () => {
       })
     );
 
-    await waitFor(() => {
-      expect(result.current.openPRCount).toBe(3);
-    });
+    expect(result.current.openPRCount).toBe(3);
+    expect(result.current.lintSummary).not.toBeNull();
+    expect(result.current.lintSummary?.total_issues).toBe(3);
 
-    await waitFor(() => {
-      expect(result.current.lintSummary).not.toBeNull();
-      expect(result.current.lintSummary?.total_issues).toBe(3);
-    });
-
-    expect(pullRequestsApi.list).toHaveBeenCalledWith("p1", "tok", "open", undefined, 0, 1);
-    expect(lintApi.getStatus).toHaveBeenCalledWith("p1", "tok");
+    // Verify hooks were called with correct args
+    expect(mockUseOpenPRCount).toHaveBeenCalledWith("p1", "tok");
+    expect(mockUseLintSummary).toHaveBeenCalledWith("p1", "tok");
   });
 
-  it("fetches normalization status when project has source_file_path", async () => {
+  it("passes normalization status from React Query hook", () => {
     const project = makeProject({ source_file_path: "ont.ttl" });
     mockUseProject.mockReturnValue({
       project,
@@ -300,14 +300,16 @@ describe("useProjectViewer", () => {
       })
     );
 
-    await waitFor(() => {
-      expect(result.current.normalizationStatus).not.toBeNull();
-    });
-
-    expect(normalizationApi.getStatus).toHaveBeenCalledWith("p1", "tok");
+    expect(result.current.normalizationStatus).not.toBeNull();
+    // Verify the hook was called with enabled based on source_file_path
+    expect(mockUseNormalizationStatus).toHaveBeenCalledWith(
+      "p1",
+      "tok",
+      { enabled: true },
+    );
   });
 
-  it("does not fetch normalization status when no source_file_path", async () => {
+  it("disables normalization status hook when no source_file_path", () => {
     const project = makeProject({ source_file_path: undefined });
     mockUseProject.mockReturnValue({
       project,
@@ -315,6 +317,8 @@ describe("useProjectViewer", () => {
       error: null,
       errorKind: null,
     });
+    mockDerivePermissions.mockReturnValue(defaultPermissions({ hasOntology: false }));
+    mockUseNormalizationStatus.mockReturnValue({ data: undefined });
 
     renderHook(() =>
       useProjectViewer({
@@ -325,15 +329,15 @@ describe("useProjectViewer", () => {
       })
     );
 
-    // Wait for secondary effects to complete
-    await waitFor(() => {
-      expect(pullRequestsApi.list).toHaveBeenCalled();
-    });
-
-    expect(normalizationApi.getStatus).not.toHaveBeenCalled();
+    // Hook should be called with enabled: false (no source_file_path)
+    expect(mockUseNormalizationStatus).toHaveBeenCalledWith(
+      "p1",
+      "tok",
+      { enabled: false },
+    );
   });
 
-  it("fetches pending suggestions when canEdit and has accessToken", async () => {
+  it("returns pending suggestion count from React Query hook when canEdit", () => {
     const project = makeProject();
     mockUseProject.mockReturnValue({
       project,
@@ -352,14 +356,15 @@ describe("useProjectViewer", () => {
       })
     );
 
-    await waitFor(() => {
-      expect(result.current.pendingSuggestionCount).toBe(1);
-    });
-
-    expect(suggestionsApi.listPending).toHaveBeenCalledWith("p1", "tok");
+    expect(result.current.pendingSuggestionCount).toBe(1);
+    expect(mockUsePendingSuggestionCount).toHaveBeenCalledWith(
+      "p1",
+      "tok",
+      { enabled: true },
+    );
   });
 
-  it("does not fetch suggestions when canEdit is false", async () => {
+  it("disables suggestion count hook when canEdit is false", () => {
     const project = makeProject();
     mockUseProject.mockReturnValue({
       project,
@@ -368,6 +373,7 @@ describe("useProjectViewer", () => {
       errorKind: null,
     });
     mockDerivePermissions.mockReturnValue(defaultPermissions({ canEdit: false }));
+    mockUsePendingSuggestionCount.mockReturnValue({ data: undefined });
 
     renderHook(() =>
       useProjectViewer({
@@ -378,39 +384,11 @@ describe("useProjectViewer", () => {
       })
     );
 
-    // Wait for other effects
-    await waitFor(() => {
-      expect(pullRequestsApi.list).toHaveBeenCalled();
-    });
-
-    expect(suggestionsApi.listPending).not.toHaveBeenCalled();
-  });
-
-  it("does not fetch suggestions when canEdit is true but accessToken is missing", async () => {
-    const project = makeProject();
-    mockUseProject.mockReturnValue({
-      project,
-      isLoading: false,
-      error: null,
-      errorKind: null,
-    });
-    mockDerivePermissions.mockReturnValue(defaultPermissions({ canEdit: true }));
-
-    renderHook(() =>
-      useProjectViewer({
-        projectId: "p1",
-        accessToken: undefined,
-        sessionStatus: "unauthenticated",
-        activeBranch: "main",
-      })
+    expect(mockUsePendingSuggestionCount).toHaveBeenCalledWith(
+      "p1",
+      "tok",
+      { enabled: false },
     );
-
-    // Wait for other effects
-    await waitFor(() => {
-      expect(pullRequestsApi.list).toHaveBeenCalled();
-    });
-
-    expect(suggestionsApi.listPending).not.toHaveBeenCalled();
   });
 
   it("exposes tree properties from useOntologyTree", () => {
@@ -483,15 +461,20 @@ describe("useProjectViewer", () => {
     expect(typeof result.current.resetSourceState).toBe("function");
   });
 
-  it("does not fetch secondary data when project is null", async () => {
+  it("returns default values when project is null", () => {
     mockUseProject.mockReturnValue({
       project: null,
       isLoading: false,
       error: "Not found",
       errorKind: "not-found",
     });
+    // Hooks return undefined data when project is null
+    mockUseOpenPRCount.mockReturnValue({ data: undefined });
+    mockUseLintSummary.mockReturnValue({ data: undefined });
+    mockUseNormalizationStatus.mockReturnValue({ data: undefined });
+    mockUsePendingSuggestionCount.mockReturnValue({ data: undefined });
 
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useProjectViewer({
         projectId: "p1",
         accessToken: "tok",
@@ -500,13 +483,10 @@ describe("useProjectViewer", () => {
       })
     );
 
-    // Give effects time to fire (they shouldn't)
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
-    });
-
-    expect(pullRequestsApi.list).not.toHaveBeenCalled();
-    expect(lintApi.getStatus).not.toHaveBeenCalled();
+    expect(result.current.openPRCount).toBe(0);
+    expect(result.current.lintSummary).toBeNull();
+    expect(result.current.normalizationStatus).toBeNull();
+    expect(result.current.pendingSuggestionCount).toBe(0);
   });
 
   // --- loadSourceContent ---

--- a/__tests__/lib/hooks/useQueryHooks.test.ts
+++ b/__tests__/lib/hooks/useQueryHooks.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for the standalone React Query data-fetching hooks:
+ *   useOpenPRCount, useLintSummary, useMembers,
+ *   useNormalizationStatus, useIndexStatus, usePendingSuggestionCount
+ *
+ * Each hook is a thin useQuery wrapper — tests verify:
+ *   1. Data is returned when the query resolves
+ *   2. The query is disabled when required params are missing
+ *   3. The enabled option (where applicable) is respected
+ */
+
+import React, { type ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// ---- Mocks ----
+
+vi.mock("@/lib/api/pullRequests", () => ({
+  pullRequestsApi: { list: vi.fn() },
+}));
+vi.mock("@/lib/api/lint", () => ({
+  lintApi: { getStatus: vi.fn() },
+}));
+vi.mock("@/lib/api/projects", () => ({
+  projectApi: { listMembers: vi.fn() },
+}));
+vi.mock("@/lib/api/normalization", () => ({
+  normalizationApi: { getStatus: vi.fn() },
+}));
+vi.mock("@/lib/api/client", () => ({
+  projectOntologyApi: { getIndexStatus: vi.fn() },
+}));
+vi.mock("@/lib/api/suggestions", () => ({
+  suggestionsApi: { listPending: vi.fn() },
+}));
+
+import { pullRequestsApi } from "@/lib/api/pullRequests";
+import { lintApi } from "@/lib/api/lint";
+import { projectApi } from "@/lib/api/projects";
+import { normalizationApi } from "@/lib/api/normalization";
+import { projectOntologyApi } from "@/lib/api/client";
+import { suggestionsApi } from "@/lib/api/suggestions";
+
+import { useOpenPRCount } from "@/lib/hooks/useOpenPRCount";
+import { useLintSummary } from "@/lib/hooks/useLintSummary";
+import { useMembers } from "@/lib/hooks/useMembers";
+import { useNormalizationStatus } from "@/lib/hooks/useNormalizationStatus";
+import { useIndexStatus } from "@/lib/hooks/useIndexStatus";
+import { usePendingSuggestionCount } from "@/lib/hooks/usePendingSuggestionCount";
+
+const mockedPRList = pullRequestsApi.list as ReturnType<typeof vi.fn>;
+const mockedLintStatus = lintApi.getStatus as ReturnType<typeof vi.fn>;
+const mockedListMembers = projectApi.listMembers as ReturnType<typeof vi.fn>;
+const mockedNormStatus = normalizationApi.getStatus as ReturnType<typeof vi.fn>;
+const mockedIndexStatus = projectOntologyApi.getIndexStatus as ReturnType<typeof vi.fn>;
+const mockedListPending = suggestionsApi.listPending as ReturnType<typeof vi.fn>;
+
+// ---- Helpers ----
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---- useOpenPRCount ----
+
+describe("useOpenPRCount", () => {
+  it("returns the total open PR count", async () => {
+    mockedPRList.mockResolvedValue({ total: 7, items: [] });
+
+    const { result } = renderHook(() => useOpenPRCount("p1", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(7);
+    expect(mockedPRList).toHaveBeenCalledWith("p1", "tok", "open", undefined, 0, 1);
+  });
+
+  it("does not fetch when accessToken is missing", () => {
+    const { result } = renderHook(() => useOpenPRCount("p1", undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedPRList).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    const { result } = renderHook(() => useOpenPRCount("", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedPRList).not.toHaveBeenCalled();
+  });
+});
+
+// ---- useLintSummary ----
+
+describe("useLintSummary", () => {
+  const summary = { project_id: "p1", error_count: 2, warning_count: 1, info_count: 0, total_issues: 3, last_run: null };
+
+  it("returns lint summary data", async () => {
+    mockedLintStatus.mockResolvedValue(summary);
+
+    const { result } = renderHook(() => useLintSummary("p1", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(summary);
+    expect(mockedLintStatus).toHaveBeenCalledWith("p1", "tok");
+  });
+
+  it("does not fetch when accessToken is missing", () => {
+    const { result } = renderHook(() => useLintSummary("p1", undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedLintStatus).not.toHaveBeenCalled();
+  });
+});
+
+// ---- useMembers ----
+
+describe("useMembers", () => {
+  const membersResponse = { items: [{ user_id: "u1", role: "editor" }], total: 1 };
+
+  it("returns member list", async () => {
+    mockedListMembers.mockResolvedValue(membersResponse);
+
+    const { result } = renderHook(() => useMembers("p1", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(membersResponse);
+    expect(mockedListMembers).toHaveBeenCalledWith("p1", "tok");
+  });
+
+  it("does not fetch when accessToken is missing", () => {
+    const { result } = renderHook(() => useMembers("p1", undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedListMembers).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    const { result } = renderHook(() => useMembers("", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedListMembers).not.toHaveBeenCalled();
+  });
+});
+
+// ---- useNormalizationStatus ----
+
+describe("useNormalizationStatus", () => {
+  const normStatus = { needs_normalization: false, last_run: null, last_run_id: null, last_check: null, preview_report: null, checking: false, error: null };
+
+  it("returns normalization status", async () => {
+    mockedNormStatus.mockResolvedValue(normStatus);
+
+    const { result } = renderHook(() => useNormalizationStatus("p1", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(normStatus);
+    expect(mockedNormStatus).toHaveBeenCalledWith("p1", "tok");
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    const { result } = renderHook(() => useNormalizationStatus("", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedNormStatus).not.toHaveBeenCalled();
+  });
+
+  it("respects enabled: false option", () => {
+    const { result } = renderHook(
+      () => useNormalizationStatus("p1", "tok", { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedNormStatus).not.toHaveBeenCalled();
+  });
+});
+
+// ---- useIndexStatus ----
+
+describe("useIndexStatus", () => {
+  const idxStatus = { status: "ready", entity_count: 42, last_indexed: "2026-01-01T00:00:00Z" };
+
+  it("returns index status", async () => {
+    mockedIndexStatus.mockResolvedValue(idxStatus);
+
+    const { result } = renderHook(() => useIndexStatus("p1", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(idxStatus);
+    expect(mockedIndexStatus).toHaveBeenCalledWith("p1", "tok");
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    const { result } = renderHook(() => useIndexStatus("", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedIndexStatus).not.toHaveBeenCalled();
+  });
+
+  it("respects enabled: false option", () => {
+    const { result } = renderHook(
+      () => useIndexStatus("p1", "tok", { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedIndexStatus).not.toHaveBeenCalled();
+  });
+});
+
+// ---- usePendingSuggestionCount ----
+
+describe("usePendingSuggestionCount", () => {
+  it("returns pending suggestion count", async () => {
+    mockedListPending.mockResolvedValue({ items: [{ id: "s1" }, { id: "s2" }] });
+
+    const { result } = renderHook(() => usePendingSuggestionCount("p1", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(2);
+    expect(mockedListPending).toHaveBeenCalledWith("p1", "tok");
+  });
+
+  it("does not fetch when accessToken is missing", () => {
+    const { result } = renderHook(() => usePendingSuggestionCount("p1", undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedListPending).not.toHaveBeenCalled();
+  });
+
+  it("respects enabled: false option", () => {
+    const { result } = renderHook(
+      () => usePendingSuggestionCount("p1", "tok", { enabled: false }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedListPending).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    const { result } = renderHook(() => usePendingSuggestionCount("", "tok"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedListPending).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/hooks/useQueryHooks.test.ts
+++ b/__tests__/lib/hooks/useQueryHooks.test.ts
@@ -60,8 +60,10 @@ const mockedListPending = suggestionsApi.listPending as ReturnType<typeof vi.fn>
 
 function createWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return ({ children }: { children: ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: qc }, children);
+  }
+  return Wrapper;
 }
 
 beforeEach(() => {

--- a/__tests__/lib/hooks/useRemoteSync.test.ts
+++ b/__tests__/lib/hooks/useRemoteSync.test.ts
@@ -1,5 +1,7 @@
+import React, { type ReactNode } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useRemoteSync } from "@/lib/hooks/useRemoteSync";
 import type { RemoteSyncConfig, SyncEvent } from "@/lib/api/remoteSync";
 
@@ -23,6 +25,13 @@ const mockedTriggerCheck = remoteSyncApi.triggerCheck as ReturnType<typeof vi.fn
 const mockedGetJobStatus = remoteSyncApi.getJobStatus as ReturnType<typeof vi.fn>;
 const mockedSaveConfig = remoteSyncApi.saveConfig as ReturnType<typeof vi.fn>;
 const mockedDeleteConfig = remoteSyncApi.deleteConfig as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // eslint-disable-next-line react/display-name
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
 
 function makeConfig(overrides: Partial<RemoteSyncConfig> = {}): RemoteSyncConfig {
   return {
@@ -56,6 +65,7 @@ describe("useRemoteSync", () => {
 
     renderHook(() =>
       useRemoteSync({ projectId: "proj-1", accessToken: "token", enabled: false }),
+      { wrapper: createWrapper() },
     );
 
     // Give time for any potential async calls
@@ -69,6 +79,7 @@ describe("useRemoteSync", () => {
 
     renderHook(() =>
       useRemoteSync({ projectId: "", accessToken: "token" }),
+      { wrapper: createWrapper() },
     );
 
     await act(async () => {});
@@ -97,6 +108,7 @@ describe("useRemoteSync", () => {
 
     const { result } = renderHook(() =>
       useRemoteSync({ projectId: "proj-1", accessToken: "token" }),
+      { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -111,6 +123,7 @@ describe("useRemoteSync", () => {
 
     const { result } = renderHook(() =>
       useRemoteSync({ projectId: "proj-1", accessToken: "token" }),
+      { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -124,6 +137,7 @@ describe("useRemoteSync", () => {
 
     const { result } = renderHook(() =>
       useRemoteSync({ projectId: "proj-1" }),
+      { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -149,6 +163,7 @@ describe("useRemoteSync", () => {
 
     const { result } = renderHook(() =>
       useRemoteSync({ projectId: "proj-1", accessToken: "token" }),
+      { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -171,6 +186,7 @@ describe("useRemoteSync", () => {
 
     const { result } = renderHook(() =>
       useRemoteSync({ projectId: "proj-1", accessToken: "token" }),
+      { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -190,6 +206,7 @@ describe("useRemoteSync", () => {
 
     const { result } = renderHook(() =>
       useRemoteSync({ projectId: "proj-1", accessToken: "token" }),
+      { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -213,6 +230,7 @@ describe("useRemoteSync", () => {
 
     const { result } = renderHook(() =>
       useRemoteSync({ projectId: "proj-1", accessToken: "token" }),
+      { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -659,7 +659,7 @@ export default function ProjectSettingsPage() {
             clearInterval(reindexPollRef.current!);
             reindexPollRef.current = null;
             setIsReindexing(false);
-            queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId) });
+            queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId, session.accessToken) });
           }
         } catch {
           clearInterval(reindexPollRef.current!);

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -12,6 +12,7 @@ function isHttpUrl(url: string): boolean {
 import { useState, useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter, useParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { ArrowLeft, UserPlus, Trash2, Tag, Check, GitPullRequest, AlertCircle, FileText, RefreshCw, History, Play, Inbox, CheckCircle, XCircle, Download, Copy, Eye, EyeOff, Database, ExternalLink } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github";
@@ -53,6 +54,10 @@ import {
   type JoinRequest as JoinRequestType,
 } from "@/lib/api/joinRequests";
 import { useRemoteSync } from "@/lib/hooks/useRemoteSync";
+import { useProject, projectQueryKeys } from "@/lib/hooks/useProject";
+import { useMembers, memberQueryKeys } from "@/lib/hooks/useMembers";
+import { useNormalizationStatus, normalizationQueryKeys } from "@/lib/hooks/useNormalizationStatus";
+import { useIndexStatus, indexQueryKeys } from "@/lib/hooks/useIndexStatus";
 import type {
   SyncFrequency,
   SyncUpdateMode,
@@ -89,13 +94,37 @@ export default function ProjectSettingsPage() {
   const params = useParams();
   const projectId = params.id as string;
 
+  const queryClient = useQueryClient();
+
+  // React Query hooks for initial data
+  const {
+    project: projectData,
+    isLoading: isProjectLoading,
+    error: projectError,
+  } = useProject(projectId, session?.accessToken);
+  const { data: membersData } = useMembers(projectId, session?.accessToken);
+
+  // Local state seeded from React Query (allows optimistic updates in mutation handlers)
   const [project, setProject] = useState<Project | null>(null);
   const [members, setMembers] = useState<ProjectMember[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+
+  // Sync local state from query data
+  useEffect(() => {
+    if (projectData) setProject(projectData);
+  }, [projectData]);
+  useEffect(() => {
+    if (membersData?.items) setMembers(membersData.items);
+  }, [membersData]);
+
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(projectError);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  // Sync project-level error from query
+  useEffect(() => {
+    if (projectError) setError(projectError);
+  }, [projectError]);
 
   // Add member form state
   const [showAddMember, setShowAddMember] = useState(false);
@@ -113,8 +142,18 @@ export default function ProjectSettingsPage() {
   const [isSavingPreferences, setIsSavingPreferences] = useState(false);
   const [preferencesSaved, setPreferencesSaved] = useState(false);
 
-  // Normalization state
+  // Normalization status via React Query
+  const {
+    data: normalizationQueryData,
+  } = useNormalizationStatus(projectId, session?.accessToken, {
+    enabled: !!project?.source_file_path,
+  });
+  // Local normalization state (for optimistic updates during dry run / normalization)
   const [normalizationStatus, setNormalizationStatus] = useState<NormalizationStatusResponse | null>(null);
+  useEffect(() => {
+    if (normalizationQueryData) setNormalizationStatus(normalizationQueryData);
+  }, [normalizationQueryData]);
+
   const [normalizationHistory, setNormalizationHistory] = useState<NormalizationRunResponse[]>([]);
   const [isCheckingNormalization, setIsCheckingNormalization] = useState(false);
   const [isRunningNormalization, setIsRunningNormalization] = useState(false);
@@ -130,8 +169,18 @@ export default function ProjectSettingsPage() {
   const [normalizationJobId, setNormalizationJobId] = useState<string | null>(null);
   const [normalizationJobStatus, setNormalizationJobStatus] = useState<string | null>(null);
 
-  // Ontology index state
+  // Ontology index status via React Query
+  const {
+    data: indexQueryData,
+  } = useIndexStatus(projectId, session?.accessToken, {
+    enabled: !!project?.source_file_path,
+  });
+  // Local index state (for optimistic updates during reindex)
   const [indexStatus, setIndexStatus] = useState<IndexStatusResponse | null>(null);
+  useEffect(() => {
+    if (indexQueryData) setIndexStatus(indexQueryData);
+  }, [indexQueryData]);
+
   const [isReindexing, setIsReindexing] = useState(false);
   const reindexPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -167,91 +216,52 @@ export default function ProjectSettingsPage() {
   const [githubOutputPath, setGithubOutputPath] = useState<string | null>(null);
 
   const isAuthenticated = status === "authenticated";
+  const isLoading = isProjectLoading || status === "loading";
 
+  // Sync label preferences from project data
   useEffect(() => {
-    const fetchData = async () => {
-      if (!session?.accessToken) return;
-
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const [projectData, membersData] = await Promise.all([
-          projectApi.get(projectId, session.accessToken),
-          projectApi.listMembers(projectId, session.accessToken),
-        ]);
-        setProject(projectData);
-        setMembers(membersData.items);
-        setLabelPreferences(projectData.label_preferences || []);
-
-        // Fetch normalization status if project has an ontology file
-        if (projectData.source_file_path) {
-          try {
-            const normStatus = await normalizationApi.getStatus(projectId, session.accessToken);
-            setNormalizationStatus(normStatus);
-          } catch {
-            // Normalization status may not be available, ignore
-          }
-
-          // Fetch ontology index status
-          try {
-            const idxStatus = await projectOntologyApi.getIndexStatus(projectId, session.accessToken);
-            setIndexStatus(idxStatus);
-          } catch {
-            // Index status endpoint may not be available, ignore
-          }
-        }
-
-        // Fetch PR settings and GitHub integration for owners/admins/superadmins
-        if (projectData.user_role === "owner" || projectData.user_role === "admin" || projectData.is_superadmin) {
-          try {
-            const prSettingsData = await prSettingsApi.get(projectId, session.accessToken);
-            setPrSettings(prSettingsData);
-            setGithubIntegration(prSettingsData.github_integration || null);
-            setPrApprovalRequired(prSettingsData.pr_approval_required);
-          } catch {
-            // PR settings may not be available, ignore
-          }
-
-          // Fetch join requests for public projects
-          if (projectData.is_public) {
-            try {
-              const jrData = await joinRequestApi.list(projectId, session.accessToken);
-              setJoinRequests(jrData.items);
-              setJoinRequestCount(jrData.total);
-            } catch {
-              // Join requests may not be available, ignore
-            }
-          }
-
-          // Check if user has a GitHub token (for the repo picker)
-          try {
-            const tokenStatus = await userSettingsApi.getGitHubTokenStatus(session.accessToken);
-            setHasGithubToken(tokenStatus.has_token);
-          } catch {
-            setHasGithubToken(false);
-          }
-        }
-      } catch (err) {
-        if (err instanceof Error && err.message.includes("403")) {
-          setError("You don't have permission to access project settings");
-        } else if (err instanceof Error && err.message.includes("404")) {
-          setError("Project not found");
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to load project");
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    if (status !== "loading" && projectId && isAuthenticated) {
-      fetchData();
-    } else if (status !== "loading" && !isAuthenticated) {
-      setError("You must be signed in to access project settings");
-      setIsLoading(false);
+    if (project) {
+      setLabelPreferences(project.label_preferences || []);
     }
-  }, [projectId, session?.accessToken, status, isAuthenticated]);
+  }, [project]);
+
+  // Fetch admin-only data (PR settings, join requests, GitHub token status) when project loads
+  useEffect(() => {
+    if (!project || !session?.accessToken) return;
+    const isAdmin = project.user_role === "owner" || project.user_role === "admin" || project.is_superadmin;
+    if (!isAdmin) return;
+
+    // PR settings + GitHub integration
+    prSettingsApi.get(projectId, session.accessToken)
+      .then((prSettingsData) => {
+        setPrSettings(prSettingsData);
+        setGithubIntegration(prSettingsData.github_integration || null);
+        setPrApprovalRequired(prSettingsData.pr_approval_required);
+      })
+      .catch(() => { /* PR settings may not be available */ });
+
+    // Join requests for public projects
+    if (project.is_public) {
+      joinRequestApi.list(projectId, session.accessToken)
+        .then((jrData) => {
+          setJoinRequests(jrData.items);
+          setJoinRequestCount(jrData.total);
+        })
+        .catch(() => { /* ignore */ });
+    }
+
+    // GitHub token status
+    userSettingsApi.getGitHubTokenStatus(session.accessToken)
+      .then((tokenStatus) => setHasGithubToken(tokenStatus.has_token))
+      .catch(() => setHasGithubToken(false));
+  }, [project, projectId, session?.accessToken]);
+
+  // Handle unauthenticated state
+  useEffect(() => {
+    if (status !== "loading" && !isAuthenticated) {
+      setError("You must be signed in to access project settings");
+    }
+  }, [status, isAuthenticated]);
 
   // Scroll to hash on page load (for #normalization link from editor)
   useEffect(() => {
@@ -287,6 +297,7 @@ export default function ProjectSettingsPage() {
     try {
       const updated = await projectApi.update(project.id, data as ProjectUpdate, session.accessToken);
       setProject(updated);
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
       setSuccessMessage("Project settings saved successfully");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
@@ -315,6 +326,8 @@ export default function ProjectSettingsPage() {
       );
       setMembers([...members, newMember]);
       setProject({ ...project, member_count: project.member_count + 1 });
+      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
       setShowAddMember(false);
       setNewMemberUserId("");
       setNewMemberRole("suggester");
@@ -340,6 +353,7 @@ export default function ProjectSettingsPage() {
         session.accessToken
       );
       setMembers(members.map((m) => (m.user_id === userId ? updated : m)));
+      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to update member role");
     }
@@ -352,6 +366,8 @@ export default function ProjectSettingsPage() {
       await projectApi.removeMember(project.id, userId, session.accessToken);
       setMembers(members.filter((m) => m.user_id !== userId));
       setProject({ ...project, member_count: project.member_count - 1 });
+      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
 
       // If user removed themselves, redirect to projects
       if (userId === session.user?.id) {
@@ -385,6 +401,8 @@ export default function ProjectSettingsPage() {
       // Refresh the project to get updated owner_id and user_role
       const updatedProject = await projectApi.get(project.id, session.accessToken);
       setProject(updatedProject);
+      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
       setSuccessMessage("Ownership transferred successfully");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
@@ -407,6 +425,8 @@ export default function ProjectSettingsPage() {
           const updatedProject = await projectApi.get(project.id, session.accessToken);
           setProject(updatedProject);
           setGithubIntegration(null);
+          queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
+          queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
           setSuccessMessage(
             "Ownership transferred. GitHub integration was disconnected because the new owner has no GitHub token."
           );
@@ -454,6 +474,7 @@ export default function ProjectSettingsPage() {
         session.accessToken
       );
       setProject(updated);
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
       setPreferencesSaved(true);
       setTimeout(() => setPreferencesSaved(false), 3000);
     } catch (err) {
@@ -582,10 +603,12 @@ export default function ProjectSettingsPage() {
       await joinRequestApi.approve(project.id, requestId, session.accessToken);
       setJoinRequests(joinRequests.filter((jr) => jr.id !== requestId));
       setJoinRequestCount(Math.max(0, joinRequestCount - 1));
-      // Refresh member list
-      const membersData = await projectApi.listMembers(project.id, session.accessToken);
-      setMembers(membersData.items);
-      setProject({ ...project, member_count: membersData.total });
+      // Refresh member list via React Query
+      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
+      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
+      const refreshedMembers = await projectApi.listMembers(project.id, session.accessToken);
+      setMembers(refreshedMembers.items);
+      setProject({ ...project, member_count: refreshedMembers.total });
       setSuccessMessage("Join request approved — user added as suggester");
       setTimeout(() => setSuccessMessage(null), 3000);
       window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));
@@ -645,6 +668,7 @@ export default function ProjectSettingsPage() {
             clearInterval(reindexPollRef.current!);
             reindexPollRef.current = null;
             setIsReindexing(false);
+            queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId) });
           }
         } catch {
           clearInterval(reindexPollRef.current!);
@@ -667,6 +691,7 @@ export default function ProjectSettingsPage() {
     try {
       const status = await normalizationApi.getStatus(project.id, session.accessToken);
       setNormalizationStatus(status);
+      queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId) });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to check normalization status");
     } finally {
@@ -748,6 +773,7 @@ export default function ProjectSettingsPage() {
               // Refresh status
               const newStatus = await normalizationApi.getStatus(project.id, session.accessToken);
               setNormalizationStatus(newStatus);
+              queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId) });
               setSuccessMessage("Normalization completed successfully");
               setTimeout(() => setSuccessMessage(null), 3000);
             } else if (jobStatus.status === "failed" || jobStatus.status === "not_found") {
@@ -784,7 +810,7 @@ export default function ProjectSettingsPage() {
     }
   };
 
-  if (isLoading || status === "loading") {
+  if (isLoading) {
     return (
       <>
         <Header />

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -12,7 +12,7 @@ function isHttpUrl(url: string): boolean {
 import { useState, useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter, useParams } from "next/navigation";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { ArrowLeft, UserPlus, Trash2, Tag, Check, GitPullRequest, AlertCircle, FileText, RefreshCw, History, Play, Inbox, CheckCircle, XCircle, Download, Copy, Eye, EyeOff, Database, ExternalLink } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github";
@@ -224,36 +224,49 @@ export default function ProjectSettingsPage() {
     }
   }, [project]);
 
-  // Fetch admin-only data (PR settings, join requests, GitHub token status) when project loads
-  // Use derived booleans as deps to avoid re-firing on every query refetch
+  // Admin-only data via React Query (replaces manual useEffect fetch)
   const isPublic = project?.is_public;
+
+  const prSettingsQuery = useQuery({
+    queryKey: ["prSettings", projectId, session?.accessToken],
+    queryFn: () => prSettingsApi.get(projectId, session!.accessToken!),
+    enabled: !!canManage && !!session?.accessToken,
+    retry: false,
+  });
   useEffect(() => {
-    if (!canManage || !session?.accessToken) return;
-
-    // PR settings + GitHub integration
-    prSettingsApi.get(projectId, session.accessToken)
-      .then((prSettingsData) => {
-        setPrSettings(prSettingsData);
-        setGithubIntegration(prSettingsData.github_integration || null);
-        setPrApprovalRequired(prSettingsData.pr_approval_required);
-      })
-      .catch(() => { /* PR settings may not be available */ });
-
-    // Join requests for public projects
-    if (isPublic) {
-      joinRequestApi.list(projectId, session.accessToken)
-        .then((jrData) => {
-          setJoinRequests(jrData.items);
-          setJoinRequestCount(jrData.total);
-        })
-        .catch(() => { /* ignore */ });
+    if (prSettingsQuery.data) {
+      setPrSettings(prSettingsQuery.data);
+      setGithubIntegration(prSettingsQuery.data.github_integration || null);
+      setPrApprovalRequired(prSettingsQuery.data.pr_approval_required);
     }
+  }, [prSettingsQuery.data]);
 
-    // GitHub token status
-    userSettingsApi.getGitHubTokenStatus(session.accessToken)
-      .then((tokenStatus) => setHasGithubToken(tokenStatus.has_token))
-      .catch(() => setHasGithubToken(false));
-  }, [canManage, isPublic, projectId, session?.accessToken]);
+  const joinRequestsQuery = useQuery({
+    queryKey: ["joinRequests", projectId, session?.accessToken],
+    queryFn: () => joinRequestApi.list(projectId, session!.accessToken!),
+    enabled: !!isPublic && !!canManage && !!session?.accessToken,
+    retry: false,
+  });
+  useEffect(() => {
+    if (joinRequestsQuery.data) {
+      setJoinRequests(joinRequestsQuery.data.items);
+      setJoinRequestCount(joinRequestsQuery.data.total);
+    }
+  }, [joinRequestsQuery.data]);
+
+  const githubTokenStatusQuery = useQuery({
+    queryKey: ["githubTokenStatus", session?.accessToken],
+    queryFn: () => userSettingsApi.getGitHubTokenStatus(session!.accessToken!),
+    enabled: !!canManage && !!session?.accessToken,
+    retry: false,
+  });
+  useEffect(() => {
+    if (githubTokenStatusQuery.data) {
+      setHasGithubToken(githubTokenStatusQuery.data.has_token);
+    } else if (githubTokenStatusQuery.isError) {
+      setHasGithubToken(false);
+    }
+  }, [githubTokenStatusQuery.data, githubTokenStatusQuery.isError]);
 
   // Handle unauthenticated state
   useEffect(() => {

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -595,8 +595,8 @@ export default function ProjectSettingsPage() {
     setProcessingJoinRequest(requestId);
     try {
       await joinRequestApi.approve(project.id, requestId, session.accessToken);
-      setJoinRequests(joinRequests.filter((jr) => jr.id !== requestId));
-      setJoinRequestCount(Math.max(0, joinRequestCount - 1));
+      setJoinRequests(prev => prev.filter((jr) => jr.id !== requestId));
+      setJoinRequestCount(prev => Math.max(0, prev - 1));
       // Refresh member list + project via React Query (refetches in background)
       queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
       queryClient.invalidateQueries({ queryKey: projectKey });
@@ -616,8 +616,8 @@ export default function ProjectSettingsPage() {
     setProcessingJoinRequest(requestId);
     try {
       await joinRequestApi.decline(project.id, requestId, session.accessToken);
-      setJoinRequests(joinRequests.filter((jr) => jr.id !== requestId));
-      setJoinRequestCount(Math.max(0, joinRequestCount - 1));
+      setJoinRequests(prev => prev.filter((jr) => jr.id !== requestId));
+      setJoinRequestCount(prev => Math.max(0, prev - 1));
       setSuccessMessage("Join request declined");
       setTimeout(() => setSuccessMessage(null), 3000);
       window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -137,7 +137,7 @@ export default function ProjectSettingsPage() {
   const {
     data: normalizationQueryData,
   } = useNormalizationStatus(projectId, session?.accessToken, {
-    enabled: !!project?.source_file_path,
+    enabled: !!project?.source_file_path && !!session?.accessToken,
   });
   // Local normalization state (for optimistic updates during dry run / normalization)
   const [normalizationStatus, setNormalizationStatus] = useState<NormalizationStatusResponse | null>(null);
@@ -164,7 +164,7 @@ export default function ProjectSettingsPage() {
   const {
     data: indexQueryData,
   } = useIndexStatus(projectId, session?.accessToken, {
-    enabled: !!project?.source_file_path,
+    enabled: !!project?.source_file_path && !!session?.accessToken,
   });
   // Local index state (for optimistic updates during reindex)
   const [indexStatus, setIndexStatus] = useState<IndexStatusResponse | null>(null);

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -682,7 +682,7 @@ export default function ProjectSettingsPage() {
     try {
       const status = await normalizationApi.getStatus(project.id, session.accessToken);
       setNormalizationStatus(status);
-      queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId) });
+      queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId, session.accessToken) });
     } catch (err) {
       setLocalError(err instanceof Error ? err.message : "Failed to check normalization status");
     } finally {
@@ -764,7 +764,7 @@ export default function ProjectSettingsPage() {
               // Refresh status
               const newStatus = await normalizationApi.getStatus(project.id, session.accessToken);
               setNormalizationStatus(newStatus);
-              queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId) });
+              queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId, session.accessToken) });
               setSuccessMessage("Normalization completed successfully");
               setTimeout(() => setSuccessMessage(null), 3000);
             } else if (jobStatus.status === "failed" || jobStatus.status === "not_found") {

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -97,6 +97,12 @@ export default function ProjectSettingsPage() {
 
   const queryClient = useQueryClient();
 
+  // Keep a ref to the latest accessToken so polling closures never go stale
+  const accessTokenRef = useRef(session?.accessToken);
+  useEffect(() => {
+    accessTokenRef.current = session?.accessToken;
+  }, [session?.accessToken]);
+
   // React Query hooks for data (single source of truth — no local mirrors)
   const {
     project,
@@ -228,7 +234,7 @@ export default function ProjectSettingsPage() {
   const isPublic = project?.is_public;
 
   const prSettingsQuery = useQuery({
-    queryKey: ["prSettings", projectId, session?.accessToken],
+    queryKey: ["prSettings", projectId],
     queryFn: () => prSettingsApi.get(projectId, session!.accessToken!),
     enabled: !!canManage && !!session?.accessToken,
     retry: false,
@@ -242,7 +248,7 @@ export default function ProjectSettingsPage() {
   }, [prSettingsQuery.data]);
 
   const joinRequestsQuery = useQuery({
-    queryKey: ["joinRequests", projectId, session?.accessToken],
+    queryKey: ["joinRequests", projectId],
     queryFn: () => joinRequestApi.list(projectId, session!.accessToken!),
     enabled: !!isPublic && !!canManage && !!session?.accessToken,
     retry: false,
@@ -255,7 +261,7 @@ export default function ProjectSettingsPage() {
   }, [joinRequestsQuery.data]);
 
   const githubTokenStatusQuery = useQuery({
-    queryKey: ["githubTokenStatus", session?.accessToken],
+    queryKey: ["githubTokenStatus"],
     queryFn: () => userSettingsApi.getGitHubTokenStatus(session!.accessToken!),
     enabled: !!canManage && !!session?.accessToken,
     retry: false,
@@ -664,19 +670,20 @@ export default function ProjectSettingsPage() {
         clearInterval(reindexPollRef.current);
       }
 
-      // Poll for completion
+      // Poll for completion (read token from ref to avoid stale closure)
       reindexPollRef.current = setInterval(async () => {
         try {
+          const token = accessTokenRef.current;
           const status = await projectOntologyApi.getIndexStatus(
             project.id,
-            session.accessToken
+            token
           );
           setIndexStatus(status);
           if (status.status === "ready" || status.status === "failed") {
             clearInterval(reindexPollRef.current!);
             reindexPollRef.current = null;
             setIsReindexing(false);
-            queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId, session.accessToken) });
+            queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId, token) });
           }
         } catch {
           clearInterval(reindexPollRef.current!);
@@ -761,13 +768,14 @@ export default function ProjectSettingsPage() {
         setNormalizationJobStatus("queued");
         setSuccessMessage("Normalization job queued - processing in background...");
 
-        // Poll for completion (ref-based so useEffect cleanup can cancel)
+        // Poll for completion (ref-based so useEffect cleanup can cancel, token from ref to avoid stale closure)
         normalizationPollRef.current = setInterval(async () => {
           try {
+            const token = accessTokenRef.current;
             const jobStatus = await normalizationApi.getJobStatus(
               project.id,
               queueResult.job_id,
-              session.accessToken
+              token
             );
 
             setNormalizationJobStatus(jobStatus.status);
@@ -780,9 +788,9 @@ export default function ProjectSettingsPage() {
               setIsRunningNormalization(false);
 
               // Refresh status
-              const newStatus = await normalizationApi.getStatus(project.id, session.accessToken);
+              const newStatus = await normalizationApi.getStatus(project.id, token);
               setNormalizationStatus(newStatus);
-              queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId, session.accessToken) });
+              queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId, token) });
               setSuccessMessage("Normalization completed successfully");
               setTimeout(() => setSuccessMessage(null), 3000);
             } else if (jobStatus.status === "failed" || jobStatus.status === "not_found") {
@@ -2049,6 +2057,7 @@ function WebhookConfigPanel({
   onIntegrationUpdate: (integration: GitHubIntegration) => void;
 }) {
   const [isToggling, setIsToggling] = useState(false);
+  const webhookSetupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [webhookSecret, setWebhookSecret] = useState<string | null>(null);
   const [webhookUrl, setWebhookUrl] = useState<string | null>(null);
   const [showSecret, setShowSecret] = useState(false);
@@ -2067,6 +2076,15 @@ function WebhookConfigPanel({
       setWebhookStatus("unknown");
     }
   }, [githubIntegration.webhooks_enabled, githubIntegration.github_hook_id]);
+
+  // Clean up webhook setup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (webhookSetupTimerRef.current) {
+        clearTimeout(webhookSetupTimerRef.current);
+      }
+    };
+  }, []);
 
   const runWebhookSetup = async () => {
     if (!accessToken) return;
@@ -2108,8 +2126,8 @@ function WebhookConfigPanel({
       } else {
         // When enabling, attempt auto-setup
         setIsToggling(false);
-        // Small delay to let state settle
-        setTimeout(async () => {
+        // Small delay to let state settle (stored in ref for unmount cleanup)
+        webhookSetupTimerRef.current = setTimeout(async () => {
           try {
             const result = await githubIntegrationApi.setupWebhook(projectId, accessToken);
             setWebhookStatus(result.status as WebhookStatus);
@@ -2971,6 +2989,10 @@ function EmbeddingSettingsSection({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const accessTokenRef = useRef(accessToken);
+  useEffect(() => {
+    accessTokenRef.current = accessToken;
+  }, [accessToken]);
 
   // Clean up polling on unmount
   useEffect(() => {
@@ -3014,7 +3036,7 @@ function EmbeddingSettingsSection({
             if (pollTimerRef.current) clearInterval(pollTimerRef.current);
             pollTimerRef.current = setInterval(async () => {
               try {
-                const updated = await embeddingsApi.getStatus(projectId, accessToken!);
+                const updated = await embeddingsApi.getStatus(projectId, accessTokenRef.current!);
                 setStatus(updated);
                 if (!updated.job_in_progress) {
                   if (pollTimerRef.current) {
@@ -3088,7 +3110,7 @@ function EmbeddingSettingsSection({
       if (pollTimerRef.current) clearInterval(pollTimerRef.current);
       pollTimerRef.current = setInterval(async () => {
         try {
-          const updated = await embeddingsApi.getStatus(projectId, accessToken);
+          const updated = await embeddingsApi.getStatus(projectId, accessTokenRef.current!);
           setStatus(updated);
           if (!updated.job_in_progress) {
             if (pollTimerRef.current) {

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -620,9 +620,10 @@ export default function ProjectSettingsPage() {
       await joinRequestApi.approve(project.id, requestId, session.accessToken);
       setJoinRequests(prev => prev.filter((jr) => jr.id !== requestId));
       setJoinRequestCount(prev => Math.max(0, prev - 1));
-      // Refresh member list + project via React Query (refetches in background)
+      // Refresh member list, project, and join requests via React Query
       queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
       queryClient.invalidateQueries({ queryKey: projectKey });
+      queryClient.invalidateQueries({ queryKey: ["joinRequests", projectId] });
       setSuccessMessage("Join request approved — user added as suggester");
       setTimeout(() => setSuccessMessage(null), 3000);
       window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));
@@ -641,6 +642,7 @@ export default function ProjectSettingsPage() {
       await joinRequestApi.decline(project.id, requestId, session.accessToken);
       setJoinRequests(prev => prev.filter((jr) => jr.id !== requestId));
       setJoinRequestCount(prev => Math.max(0, prev - 1));
+      queryClient.invalidateQueries({ queryKey: ["joinRequests", projectId] });
       setSuccessMessage("Join request declined");
       setTimeout(() => setSuccessMessage(null), 3000);
       window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));
@@ -2119,6 +2121,11 @@ function WebhookConfigPanel({
       onIntegrationUpdate(updated);
       // Clear state when disabling
       if (!updated.webhooks_enabled) {
+        // Cancel any pending auto-setup from a prior enable
+        if (webhookSetupTimerRef.current) {
+          clearTimeout(webhookSetupTimerRef.current);
+          webhookSetupTimerRef.current = null;
+        }
         setWebhookSecret(null);
         setWebhookUrl(null);
         setWebhookStatus("unknown");

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -159,6 +159,7 @@ export default function ProjectSettingsPage() {
   // Background job state
   const [normalizationJobId, setNormalizationJobId] = useState<string | null>(null);
   const [normalizationJobStatus, setNormalizationJobStatus] = useState<string | null>(null);
+  const normalizationPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Ontology index status via React Query
   const {
@@ -175,11 +176,14 @@ export default function ProjectSettingsPage() {
   const [isReindexing, setIsReindexing] = useState(false);
   const reindexPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Clean up reindex polling on unmount
+  // Clean up polling on unmount
   useEffect(() => {
     return () => {
       if (reindexPollRef.current) {
         clearInterval(reindexPollRef.current);
+      }
+      if (normalizationPollRef.current) {
+        clearInterval(normalizationPollRef.current);
       }
     };
   }, []);
@@ -744,8 +748,8 @@ export default function ProjectSettingsPage() {
         setNormalizationJobStatus("queued");
         setSuccessMessage("Normalization job queued - processing in background...");
 
-        // Poll for completion
-        const pollInterval = setInterval(async () => {
+        // Poll for completion (ref-based so useEffect cleanup can cancel)
+        normalizationPollRef.current = setInterval(async () => {
           try {
             const jobStatus = await normalizationApi.getJobStatus(
               project.id,
@@ -756,7 +760,8 @@ export default function ProjectSettingsPage() {
             setNormalizationJobStatus(jobStatus.status);
 
             if (jobStatus.status === "complete") {
-              clearInterval(pollInterval);
+              clearInterval(normalizationPollRef.current!);
+              normalizationPollRef.current = null;
               setNormalizationJobId(null);
               setNormalizationJobStatus(null);
               setIsRunningNormalization(false);
@@ -768,7 +773,8 @@ export default function ProjectSettingsPage() {
               setSuccessMessage("Normalization completed successfully");
               setTimeout(() => setSuccessMessage(null), 3000);
             } else if (jobStatus.status === "failed" || jobStatus.status === "not_found") {
-              clearInterval(pollInterval);
+              clearInterval(normalizationPollRef.current!);
+              normalizationPollRef.current = null;
               setNormalizationJobId(null);
               setNormalizationJobStatus(null);
               setIsRunningNormalization(false);
@@ -779,9 +785,6 @@ export default function ProjectSettingsPage() {
             console.error("Error polling job status:", pollErr);
           }
         }, 2000); // Poll every 2 seconds
-
-        // Cleanup on unmount
-        return () => clearInterval(pollInterval);
       }
     } catch (err) {
       setLocalError(err instanceof Error ? err.message : "Failed to run normalization");

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -30,6 +30,7 @@ import {
   type ProjectUpdate,
   type MemberCreate,
   type MemberUpdate,
+  type MemberListResponse,
   type TransferOwnership,
 } from "@/lib/api/projects";
 import { TurtleOutputPicker } from "@/components/projects/turtle-output-picker";
@@ -96,35 +97,25 @@ export default function ProjectSettingsPage() {
 
   const queryClient = useQueryClient();
 
-  // React Query hooks for initial data
+  // React Query hooks for data (single source of truth — no local mirrors)
   const {
-    project: projectData,
+    project,
     isLoading: isProjectLoading,
     error: projectError,
   } = useProject(projectId, session?.accessToken);
   const { data: membersData } = useMembers(projectId, session?.accessToken);
+  const members = membersData?.items ?? [];
 
-  // Local state seeded from React Query (allows optimistic updates in mutation handlers)
-  const [project, setProject] = useState<Project | null>(null);
-  const [members, setMembers] = useState<ProjectMember[]>([]);
-
-  // Sync local state from query data
-  useEffect(() => {
-    if (projectData) setProject(projectData);
-  }, [projectData]);
-  useEffect(() => {
-    if (membersData?.items) setMembers(membersData.items);
-  }, [membersData]);
+  // Stable query key for optimistic updates via setQueryData
+  const projectKey = projectQueryKeys.detail(projectId, !!session?.accessToken);
 
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [error, setError] = useState<string | null>(projectError);
+  const [localError, setLocalError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  // Sync project-level error from query
-  useEffect(() => {
-    if (projectError) setError(projectError);
-  }, [projectError]);
+  // Derive displayed error: local mutation errors take priority, then query errors
+  const error = localError || projectError || null;
 
   // Add member form state
   const [showAddMember, setShowAddMember] = useState(false);
@@ -218,6 +209,10 @@ export default function ProjectSettingsPage() {
   const isAuthenticated = status === "authenticated";
   const isLoading = isProjectLoading || status === "loading";
 
+  const canManage =
+    project?.user_role === "owner" || project?.user_role === "admin" || project?.is_superadmin;
+  const isOwner = project?.user_role === "owner";
+
   // Sync label preferences from project data
   useEffect(() => {
     if (project) {
@@ -226,10 +221,10 @@ export default function ProjectSettingsPage() {
   }, [project]);
 
   // Fetch admin-only data (PR settings, join requests, GitHub token status) when project loads
+  // Use derived booleans as deps to avoid re-firing on every query refetch
+  const isPublic = project?.is_public;
   useEffect(() => {
-    if (!project || !session?.accessToken) return;
-    const isAdmin = project.user_role === "owner" || project.user_role === "admin" || project.is_superadmin;
-    if (!isAdmin) return;
+    if (!canManage || !session?.accessToken) return;
 
     // PR settings + GitHub integration
     prSettingsApi.get(projectId, session.accessToken)
@@ -241,7 +236,7 @@ export default function ProjectSettingsPage() {
       .catch(() => { /* PR settings may not be available */ });
 
     // Join requests for public projects
-    if (project.is_public) {
+    if (isPublic) {
       joinRequestApi.list(projectId, session.accessToken)
         .then((jrData) => {
           setJoinRequests(jrData.items);
@@ -254,12 +249,12 @@ export default function ProjectSettingsPage() {
     userSettingsApi.getGitHubTokenStatus(session.accessToken)
       .then((tokenStatus) => setHasGithubToken(tokenStatus.has_token))
       .catch(() => setHasGithubToken(false));
-  }, [project, projectId, session?.accessToken]);
+  }, [canManage, isPublic, projectId, session?.accessToken]);
 
   // Handle unauthenticated state
   useEffect(() => {
     if (status !== "loading" && !isAuthenticated) {
-      setError("You must be signed in to access project settings");
+      setLocalError("You must be signed in to access project settings");
     }
   }, [status, isAuthenticated]);
 
@@ -276,10 +271,6 @@ export default function ProjectSettingsPage() {
     }
   }, [isLoading]);
 
-  const canManage =
-    project?.user_role === "owner" || project?.user_role === "admin" || project?.is_superadmin;
-  const isOwner = project?.user_role === "owner";
-
   // Remote sync hook
   const remoteSync = useRemoteSync({
     projectId,
@@ -291,13 +282,12 @@ export default function ProjectSettingsPage() {
     if (!session?.accessToken || !project) return;
 
     setIsSaving(true);
-    setError(null);
+    setLocalError(null);
     setSuccessMessage(null);
 
     try {
       const updated = await projectApi.update(project.id, data as ProjectUpdate, session.accessToken);
-      setProject(updated);
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
+      queryClient.setQueryData<Project>(projectKey, updated);
       setSuccessMessage("Project settings saved successfully");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
@@ -324,10 +314,12 @@ export default function ProjectSettingsPage() {
         memberData,
         session.accessToken
       );
-      setMembers([...members, newMember]);
-      setProject({ ...project, member_count: project.member_count + 1 });
-      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
+      queryClient.setQueryData<MemberListResponse>(memberQueryKeys.list(projectId), (old) =>
+        old ? { ...old, items: [...old.items, newMember], total: old.total + 1 } : { items: [newMember], total: 1 }
+      );
+      queryClient.setQueryData<Project>(projectKey, (old) =>
+        old ? { ...old, member_count: old.member_count + 1 } : undefined
+      );
       setShowAddMember(false);
       setNewMemberUserId("");
       setNewMemberRole("suggester");
@@ -352,10 +344,11 @@ export default function ProjectSettingsPage() {
         data,
         session.accessToken
       );
-      setMembers(members.map((m) => (m.user_id === userId ? updated : m)));
-      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
+      queryClient.setQueryData<MemberListResponse>(memberQueryKeys.list(projectId), (old) =>
+        old ? { ...old, items: old.items.map((m: ProjectMember) => m.user_id === userId ? updated : m) } : undefined
+      );
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update member role");
+      setLocalError(err instanceof Error ? err.message : "Failed to update member role");
     }
   };
 
@@ -364,17 +357,19 @@ export default function ProjectSettingsPage() {
 
     try {
       await projectApi.removeMember(project.id, userId, session.accessToken);
-      setMembers(members.filter((m) => m.user_id !== userId));
-      setProject({ ...project, member_count: project.member_count - 1 });
-      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
+      queryClient.setQueryData<MemberListResponse>(memberQueryKeys.list(projectId), (old) =>
+        old ? { ...old, items: old.items.filter((m: ProjectMember) => m.user_id !== userId), total: old.total - 1 } : undefined
+      );
+      queryClient.setQueryData<Project>(projectKey, (old) =>
+        old ? { ...old, member_count: old.member_count - 1 } : undefined
+      );
 
       // If user removed themselves, redirect to projects
       if (userId === session.user?.id) {
         router.push("/");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to remove member");
+      setLocalError(err instanceof Error ? err.message : "Failed to remove member");
     }
   };
 
@@ -397,12 +392,12 @@ export default function ProjectSettingsPage() {
         { new_owner_id: userId } as TransferOwnership,
         session.accessToken
       );
-      setMembers(result.items);
+      queryClient.setQueryData<MemberListResponse>(memberQueryKeys.list(projectId), (old) =>
+        old ? { ...old, items: result.items } : { items: result.items, total: result.items.length }
+      );
       // Refresh the project to get updated owner_id and user_role
       const updatedProject = await projectApi.get(project.id, session.accessToken);
-      setProject(updatedProject);
-      queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
+      queryClient.setQueryData<Project>(projectKey, updatedProject);
       setSuccessMessage("Ownership transferred successfully");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
@@ -421,25 +416,25 @@ export default function ProjectSettingsPage() {
             session.accessToken,
             true
           );
-          setMembers(result.items);
+          queryClient.setQueryData<MemberListResponse>(memberQueryKeys.list(projectId), (old) =>
+            old ? { ...old, items: result.items } : { items: result.items, total: result.items.length }
+          );
           const updatedProject = await projectApi.get(project.id, session.accessToken);
-          setProject(updatedProject);
+          queryClient.setQueryData<Project>(projectKey, updatedProject);
           setGithubIntegration(null);
-          queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
-          queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
           setSuccessMessage(
             "Ownership transferred. GitHub integration was disconnected because the new owner has no GitHub token."
           );
           setTimeout(() => setSuccessMessage(null), 5000);
         } catch (retryErr) {
-          setError(
+          setLocalError(
             retryErr instanceof Error ? retryErr.message : "Failed to transfer ownership"
           );
         }
         return;
       }
 
-      setError(
+      setLocalError(
         err instanceof Error ? err.message : "Failed to transfer ownership"
       );
     }
@@ -455,7 +450,7 @@ export default function ProjectSettingsPage() {
       await projectApi.delete(project.id, session.accessToken);
       router.push("/");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete project");
+      setLocalError(err instanceof Error ? err.message : "Failed to delete project");
       setIsDeleting(false);
     }
   };
@@ -465,7 +460,7 @@ export default function ProjectSettingsPage() {
 
     setIsSavingPreferences(true);
     setPreferencesSaved(false);
-    setError(null);
+    setLocalError(null);
 
     try {
       const updated = await projectApi.update(
@@ -473,12 +468,11 @@ export default function ProjectSettingsPage() {
         { label_preferences: labelPreferences },
         session.accessToken
       );
-      setProject(updated);
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
+      queryClient.setQueryData<Project>(projectKey, updated);
       setPreferencesSaved(true);
       setTimeout(() => setPreferencesSaved(false), 3000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save label preferences");
+      setLocalError(err instanceof Error ? err.message : "Failed to save label preferences");
     } finally {
       setIsSavingPreferences(false);
     }
@@ -488,7 +482,7 @@ export default function ProjectSettingsPage() {
     if (!session?.accessToken || !project || !selectedRepo) return;
 
     setIsSetupGitHub(true);
-    setError(null);
+    setLocalError(null);
 
     try {
       const integration = await githubIntegrationApi.create(
@@ -511,7 +505,7 @@ export default function ProjectSettingsPage() {
       setSuccessMessage("GitHub repository connected successfully");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to connect repository");
+      setLocalError(err instanceof Error ? err.message : "Failed to connect repository");
     } finally {
       setIsSetupGitHub(false);
     }
@@ -569,7 +563,7 @@ export default function ProjectSettingsPage() {
       setSuccessMessage("GitHub integration removed");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to remove GitHub integration");
+      setLocalError(err instanceof Error ? err.message : "Failed to remove GitHub integration");
     }
   };
 
@@ -577,7 +571,7 @@ export default function ProjectSettingsPage() {
     if (!session?.accessToken || !project) return;
 
     setIsSavingPrSettings(true);
-    setError(null);
+    setLocalError(null);
 
     try {
       const updated = await prSettingsApi.update(
@@ -589,7 +583,7 @@ export default function ProjectSettingsPage() {
       setSuccessMessage("PR settings saved");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save PR settings");
+      setLocalError(err instanceof Error ? err.message : "Failed to save PR settings");
     } finally {
       setIsSavingPrSettings(false);
     }
@@ -603,17 +597,14 @@ export default function ProjectSettingsPage() {
       await joinRequestApi.approve(project.id, requestId, session.accessToken);
       setJoinRequests(joinRequests.filter((jr) => jr.id !== requestId));
       setJoinRequestCount(Math.max(0, joinRequestCount - 1));
-      // Refresh member list via React Query
+      // Refresh member list + project via React Query (refetches in background)
       queryClient.invalidateQueries({ queryKey: memberQueryKeys.list(projectId) });
-      queryClient.invalidateQueries({ queryKey: projectQueryKeys.detail(projectId, true) });
-      const refreshedMembers = await projectApi.listMembers(project.id, session.accessToken);
-      setMembers(refreshedMembers.items);
-      setProject({ ...project, member_count: refreshedMembers.total });
+      queryClient.invalidateQueries({ queryKey: projectKey });
       setSuccessMessage("Join request approved — user added as suggester");
       setTimeout(() => setSuccessMessage(null), 3000);
       window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to approve request");
+      setLocalError(err instanceof Error ? err.message : "Failed to approve request");
     } finally {
       setProcessingJoinRequest(null);
     }
@@ -631,7 +622,7 @@ export default function ProjectSettingsPage() {
       setTimeout(() => setSuccessMessage(null), 3000);
       window.dispatchEvent(new Event(NOTIFICATIONS_CHANGED_EVENT));
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to decline request");
+      setLocalError(err instanceof Error ? err.message : "Failed to decline request");
     } finally {
       setProcessingJoinRequest(null);
     }
@@ -641,7 +632,7 @@ export default function ProjectSettingsPage() {
     if (!session?.accessToken || !project) return;
 
     setIsReindexing(true);
-    setError(null);
+    setLocalError(null);
 
     try {
       await projectOntologyApi.reindex(project.id, session.accessToken);
@@ -677,7 +668,7 @@ export default function ProjectSettingsPage() {
         }
       }, 3000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to trigger reindex");
+      setLocalError(err instanceof Error ? err.message : "Failed to trigger reindex");
       setIsReindexing(false);
     }
   };
@@ -686,14 +677,14 @@ export default function ProjectSettingsPage() {
     if (!session?.accessToken || !project) return;
 
     setIsCheckingNormalization(true);
-    setError(null);
+    setLocalError(null);
 
     try {
       const status = await normalizationApi.getStatus(project.id, session.accessToken);
       setNormalizationStatus(status);
       queryClient.invalidateQueries({ queryKey: normalizationQueryKeys.status(projectId) });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to check normalization status");
+      setLocalError(err instanceof Error ? err.message : "Failed to check normalization status");
     } finally {
       setIsCheckingNormalization(false);
     }
@@ -703,7 +694,7 @@ export default function ProjectSettingsPage() {
     if (!session?.accessToken || !project) return;
 
     setIsRunningNormalization(true);
-    setError(null);
+    setLocalError(null);
 
     try {
       if (dryRun) {
@@ -781,7 +772,7 @@ export default function ProjectSettingsPage() {
               setNormalizationJobId(null);
               setNormalizationJobStatus(null);
               setIsRunningNormalization(false);
-              setError(jobStatus.error || "Normalization job failed");
+              setLocalError(jobStatus.error || "Normalization job failed");
             }
           } catch (pollErr) {
             // Continue polling on error
@@ -793,7 +784,7 @@ export default function ProjectSettingsPage() {
         return () => clearInterval(pollInterval);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to run normalization");
+      setLocalError(err instanceof Error ? err.message : "Failed to run normalization");
       setIsRunningNormalization(false);
     }
   };
@@ -806,7 +797,7 @@ export default function ProjectSettingsPage() {
       setNormalizationHistory(history.items);
       setShowNormalizationHistory(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load normalization history");
+      setLocalError(err instanceof Error ? err.message : "Failed to load normalization history");
     }
   };
 

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -261,7 +261,7 @@ export default function ProjectSettingsPage() {
   }, [joinRequestsQuery.data]);
 
   const githubTokenStatusQuery = useQuery({
-    queryKey: ["githubTokenStatus"],
+    queryKey: ["githubTokenStatus", session?.user?.id],
     queryFn: () => userSettingsApi.getGitHubTokenStatus(session!.accessToken!),
     enabled: !!canManage && !!session?.accessToken,
     retry: false,

--- a/lib/hooks/useIndexStatus.ts
+++ b/lib/hooks/useIndexStatus.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { projectOntologyApi } from "@/lib/api/client";
+
+export const indexQueryKeys = {
+  status: (projectId: string) => ["index", "status", projectId] as const,
+};
+
+export function useIndexStatus(
+  projectId: string,
+  accessToken?: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: indexQueryKeys.status(projectId),
+    queryFn: () => projectOntologyApi.getIndexStatus(projectId, accessToken),
+    enabled: (options?.enabled ?? true) && !!projectId,
+  });
+}

--- a/lib/hooks/useIndexStatus.ts
+++ b/lib/hooks/useIndexStatus.ts
@@ -2,7 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { projectOntologyApi } from "@/lib/api/client";
 
 export const indexQueryKeys = {
-  status: (projectId: string) => ["index", "status", projectId] as const,
+  status: (projectId: string, accessToken?: string) =>
+    ["index", "status", projectId, accessToken] as const,
 };
 
 export function useIndexStatus(
@@ -11,8 +12,8 @@ export function useIndexStatus(
   options?: { enabled?: boolean },
 ) {
   return useQuery({
-    queryKey: indexQueryKeys.status(projectId),
+    queryKey: indexQueryKeys.status(projectId, accessToken),
     queryFn: () => projectOntologyApi.getIndexStatus(projectId, accessToken),
-    enabled: (options?.enabled ?? true) && !!projectId,
+    enabled: (options?.enabled ?? true) && !!projectId && !!accessToken,
   });
 }

--- a/lib/hooks/useLintSummary.ts
+++ b/lib/hooks/useLintSummary.ts
@@ -9,6 +9,6 @@ export function useLintSummary(projectId: string, accessToken?: string) {
   return useQuery({
     queryKey: lintQueryKeys.summary(projectId),
     queryFn: () => lintApi.getStatus(projectId, accessToken),
-    enabled: !!projectId,
+    enabled: !!projectId && !!accessToken,
   });
 }

--- a/lib/hooks/useLintSummary.ts
+++ b/lib/hooks/useLintSummary.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { lintApi } from "@/lib/api/lint";
+
+export const lintQueryKeys = {
+  summary: (projectId: string) => ["lint", "summary", projectId] as const,
+};
+
+export function useLintSummary(projectId: string, accessToken?: string) {
+  return useQuery({
+    queryKey: lintQueryKeys.summary(projectId),
+    queryFn: () => lintApi.getStatus(projectId, accessToken),
+    enabled: !!projectId,
+  });
+}

--- a/lib/hooks/useMembers.ts
+++ b/lib/hooks/useMembers.ts
@@ -1,11 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  projectApi,
-  type ProjectMember,
-  type MemberCreate,
-  type MemberUpdate,
-  type MemberListResponse,
-} from "@/lib/api/projects";
+import { useQuery } from "@tanstack/react-query";
+import { projectApi } from "@/lib/api/projects";
 
 export const memberQueryKeys = {
   list: (projectId: string) => ["members", projectId] as const,
@@ -16,66 +10,5 @@ export function useMembers(projectId: string, accessToken?: string) {
     queryKey: memberQueryKeys.list(projectId),
     queryFn: () => projectApi.listMembers(projectId, accessToken!),
     enabled: !!projectId && !!accessToken,
-  });
-}
-
-export function useAddMember(projectId: string, accessToken?: string) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (data: MemberCreate) => projectApi.addMember(projectId, data, accessToken!),
-    onSuccess: (newMember) => {
-      queryClient.setQueryData<MemberListResponse>(
-        memberQueryKeys.list(projectId),
-        (old) =>
-          old
-            ? { ...old, items: [...old.items, newMember], total: old.total + 1 }
-            : { items: [newMember], total: 1 },
-      );
-    },
-  });
-}
-
-export function useUpdateMemberRole(projectId: string, accessToken?: string) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: ({ userId, data }: { userId: string; data: MemberUpdate }) =>
-      projectApi.updateMember(projectId, userId, data, accessToken!),
-    onSuccess: (updated) => {
-      queryClient.setQueryData<MemberListResponse>(
-        memberQueryKeys.list(projectId),
-        (old) =>
-          old
-            ? {
-                ...old,
-                items: old.items.map((m: ProjectMember) =>
-                  m.user_id === updated.user_id ? updated : m,
-                ),
-              }
-            : undefined,
-      );
-    },
-  });
-}
-
-export function useRemoveMember(projectId: string, accessToken?: string) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (userId: string) => projectApi.removeMember(projectId, userId, accessToken!),
-    onSuccess: (_, userId) => {
-      queryClient.setQueryData<MemberListResponse>(
-        memberQueryKeys.list(projectId),
-        (old) =>
-          old
-            ? {
-                ...old,
-                items: old.items.filter((m: ProjectMember) => m.user_id !== userId),
-                total: old.total - 1,
-              }
-            : undefined,
-      );
-    },
   });
 }

--- a/lib/hooks/useMembers.ts
+++ b/lib/hooks/useMembers.ts
@@ -1,0 +1,81 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  projectApi,
+  type ProjectMember,
+  type MemberCreate,
+  type MemberUpdate,
+  type MemberListResponse,
+} from "@/lib/api/projects";
+
+export const memberQueryKeys = {
+  list: (projectId: string) => ["members", projectId] as const,
+};
+
+export function useMembers(projectId: string, accessToken?: string) {
+  return useQuery({
+    queryKey: memberQueryKeys.list(projectId),
+    queryFn: () => projectApi.listMembers(projectId, accessToken!),
+    enabled: !!projectId && !!accessToken,
+  });
+}
+
+export function useAddMember(projectId: string, accessToken?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: MemberCreate) => projectApi.addMember(projectId, data, accessToken!),
+    onSuccess: (newMember) => {
+      queryClient.setQueryData<MemberListResponse>(
+        memberQueryKeys.list(projectId),
+        (old) =>
+          old
+            ? { ...old, items: [...old.items, newMember], total: old.total + 1 }
+            : { items: [newMember], total: 1 },
+      );
+    },
+  });
+}
+
+export function useUpdateMemberRole(projectId: string, accessToken?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ userId, data }: { userId: string; data: MemberUpdate }) =>
+      projectApi.updateMember(projectId, userId, data, accessToken!),
+    onSuccess: (updated) => {
+      queryClient.setQueryData<MemberListResponse>(
+        memberQueryKeys.list(projectId),
+        (old) =>
+          old
+            ? {
+                ...old,
+                items: old.items.map((m: ProjectMember) =>
+                  m.user_id === updated.user_id ? updated : m,
+                ),
+              }
+            : undefined,
+      );
+    },
+  });
+}
+
+export function useRemoveMember(projectId: string, accessToken?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: string) => projectApi.removeMember(projectId, userId, accessToken!),
+    onSuccess: (_, userId) => {
+      queryClient.setQueryData<MemberListResponse>(
+        memberQueryKeys.list(projectId),
+        (old) =>
+          old
+            ? {
+                ...old,
+                items: old.items.filter((m: ProjectMember) => m.user_id !== userId),
+                total: old.total - 1,
+              }
+            : undefined,
+      );
+    },
+  });
+}

--- a/lib/hooks/useNormalizationStatus.ts
+++ b/lib/hooks/useNormalizationStatus.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { normalizationApi } from "@/lib/api/normalization";
+
+export const normalizationQueryKeys = {
+  status: (projectId: string) => ["normalization", "status", projectId] as const,
+};
+
+export function useNormalizationStatus(
+  projectId: string,
+  accessToken?: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: normalizationQueryKeys.status(projectId),
+    queryFn: () => normalizationApi.getStatus(projectId, accessToken),
+    enabled: (options?.enabled ?? true) && !!projectId,
+  });
+}

--- a/lib/hooks/useNormalizationStatus.ts
+++ b/lib/hooks/useNormalizationStatus.ts
@@ -2,7 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { normalizationApi } from "@/lib/api/normalization";
 
 export const normalizationQueryKeys = {
-  status: (projectId: string) => ["normalization", "status", projectId] as const,
+  status: (projectId: string, accessToken?: string) =>
+    ["normalization", "status", projectId, accessToken] as const,
 };
 
 export function useNormalizationStatus(
@@ -11,8 +12,8 @@ export function useNormalizationStatus(
   options?: { enabled?: boolean },
 ) {
   return useQuery({
-    queryKey: normalizationQueryKeys.status(projectId),
+    queryKey: normalizationQueryKeys.status(projectId, accessToken),
     queryFn: () => normalizationApi.getStatus(projectId, accessToken),
-    enabled: (options?.enabled ?? true) && !!projectId,
+    enabled: (options?.enabled ?? true) && !!projectId && !!accessToken,
   });
 }

--- a/lib/hooks/useOpenPRCount.ts
+++ b/lib/hooks/useOpenPRCount.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { pullRequestsApi } from "@/lib/api/pullRequests";
+
+export const openPRCountQueryKeys = {
+  count: (projectId: string) => ["pullRequests", "openCount", projectId] as const,
+};
+
+export function useOpenPRCount(projectId: string, accessToken?: string) {
+  return useQuery({
+    queryKey: openPRCountQueryKeys.count(projectId),
+    queryFn: async () => {
+      const res = await pullRequestsApi.list(projectId, accessToken, "open", undefined, 0, 1);
+      return res.total;
+    },
+    enabled: !!projectId,
+  });
+}

--- a/lib/hooks/useOpenPRCount.ts
+++ b/lib/hooks/useOpenPRCount.ts
@@ -12,6 +12,6 @@ export function useOpenPRCount(projectId: string, accessToken?: string) {
       const res = await pullRequestsApi.list(projectId, accessToken, "open", undefined, 0, 1);
       return res.total;
     },
-    enabled: !!projectId,
+    enabled: !!projectId && !!accessToken,
   });
 }

--- a/lib/hooks/usePendingSuggestionCount.ts
+++ b/lib/hooks/usePendingSuggestionCount.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { suggestionsApi } from "@/lib/api/suggestions";
+
+export const pendingSuggestionQueryKeys = {
+  count: (projectId: string) => ["suggestions", "pendingCount", projectId] as const,
+};
+
+export function usePendingSuggestionCount(
+  projectId: string,
+  accessToken?: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: pendingSuggestionQueryKeys.count(projectId),
+    queryFn: async () => {
+      const res = await suggestionsApi.listPending(projectId, accessToken!);
+      return res.items.length;
+    },
+    enabled: (options?.enabled ?? true) && !!projectId && !!accessToken,
+  });
+}

--- a/lib/hooks/useProjectViewer.ts
+++ b/lib/hooks/useProjectViewer.ts
@@ -1,12 +1,12 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { useOntologyTree } from "@/lib/hooks/useOntologyTree";
 import { useCollaborationStatus } from "@/lib/hooks/useCollaborationStatus";
 import { useProject, derivePermissions } from "@/lib/hooks/useProject";
-import { pullRequestsApi } from "@/lib/api/pullRequests";
-import { lintApi, type LintSummary } from "@/lib/api/lint";
-import { normalizationApi, type NormalizationStatusResponse } from "@/lib/api/normalization";
+import { useOpenPRCount } from "@/lib/hooks/useOpenPRCount";
+import { useLintSummary } from "@/lib/hooks/useLintSummary";
+import { useNormalizationStatus } from "@/lib/hooks/useNormalizationStatus";
+import { usePendingSuggestionCount } from "@/lib/hooks/usePendingSuggestionCount";
 import { revisionsApi } from "@/lib/api/revisions";
-import { suggestionsApi } from "@/lib/api/suggestions";
 import type { TreeNodeFallback } from "@/components/editor/ClassDetailPanel";
 import type { IriPosition } from "@/lib/editor/indexWorker";
 
@@ -35,11 +35,19 @@ export function useProjectViewer({
   // Override hasValidAccess to check session status (not just token presence)
   const hasValidAccess = sessionStatus === "authenticated" && !!accessToken;
 
-  // Secondary data state
-  const [openPRCount, setOpenPRCount] = useState(0);
-  const [pendingSuggestionCount, setPendingSuggestionCount] = useState(0);
-  const [lintSummary, setLintSummary] = useState<LintSummary | null>(null);
-  const [normalizationStatus, setNormalizationStatus] = useState<NormalizationStatusResponse | null>(null);
+  // Secondary data via React Query hooks
+  const { data: openPRCount = 0 } = useOpenPRCount(projectId, accessToken);
+  const { data: lintSummary = null } = useLintSummary(projectId, accessToken);
+  const { data: normalizationStatus = null } = useNormalizationStatus(
+    projectId,
+    accessToken,
+    { enabled: !!project?.source_file_path },
+  );
+  const { data: pendingSuggestionCount = 0 } = usePendingSuggestionCount(
+    projectId,
+    accessToken,
+    { enabled: !!canEdit },
+  );
 
   // Source state
   const [sourceContent, setSourceContent] = useState<string>("");
@@ -64,31 +72,6 @@ export function useProjectViewer({
     projectId,
     enabled: !!projectId && sessionStatus !== "loading",
   });
-
-  // Fetch secondary data once project is loaded
-  useEffect(() => {
-    if (!project) return;
-    pullRequestsApi.list(projectId, accessToken, "open", undefined, 0, 1)
-      .then((res) => setOpenPRCount(res.total))
-      .catch(() => { /* ignore */ });
-    lintApi.getStatus(projectId, accessToken)
-      .then((summary) => setLintSummary(summary))
-      .catch(() => { /* ignore */ });
-    if (project.source_file_path) {
-      normalizationApi.getStatus(projectId, accessToken)
-        .then((status) => setNormalizationStatus(status))
-        .catch(() => { /* ignore */ });
-    }
-  }, [project, projectId, accessToken]);
-
-  // Fetch pending suggestion count for editors/admins
-  useEffect(() => {
-    if (!canEdit || !accessToken) return;
-    suggestionsApi
-      .listPending(projectId, accessToken)
-      .then((res) => setPendingSuggestionCount(res.items.length))
-      .catch(() => { /* ignore — endpoint may not exist yet */ });
-  }, [canEdit, projectId, accessToken]);
 
   // Derive fallback data for the selected node from the tree
   const { selectedIri, nodes } = tree;

--- a/lib/hooks/useRemoteSync.ts
+++ b/lib/hooks/useRemoteSync.ts
@@ -1,11 +1,12 @@
 /**
  * React hook for remote sync management.
  *
- * Handles config CRUD, manual check triggering with job polling,
- * and sync event history.
+ * Uses React Query for config/history fetching and cache management.
+ * Keeps manual check triggering with job polling as mutations.
  */
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   remoteSyncApi,
   type RemoteSyncConfig,
@@ -14,8 +15,12 @@ import {
   type SyncEvent,
 } from "@/lib/api/remoteSync";
 
-
 const JOB_POLL_INTERVAL = 2000; // 2 seconds
+
+export const remoteSyncQueryKeys = {
+  config: (projectId: string) => ["remoteSync", "config", projectId] as const,
+  history: (projectId: string) => ["remoteSync", "history", projectId] as const,
+};
 
 interface UseRemoteSyncOptions {
   projectId: string;
@@ -41,11 +46,9 @@ export function useRemoteSync({
   accessToken,
   enabled = true,
 }: UseRemoteSyncOptions): UseRemoteSyncReturn {
-  const [config, setConfig] = useState<RemoteSyncConfig | null>(null);
-  const [history, setHistory] = useState<SyncEvent[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const queryClient = useQueryClient();
   const [isChecking, setIsChecking] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [checkError, setCheckError] = useState<string | null>(null);
 
   const jobIdRef = useRef<string | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -59,38 +62,30 @@ export function useRemoteSync({
     };
   }, []);
 
-  // Fetch config + history
-  const fetchData = useCallback(async () => {
-    if (!projectId || !enabled) return;
+  // Fetch config via React Query
+  const configQuery = useQuery({
+    queryKey: remoteSyncQueryKeys.config(projectId),
+    queryFn: () => remoteSyncApi.getConfig(projectId, accessToken),
+    enabled: !!projectId && enabled,
+  });
 
-    setIsLoading(true);
-    setError(null);
+  // Fetch history via React Query (only when config exists)
+  const historyQuery = useQuery({
+    queryKey: remoteSyncQueryKeys.history(projectId),
+    queryFn: async () => {
+      const data = await remoteSyncApi.getHistory(projectId, 20, accessToken);
+      return data.items;
+    },
+    enabled: !!projectId && enabled && !!configQuery.data,
+  });
 
-    try {
-      const configData = await remoteSyncApi.getConfig(projectId, accessToken);
-      setConfig(configData);
-
-      // Fetch history if config exists
-      if (configData) {
-        try {
-          const historyData = await remoteSyncApi.getHistory(projectId, 20, accessToken);
-          setHistory(historyData.items);
-        } catch {
-          // History may be empty, ignore
-        }
-      } else {
-        setHistory([]);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load remote sync config");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [projectId, accessToken, enabled]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+  // Invalidate both queries
+  const refetchAll = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: remoteSyncQueryKeys.config(projectId) }),
+      queryClient.invalidateQueries({ queryKey: remoteSyncQueryKeys.history(projectId) }),
+    ]);
+  }, [queryClient, projectId]);
 
   // Poll for job status
   const startPolling = useCallback(
@@ -109,7 +104,7 @@ export function useRemoteSync({
           const status = await remoteSyncApi.getJobStatus(
             projectId,
             jobIdRef.current,
-            accessToken
+            accessToken,
           );
 
           if (status.status === "complete" || status.status === "failed") {
@@ -121,25 +116,25 @@ export function useRemoteSync({
             setIsChecking(false);
 
             if (status.status === "failed" && status.error) {
-              setError(status.error);
+              setCheckError(status.error);
             }
 
             // Refresh data after job completes
-            await fetchData();
+            await refetchAll();
           }
         } catch {
           // Polling error — keep trying
         }
       }, JOB_POLL_INTERVAL);
     },
-    [projectId, accessToken, fetchData]
+    [projectId, accessToken, refetchAll],
   );
 
   // Trigger a manual check
   const triggerCheck = useCallback(async () => {
     if (!accessToken) return;
 
-    setError(null);
+    setCheckError(null);
     setIsChecking(true);
 
     try {
@@ -147,55 +142,69 @@ export function useRemoteSync({
       startPolling(response.job_id);
     } catch (err) {
       setIsChecking(false);
-      setError(err instanceof Error ? err.message : "Failed to trigger check");
+      setCheckError(err instanceof Error ? err.message : "Failed to trigger check");
     }
   }, [projectId, accessToken, startPolling]);
 
-  // Save config
+  // Save config mutation
+  const saveConfigMutation = useMutation({
+    mutationFn: (data: RemoteSyncConfigCreate | RemoteSyncConfigUpdate) =>
+      remoteSyncApi.saveConfig(projectId, data, accessToken!),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(remoteSyncQueryKeys.config(projectId), updated);
+    },
+  });
+
   const saveConfig = useCallback(
     async (data: RemoteSyncConfigCreate | RemoteSyncConfigUpdate) => {
       if (!accessToken) return;
-
-      setError(null);
-
+      setCheckError(null);
       try {
-        const updated = await remoteSyncApi.saveConfig(projectId, data, accessToken);
-        setConfig(updated);
+        await saveConfigMutation.mutateAsync(data);
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Failed to save config";
-        setError(msg);
+        setCheckError(msg);
         throw err;
       }
     },
-    [projectId, accessToken]
+    [accessToken, saveConfigMutation],
   );
 
-  // Delete config
+  // Delete config mutation
+  const deleteConfigMutation = useMutation({
+    mutationFn: () => remoteSyncApi.deleteConfig(projectId, accessToken!),
+    onSuccess: () => {
+      queryClient.setQueryData(remoteSyncQueryKeys.config(projectId), null);
+      queryClient.setQueryData(remoteSyncQueryKeys.history(projectId), []);
+    },
+  });
+
   const deleteConfig = useCallback(async () => {
     if (!accessToken) return;
-
-    setError(null);
-
+    setCheckError(null);
     try {
-      await remoteSyncApi.deleteConfig(projectId, accessToken);
-      setConfig(null);
-      setHistory([]);
+      await deleteConfigMutation.mutateAsync();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to remove config";
-      setError(msg);
+      setCheckError(msg);
       throw err;
     }
-  }, [projectId, accessToken]);
+  }, [accessToken, deleteConfigMutation]);
+
+  // Combine errors: prefer check/mutation errors, then fallback to query error
+  const error =
+    checkError ??
+    (configQuery.error instanceof Error ? configQuery.error.message : null);
 
   return {
-    config,
-    history,
-    isLoading,
+    config: configQuery.data ?? null,
+    history: historyQuery.data ?? [],
+    isLoading: configQuery.isLoading,
     isChecking,
     error,
     triggerCheck,
     saveConfig,
     deleteConfig,
-    refetch: fetchData,
+    refetch: refetchAll,
   };
 }

--- a/lib/hooks/useRemoteSync.ts
+++ b/lib/hooks/useRemoteSync.ts
@@ -158,7 +158,9 @@ export function useRemoteSync({
   });
 
   const saveConfigRef = useRef(saveConfigMutation.mutateAsync);
-  saveConfigRef.current = saveConfigMutation.mutateAsync;
+  useEffect(() => {
+    saveConfigRef.current = saveConfigMutation.mutateAsync;
+  }, [saveConfigMutation.mutateAsync]);
 
   const saveConfig = useCallback(
     async (data: RemoteSyncConfigCreate | RemoteSyncConfigUpdate) => {
@@ -185,7 +187,9 @@ export function useRemoteSync({
   });
 
   const deleteConfigRef = useRef(deleteConfigMutation.mutateAsync);
-  deleteConfigRef.current = deleteConfigMutation.mutateAsync;
+  useEffect(() => {
+    deleteConfigRef.current = deleteConfigMutation.mutateAsync;
+  }, [deleteConfigMutation.mutateAsync]);
 
   const deleteConfig = useCallback(async () => {
     if (!accessToken) return;

--- a/lib/hooks/useRemoteSync.ts
+++ b/lib/hooks/useRemoteSync.ts
@@ -157,19 +157,22 @@ export function useRemoteSync({
     },
   });
 
+  const saveConfigRef = useRef(saveConfigMutation.mutateAsync);
+  saveConfigRef.current = saveConfigMutation.mutateAsync;
+
   const saveConfig = useCallback(
     async (data: RemoteSyncConfigCreate | RemoteSyncConfigUpdate) => {
       if (!accessToken) return;
       setCheckError(null);
       try {
-        await saveConfigMutation.mutateAsync(data);
+        await saveConfigRef.current(data);
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Failed to save config";
         setCheckError(msg);
         throw err;
       }
     },
-    [accessToken, saveConfigMutation],
+    [accessToken],
   );
 
   // Delete config mutation
@@ -181,17 +184,20 @@ export function useRemoteSync({
     },
   });
 
+  const deleteConfigRef = useRef(deleteConfigMutation.mutateAsync);
+  deleteConfigRef.current = deleteConfigMutation.mutateAsync;
+
   const deleteConfig = useCallback(async () => {
     if (!accessToken) return;
     setCheckError(null);
     try {
-      await deleteConfigMutation.mutateAsync();
+      await deleteConfigRef.current();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to remove config";
       setCheckError(msg);
       throw err;
     }
-  }, [accessToken, deleteConfigMutation]);
+  }, [accessToken]);
 
   // Combine errors: prefer check/mutation errors, then history, then config
   const error =

--- a/lib/hooks/useRemoteSync.ts
+++ b/lib/hooks/useRemoteSync.ts
@@ -18,8 +18,10 @@ import {
 const JOB_POLL_INTERVAL = 2000; // 2 seconds
 
 export const remoteSyncQueryKeys = {
-  config: (projectId: string) => ["remoteSync", "config", projectId] as const,
-  history: (projectId: string) => ["remoteSync", "history", projectId] as const,
+  config: (projectId: string, accessToken?: string) =>
+    ["remoteSync", "config", projectId, accessToken] as const,
+  history: (projectId: string, accessToken?: string) =>
+    ["remoteSync", "history", projectId, accessToken] as const,
 };
 
 interface UseRemoteSyncOptions {
@@ -64,28 +66,28 @@ export function useRemoteSync({
 
   // Fetch config via React Query
   const configQuery = useQuery({
-    queryKey: remoteSyncQueryKeys.config(projectId),
+    queryKey: remoteSyncQueryKeys.config(projectId, accessToken),
     queryFn: () => remoteSyncApi.getConfig(projectId, accessToken),
-    enabled: !!projectId && enabled,
+    enabled: !!projectId && enabled && !!accessToken,
   });
 
-  // Fetch history via React Query (only when config exists)
+  // Fetch history via React Query (only when config exists and loaded)
   const historyQuery = useQuery({
-    queryKey: remoteSyncQueryKeys.history(projectId),
+    queryKey: remoteSyncQueryKeys.history(projectId, accessToken),
     queryFn: async () => {
       const data = await remoteSyncApi.getHistory(projectId, 20, accessToken);
       return data.items;
     },
-    enabled: !!projectId && enabled && !!configQuery.data,
+    enabled: !!projectId && enabled && !!accessToken && configQuery.isSuccess && !!configQuery.data,
   });
 
   // Invalidate both queries
   const refetchAll = useCallback(async () => {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: remoteSyncQueryKeys.config(projectId) }),
-      queryClient.invalidateQueries({ queryKey: remoteSyncQueryKeys.history(projectId) }),
+      queryClient.invalidateQueries({ queryKey: remoteSyncQueryKeys.config(projectId, accessToken) }),
+      queryClient.invalidateQueries({ queryKey: remoteSyncQueryKeys.history(projectId, accessToken) }),
     ]);
-  }, [queryClient, projectId]);
+  }, [queryClient, projectId, accessToken]);
 
   // Poll for job status
   const startPolling = useCallback(
@@ -151,7 +153,7 @@ export function useRemoteSync({
     mutationFn: (data: RemoteSyncConfigCreate | RemoteSyncConfigUpdate) =>
       remoteSyncApi.saveConfig(projectId, data, accessToken!),
     onSuccess: (updated) => {
-      queryClient.setQueryData(remoteSyncQueryKeys.config(projectId), updated);
+      queryClient.setQueryData(remoteSyncQueryKeys.config(projectId, accessToken), updated);
     },
   });
 
@@ -174,8 +176,8 @@ export function useRemoteSync({
   const deleteConfigMutation = useMutation({
     mutationFn: () => remoteSyncApi.deleteConfig(projectId, accessToken!),
     onSuccess: () => {
-      queryClient.setQueryData(remoteSyncQueryKeys.config(projectId), null);
-      queryClient.setQueryData(remoteSyncQueryKeys.history(projectId), []);
+      queryClient.setQueryData(remoteSyncQueryKeys.config(projectId, accessToken), null);
+      queryClient.setQueryData(remoteSyncQueryKeys.history(projectId, accessToken), []);
     },
   });
 
@@ -191,15 +193,16 @@ export function useRemoteSync({
     }
   }, [accessToken, deleteConfigMutation]);
 
-  // Combine errors: prefer check/mutation errors, then fallback to query error
+  // Combine errors: prefer check/mutation errors, then history, then config
   const error =
     checkError ??
+    (historyQuery.error instanceof Error ? historyQuery.error.message : null) ??
     (configQuery.error instanceof Error ? configQuery.error.message : null);
 
   return {
     config: configQuery.data ?? null,
     history: historyQuery.data ?? [],
-    isLoading: configQuery.isLoading,
+    isLoading: configQuery.isLoading || historyQuery.isLoading,
     isChecking,
     error,
     triggerCheck,

--- a/lib/hooks/useRemoteSync.ts
+++ b/lib/hooks/useRemoteSync.ts
@@ -53,13 +53,17 @@ export function useRemoteSync({
   const [checkError, setCheckError] = useState<string | null>(null);
 
   const jobIdRef = useRef<string | null>(null);
-  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const accessTokenRef = useRef(accessToken);
+  useEffect(() => {
+    accessTokenRef.current = accessToken;
+  }, [accessToken]);
 
   // Cleanup polling on unmount
   useEffect(() => {
     return () => {
       if (pollTimerRef.current) {
-        clearInterval(pollTimerRef.current);
+        clearTimeout(pollTimerRef.current);
       }
     };
   }, []);
@@ -89,31 +93,28 @@ export function useRemoteSync({
     ]);
   }, [queryClient, projectId, accessToken]);
 
-  // Poll for job status
+  // Poll for job status using recursive setTimeout to prevent overlapping calls
   const startPolling = useCallback(
     (jobId: string) => {
       if (pollTimerRef.current) {
-        clearInterval(pollTimerRef.current);
+        clearTimeout(pollTimerRef.current);
       }
 
       jobIdRef.current = jobId;
       setIsChecking(true);
 
-      pollTimerRef.current = setInterval(async () => {
+      const poll = async () => {
         if (!jobIdRef.current) return;
 
         try {
           const status = await remoteSyncApi.getJobStatus(
             projectId,
             jobIdRef.current,
-            accessToken,
+            accessTokenRef.current,
           );
 
           if (status.status === "complete" || status.status === "failed") {
-            if (pollTimerRef.current) {
-              clearInterval(pollTimerRef.current);
-              pollTimerRef.current = null;
-            }
+            pollTimerRef.current = null;
             jobIdRef.current = null;
             setIsChecking(false);
 
@@ -123,13 +124,19 @@ export function useRemoteSync({
 
             // Refresh data after job completes
             await refetchAll();
+            return;
           }
         } catch {
           // Polling error — keep trying
         }
-      }, JOB_POLL_INTERVAL);
+
+        // Schedule next tick only after the current one completes
+        pollTimerRef.current = setTimeout(poll, JOB_POLL_INTERVAL);
+      };
+
+      pollTimerRef.current = setTimeout(poll, JOB_POLL_INTERVAL);
     },
-    [projectId, accessToken, refetchAll],
+    [projectId, refetchAll],
   );
 
   // Trigger a manual check


### PR DESCRIPTION
## Summary

- **New hooks**: `useMembers`, `useLintSummary`, `useNormalizationStatus`, `useIndexStatus`, `useOpenPRCount`, `usePendingSuggestionCount` — each with query key factories following the `useProject` convention
- **Settings page**: Replace large `useEffect`/`Promise.all` fetch with React Query hooks + `invalidateQueries` after mutations (update project, add/remove/update members, transfer ownership, reindex, normalization)
- **useRemoteSync**: Convert from `useState`/`useEffect` to `useQuery` for config/history + `useMutation` for save/delete; retain imperative interval polling for background jobs
- **useProjectViewer**: Replace 4 manual `useState` + 2 `useEffect` fetch blocks with the new standalone query hooks

Addresses #89

## Test plan

- [ ] Settings page loads project data, members, normalization status, index status correctly
- [ ] Adding/removing/updating members reflects immediately via cache invalidation
- [ ] Remote sync config loads and saves correctly; polling continues for background jobs
- [ ] Project viewer shows correct PR count, lint summary, normalization status
- [ ] No duplicate network requests when navigating between project pages (React Query cache)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Project settings, viewer, and remote sync now use a query-driven data layer for fresher data, more reliable loading/error states, safer polling and cleanup, improved token handling, optimistic cache updates, and faster refreshes after actions (e.g., join approvals, reindexing, remote jobs).
  * Statuses for PRs, linting, normalization, indexing, members, and suggestions are now sourced and reported more consistently.

* **Tests**
  * New and updated tests cover the query hooks and flows, verifying enablement, loading/error behavior, returned values, and cache refresh/invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->