### PR TITLE
feat: add lint rule configuration UI in project settings

### DIFF
--- a/__tests__/components/editor/ClassDetailPanel.test.tsx
+++ b/__tests__/components/editor/ClassDetailPanel.test.tsx
@@ -224,7 +224,7 @@ describe("ClassDetailPanel", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/is not an OWL Class/)
+        screen.getByText(/Could not load .* as an OWL Class/)
       ).toBeDefined();
     });
   });
@@ -498,7 +498,7 @@ describe("ClassDetailPanel", () => {
 
     await waitFor(() => {
       // Should show error since fallback IRI doesn't match
-      expect(screen.getByText(/is not an OWL Class/)).toBeDefined();
+      expect(screen.getByText(/Could not load .* as an OWL Class/)).toBeDefined();
     });
   });
 
@@ -1273,7 +1273,7 @@ describe("ClassDetailPanel", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Animal/)).not.toBeNull();
-      expect(screen.getByText(/is not an OWL Class/)).not.toBeNull();
+      expect(screen.getByText(/Could not load .* as an OWL Class/)).not.toBeNull();
     });
   });
 
@@ -1707,7 +1707,7 @@ describe("ClassDetailPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/is not an OWL Class/)).not.toBeNull();
+      expect(screen.getByText(/Could not load .* as an OWL Class/)).not.toBeNull();
     });
     // Error state should be visible
     expect(container.querySelector(".border-red-200")).not.toBeNull();

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -343,6 +343,58 @@ describe("HealthCheckPanel", () => {
     expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "class");
   });
 
+  it("shows related entities for duplicate-label issues", async () => {
+    mockLintApi.getIssues.mockResolvedValue({
+      items: [
+        {
+          ...baseIssues.items[0],
+          rule_id: "duplicate-label",
+          message: "Label 'Foo' is shared with 1 other resource(s)",
+          details: {
+            duplicate_iris: ["http://example.org/Bar", "http://example.org/Baz"],
+            label: "Foo",
+            local_name: "Foo",
+            total_duplicates: 2,
+          },
+        },
+      ],
+      total: 1, skip: 0, limit: 500,
+    });
+    const onNav = vi.fn();
+    setup({ onNavigateToClass: onNav });
+    await waitFor(() => {
+      expect(screen.getByText("Also:")).toBeDefined();
+      expect(screen.getByText("Bar")).toBeDefined();
+      expect(screen.getByText("Baz")).toBeDefined();
+    });
+    // Click a related entity
+    await userEvent.click(screen.getByText("Bar"));
+    expect(onNav).toHaveBeenCalledWith("http://example.org/Bar", "class");
+  });
+
+  it("shows conflicting values for label-per-language issues", async () => {
+    mockLintApi.getIssues.mockResolvedValue({
+      items: [
+        {
+          ...baseIssues.items[0],
+          rule_id: "label-per-language",
+          message: "Multiple different rdfs:label values for language 'no language tag'",
+          details: {
+            labels: ["Label One", "Label Two"],
+            predicate: "rdfs:label",
+            language: "no language tag",
+            local_name: "Foo",
+          },
+        },
+      ],
+      total: 1, skip: 0, limit: 500,
+    });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Values:")).toBeDefined();
+    });
+  });
+
   it("switches to consistency tab", async () => {
     setup();
     await waitFor(() => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -2025,4 +2025,27 @@ describe("HealthCheckPanel", () => {
     // Restore the synchronous mock for other tests
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0; });
   });
+
+  it("does not reopen the lint WebSocket when the issue filter changes", async () => {
+    // The fetchDataRef pattern keeps `filter` out of the WS effect's deps so
+    // changing filters re-issues HTTP for filtered issues without tearing
+    // down the WS — losing in-flight lint_started/lint_complete messages.
+    setup();
+    await waitFor(() => {
+      expect(mockCreateLintWebSocket).toHaveBeenCalledTimes(1);
+    });
+
+    const initialIssuesCalls = mockLintApi.getIssues.mock.calls.length;
+
+    await userEvent.click(screen.getByText("Errors"));
+    await waitFor(() => {
+      // Filter change should re-fetch issues
+      expect(mockLintApi.getIssues.mock.calls.length).toBeGreaterThan(initialIssuesCalls);
+    });
+    await userEvent.click(screen.getByText("Warnings"));
+    await userEvent.click(screen.getByText("Total"));
+
+    // WebSocket must NOT have been re-opened across any of the filter changes.
+    expect(mockCreateLintWebSocket).toHaveBeenCalledTimes(1);
+  });
 });

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -289,8 +289,9 @@ describe("HealthCheckPanel", () => {
         { ...baseIssues.items[0], subject_type: "class" as const },
         { ...baseIssues.items[0], id: "i3", subject_iri: "http://example.org/hasFoo", subject_type: "property" as const, rule_id: "R003", message: "Domain violation" },
         { ...baseIssues.items[0], id: "i4", subject_iri: "http://example.org/foo1", subject_type: "individual" as const, rule_id: "R004", message: "Range violation" },
+        { ...baseIssues.items[0], id: "i5", subject_iri: "http://example.org/unknown1", subject_type: "other" as const, rule_id: "R005", message: "Missing type" },
       ],
-      total: 3, skip: 0, limit: 500,
+      total: 4, skip: 0, limit: 500,
     });
     setup();
     await waitFor(() => {
@@ -305,6 +306,9 @@ describe("HealthCheckPanel", () => {
     // Individual badge: "I"
     const indBadge = screen.getByText("I");
     expect(indBadge).toBeDefined();
+    // Other badge: "?"
+    const otherBadge = screen.getByText("?");
+    expect(otherBadge).toBeDefined();
   });
 
   it("passes subject_type when navigating to property", async () => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -67,6 +67,7 @@ const baseIssues = {
       rule_id: "R001",
       message: "Missing label",
       subject_iri: "http://example.org/Foo",
+      subject_type: "class" as const,
       details: null,
       created_at: "2025-01-01T00:00:00Z",
       resolved_at: null,
@@ -79,6 +80,7 @@ const baseIssues = {
       rule_id: "R002",
       message: "Deprecated parent",
       subject_iri: null,
+      subject_type: null,
       details: null,
       created_at: "2025-01-01T00:00:00Z",
       resolved_at: null,
@@ -274,7 +276,7 @@ describe("HealthCheckPanel", () => {
       expect(screen.getByText("Foo")).toBeDefined();
     });
     await userEvent.click(screen.getByText("Foo"));
-    expect(onNav).toHaveBeenCalledWith("http://example.org/Foo");
+    expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "class");
   });
 
   it("switches to consistency tab", async () => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -944,7 +944,7 @@ describe("HealthCheckPanel", () => {
     await waitFor(() => {
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Failed to load cached consistency issues"),
-        expect.any(Error)
+        expect.objectContaining({ projectId: "p1", err: expect.any(Error) })
       );
     });
     consoleSpy.mockRestore();
@@ -961,7 +961,7 @@ describe("HealthCheckPanel", () => {
     await waitFor(() => {
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Failed to load cached duplicates"),
-        expect.any(Error)
+        expect.objectContaining({ projectId: "p1", err: expect.any(Error) })
       );
     });
     consoleSpy.mockRestore();

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -965,7 +965,7 @@ describe("HealthCheckPanel", () => {
       expect(screen.getByText("DupA")).toBeDefined();
     });
     await userEvent.click(screen.getByText("DupA"));
-    expect(onNav).toHaveBeenCalledWith("http://example.org/DupA");
+    expect(onNav).toHaveBeenCalledWith("http://example.org/DupA", "class");
   });
 
   it("navigates to entity from consistency issue", async () => {
@@ -994,7 +994,7 @@ describe("HealthCheckPanel", () => {
       expect(screen.getByText("ConsEntity")).toBeDefined();
     });
     await userEvent.click(screen.getByText("ConsEntity"));
-    expect(onNav).toHaveBeenCalledWith("http://example.org/ConsEntity");
+    expect(onNav).toHaveBeenCalledWith("http://example.org/ConsEntity", "class");
   });
 
   it("handles quality WebSocket duplicates_complete message", async () => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -9,6 +9,8 @@ vi.mock("@/lib/api/lint", () => ({
     getIssues: vi.fn(),
     triggerLint: vi.fn(),
     dismissIssue: vi.fn(),
+    getLintConfig: vi.fn(),
+    getLevels: vi.fn(),
   },
   createLintWebSocket: vi.fn(() => ({ close: vi.fn() })),
 }));
@@ -113,6 +115,16 @@ describe("HealthCheckPanel", () => {
     });
     mockLintApi.getStatus.mockResolvedValue(baseSummary);
     mockLintApi.getIssues.mockResolvedValue(baseIssues);
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: null, effective_rules: ["R001", "R002", "R003"], updated_at: null,
+    });
+    mockLintApi.getLevels.mockResolvedValue({
+      levels: [
+        { level: 1, name: "Critical", description: "Structural errors", rule_ids: ["R001"] },
+        { level: 2, name: "Consistency", description: "Consistency checks", rule_ids: ["R001", "R002", "R003"] },
+        { level: 3, name: "Labels", description: "Label checks", rule_ids: ["R001", "R002", "R003", "R004"] },
+      ],
+    });
     mockQualityApi.getConsistencyIssues.mockResolvedValue({
       project_id: "p1",
       branch: "main",
@@ -341,6 +353,23 @@ describe("HealthCheckPanel", () => {
     });
     await userEvent.click(screen.getByText("Foo"));
     expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "class");
+  });
+
+  it("shows lint configuration hint near Run Lint button", async () => {
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Level 2 — Consistency (3 rules)")).toBeDefined();
+    });
+  });
+
+  it("shows custom config hint when lint_level is null", async () => {
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: null, enabled_rules: ["R001", "R002"], effective_rules: ["R001", "R002"], updated_at: null,
+    });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Custom (2 rules)")).toBeDefined();
+    });
   });
 
   it("shows related entities for duplicate-label issues", async () => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -457,7 +457,9 @@ describe("HealthCheckPanel", () => {
     expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "other");
   });
 
-  it("shows lint configuration hint near Run Lint button", async () => {
+  it("shows lint configuration hint", async () => {
+    // Hint renders regardless of whether the action button is "Run Lint" or
+    // "Clear" — the default fixture (last_run completed) shows Clear.
     setup();
     await waitFor(() => {
       expect(screen.getByText("Level 2 — Consistency (3 rules)")).toBeDefined();
@@ -501,6 +503,35 @@ describe("HealthCheckPanel", () => {
     // Click a related entity
     await userEvent.click(screen.getByText("Bar"));
     expect(onNav).toHaveBeenCalledWith("http://example.org/Bar", "class");
+  });
+
+  it("routes duplicate IRIs using the issue's own subject_type", async () => {
+    // For duplicate-label and similar rules, the related entities listed in
+    // duplicate_iris are the same kind as the issue's subject. Hardcoding
+    // "class" would route property/individual duplicates to the class tree
+    // and surface a 404.
+    mockLintApi.getIssues.mockResolvedValue({
+      items: [
+        {
+          ...baseIssues.items[0],
+          subject_iri: "http://example.org/hasFoo",
+          subject_type: "property" as const,
+          rule_id: "duplicate-label",
+          message: "Label 'Foo' is shared with 1 other property",
+          details: {
+            duplicate_iris: ["http://example.org/hasBar"],
+          },
+        },
+      ],
+      total: 1, skip: 0, limit: 500,
+    });
+    const onNav = vi.fn();
+    setup({ onNavigateToClass: onNav });
+    await waitFor(() => {
+      expect(screen.getByText("hasBar")).toBeDefined();
+    });
+    await userEvent.click(screen.getByText("hasBar"));
+    expect(onNav).toHaveBeenCalledWith("http://example.org/hasBar", "property");
   });
 
   it("shows conflicting values for label-per-language issues", async () => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -242,10 +242,14 @@ describe("HealthCheckPanel", () => {
       expect(screen.getByText("Clear")).toBeDefined();
     });
     await userEvent.click(screen.getByText("Clear"));
+    // Each summary card pairs the count with its label inside the same button.
+    // Find each label, walk up to its button, and verify the numeric count is "0".
     await waitFor(() => {
-      // Summary section still visible with zeroed counters
-      expect(screen.getByText("Errors")).toBeDefined();
-      expect(screen.getByText("Warnings")).toBeDefined();
+      for (const label of ["Errors", "Warnings", "Info", "Total"]) {
+        const card = screen.getByText(label).closest("button")!;
+        const count = card.querySelector("p.text-lg")!;
+        expect(count.textContent).toBe("0");
+      }
     });
   });
 
@@ -274,6 +278,8 @@ describe("HealthCheckPanel", () => {
   });
 
   it("shows duplicate_iris related entities with +N more for many duplicates", async () => {
+    // Multi-letter local names so the test isn't confused with single-letter
+    // entity-type badges ("C", "P", "I", "?") that share a screen.
     mockLintApi.getIssues.mockResolvedValue({
       items: [
         {
@@ -282,10 +288,10 @@ describe("HealthCheckPanel", () => {
           message: "Label shared",
           details: {
             duplicate_iris: [
-              "http://example.org/A",
-              "http://example.org/B",
-              "http://example.org/C",
-              "http://example.org/D",
+              "http://example.org/Alpha",
+              "http://example.org/Beta",
+              "http://example.org/Gamma",
+              "http://example.org/Delta",
             ],
             label: "Foo",
             local_name: "Foo",
@@ -296,9 +302,14 @@ describe("HealthCheckPanel", () => {
       total: 1, skip: 0, limit: 500,
     });
     setup();
+    // First three are visible, fourth is hidden behind the "+N more" indicator.
     await waitFor(() => {
-      expect(screen.getByText("+1 more")).toBeDefined();
+      expect(screen.getByText("Alpha")).toBeDefined();
     });
+    expect(screen.getByText("Beta")).toBeDefined();
+    expect(screen.getByText("Gamma")).toBeDefined();
+    expect(screen.queryByText("Delta")).toBeNull();
+    expect(screen.getByText("+1 more")).toBeDefined();
   });
 
   it("shows error when triggerLint fails", async () => {
@@ -423,18 +434,10 @@ describe("HealthCheckPanel", () => {
     await waitFor(() => {
       expect(screen.getByText("Foo")).toBeDefined();
     });
-    // Class badge: "C"
-    const classBadge = screen.getByText("C");
-    expect(classBadge).toBeDefined();
-    // Property badge: "P"
-    const propBadge = screen.getByText("P");
-    expect(propBadge).toBeDefined();
-    // Individual badge: "I"
-    const indBadge = screen.getByText("I");
-    expect(indBadge).toBeDefined();
-    // Other badge: "?"
-    const otherBadge = screen.getByText("?");
-    expect(otherBadge).toBeDefined();
+    expect(screen.getByTestId("subject-type-badge-class")).toBeDefined();
+    expect(screen.getByTestId("subject-type-badge-property")).toBeDefined();
+    expect(screen.getByTestId("subject-type-badge-individual")).toBeDefined();
+    expect(screen.getByTestId("subject-type-badge-other")).toBeDefined();
   });
 
   it("passes subject_type when navigating to property", async () => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -206,6 +206,92 @@ describe("HealthCheckPanel", () => {
     });
   });
 
+  it("shows error when clear results fails", async () => {
+    mockLintApi.clearResults.mockRejectedValue(new Error("Clear failed"));
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Clear")).toBeDefined();
+    });
+    await userEvent.click(screen.getByText("Clear"));
+    await waitFor(() => {
+      expect(screen.getByText("Clear failed")).toBeDefined();
+    });
+  });
+
+  it("keeps summary counters at zero after clearing", async () => {
+    mockLintApi.clearResults.mockResolvedValue(undefined);
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Clear")).toBeDefined();
+    });
+    await userEvent.click(screen.getByText("Clear"));
+    await waitFor(() => {
+      // Summary section still visible with zeroed counters
+      expect(screen.getByText("Errors")).toBeDefined();
+      expect(screen.getByText("Warnings")).toBeDefined();
+    });
+  });
+
+  it("shows No lint run yet when no run exists", async () => {
+    mockLintApi.getStatus.mockResolvedValue({ ...baseSummary, last_run: null });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("No lint run yet")).toBeDefined();
+    });
+    // Should NOT show "No issues found"
+    expect(screen.queryByText("No issues found")).toBeNull();
+  });
+
+  it("shows all-rules config hint when no config is set", async () => {
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: null, enabled_rules: null, effective_rules: ["R001", "R002", "R003", "R004"], updated_at: null,
+    });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText(/All rules/)).toBeDefined();
+    });
+  });
+
+  it("shows No issues found only after completed run with zero issues", async () => {
+    mockLintApi.getStatus.mockResolvedValue({
+      ...baseSummary,
+      error_count: 0, warning_count: 0, info_count: 0, total_issues: 0,
+    });
+    mockLintApi.getIssues.mockResolvedValue({ items: [], total: 0, skip: 0, limit: 500 });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("No issues found")).toBeDefined();
+    });
+  });
+
+  it("shows duplicate_iris related entities with +N more for many duplicates", async () => {
+    mockLintApi.getIssues.mockResolvedValue({
+      items: [
+        {
+          ...baseIssues.items[0],
+          rule_id: "duplicate-label",
+          message: "Label shared",
+          details: {
+            duplicate_iris: [
+              "http://example.org/A",
+              "http://example.org/B",
+              "http://example.org/C",
+              "http://example.org/D",
+            ],
+            label: "Foo",
+            local_name: "Foo",
+            total_duplicates: 4,
+          },
+        },
+      ],
+      total: 1, skip: 0, limit: 500,
+    });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("+1 more")).toBeDefined();
+    });
+  });
+
   it("shows error when triggerLint fails", async () => {
     mockLintApi.getStatus.mockResolvedValue({ ...baseSummary, last_run: null });
     mockLintApi.triggerLint.mockRejectedValue(new Error("Nope"));

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -206,6 +206,23 @@ describe("HealthCheckPanel", () => {
     });
   });
 
+  it("shows Run Lint (not Clear) when last run completed with zero issues", async () => {
+    // No issues = nothing to clear. Re-prompt Run Lint instead.
+    mockLintApi.getStatus.mockResolvedValue({
+      ...baseSummary,
+      error_count: 0,
+      warning_count: 0,
+      info_count: 0,
+      total_issues: 0,
+    });
+    mockLintApi.getIssues.mockResolvedValue({ items: [], total: 0, skip: 0, limit: 500 });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Run Lint")).toBeDefined();
+    });
+    expect(screen.queryByText("Clear")).toBeNull();
+  });
+
   it("shows error when clear results fails", async () => {
     mockLintApi.clearResults.mockRejectedValue(new Error("Clear failed"));
     setup();

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -232,16 +232,6 @@ describe("HealthCheckPanel", () => {
     });
   });
 
-  it("shows No lint run yet when no run exists", async () => {
-    mockLintApi.getStatus.mockResolvedValue({ ...baseSummary, last_run: null });
-    setup();
-    await waitFor(() => {
-      expect(screen.getByText("No lint run yet")).toBeDefined();
-    });
-    // Should NOT show "No issues found"
-    expect(screen.queryByText("No issues found")).toBeNull();
-  });
-
   it("shows all-rules config hint when no config is set", async () => {
     mockLintApi.getLintConfig.mockResolvedValue({
       project_id: "p1", lint_level: null, enabled_rules: null, effective_rules: ["R001", "R002", "R003", "R004"], updated_at: null,
@@ -252,16 +242,18 @@ describe("HealthCheckPanel", () => {
     });
   });
 
-  it("shows No issues found only after completed run with zero issues", async () => {
+  it("does not show 'No issues found' when run is not completed", async () => {
     mockLintApi.getStatus.mockResolvedValue({
       ...baseSummary,
+      last_run: { ...baseSummary.last_run!, status: "running" as const },
       error_count: 0, warning_count: 0, info_count: 0, total_issues: 0,
     });
     mockLintApi.getIssues.mockResolvedValue({ items: [], total: 0, skip: 0, limit: 500 });
     setup();
     await waitFor(() => {
-      expect(screen.getByText("No issues found")).toBeDefined();
+      expect(screen.getByText("Running")).toBeDefined();
     });
+    expect(screen.queryByText("No issues found")).toBeNull();
   });
 
   it("shows duplicate_iris related entities with +N more for many duplicates", async () => {
@@ -399,11 +391,11 @@ describe("HealthCheckPanel", () => {
   it("shows entity type badge based on subject_type", async () => {
     mockLintApi.getStatus.mockResolvedValue({
       ...baseSummary,
-      last_run: { ...baseSummary.last_run!, issues_found: 3 },
+      last_run: { ...baseSummary.last_run!, issues_found: 4 },
     });
     mockLintApi.getIssues.mockResolvedValue({
       items: [
-        { ...baseIssues.items[0], subject_type: "class" as const },
+        baseIssues.items[0],
         { ...baseIssues.items[0], id: "i3", subject_iri: "http://example.org/hasFoo", subject_type: "property" as const, rule_id: "R003", message: "Domain violation" },
         { ...baseIssues.items[0], id: "i4", subject_iri: "http://example.org/foo1", subject_type: "individual" as const, rule_id: "R004", message: "Range violation" },
         { ...baseIssues.items[0], id: "i5", subject_iri: "http://example.org/unknown1", subject_type: "other" as const, rule_id: "R005", message: "Missing type" },

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@/lib/api/lint", () => ({
     getIssues: vi.fn(),
     triggerLint: vi.fn(),
     dismissIssue: vi.fn(),
+    clearResults: vi.fn(),
     getLintConfig: vi.fn(),
     getLevels: vi.fn(),
   },
@@ -175,7 +176,8 @@ describe("HealthCheckPanel", () => {
     expect(screen.getByText("R001")).toBeDefined();
   });
 
-  it("shows Run Lint button and triggers lint", async () => {
+  it("shows Run Lint button when no completed run exists", async () => {
+    mockLintApi.getStatus.mockResolvedValue({ ...baseSummary, last_run: null });
     mockLintApi.triggerLint.mockResolvedValue({
       job_id: "j1",
       status: "pending",
@@ -190,7 +192,22 @@ describe("HealthCheckPanel", () => {
     expect(mockLintApi.triggerLint).toHaveBeenCalledWith("p1", "tok");
   });
 
+  it("shows Clear button after completed run", async () => {
+    mockLintApi.clearResults.mockResolvedValue(undefined);
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Clear")).toBeDefined();
+    });
+    await userEvent.click(screen.getByText("Clear"));
+    expect(mockLintApi.clearResults).toHaveBeenCalledWith("p1", "tok");
+    // After clearing, should switch to Run Lint
+    await waitFor(() => {
+      expect(screen.getByText("Run Lint")).toBeDefined();
+    });
+  });
+
   it("shows error when triggerLint fails", async () => {
+    mockLintApi.getStatus.mockResolvedValue({ ...baseSummary, last_run: null });
     mockLintApi.triggerLint.mockRejectedValue(new Error("Nope"));
     setup();
     await waitFor(() => {
@@ -203,6 +220,7 @@ describe("HealthCheckPanel", () => {
   });
 
   it("disables Run Lint when canRunLint is false", async () => {
+    mockLintApi.getStatus.mockResolvedValue({ ...baseSummary, last_run: null });
     setup({ canRunLint: false });
     await waitFor(() => {
       expect(screen.getByText("Run Lint")).toBeDefined();
@@ -212,6 +230,7 @@ describe("HealthCheckPanel", () => {
   });
 
   it("shows error when lint requires auth but none provided", async () => {
+    mockLintApi.getStatus.mockResolvedValue({ ...baseSummary, last_run: null });
     setup({ accessToken: undefined, canRunLint: true });
     await waitFor(() => {
       expect(screen.getByText("Run Lint")).toBeDefined();

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -436,7 +436,12 @@ describe("HealthCheckPanel", () => {
     expect(onNav).toHaveBeenCalledWith("http://example.org/hasFoo", "property");
   });
 
-  it("defaults to class when subject_type is null", async () => {
+  it("treats null subject_type as 'other' for navigation", async () => {
+    // Null subject_type means the backend couldn't classify the entity. Routing
+    // it as a class would lead to a 404 in the class tree if it's actually a
+    // property/individual. Routing as "other" lets each layout decide:
+    // Developer mode scrolls to source; Standard mode falls back to class tree
+    // (which surfaces ClassDetailPanel's helpful 404 message).
     const onNav = vi.fn();
     mockLintApi.getIssues.mockResolvedValue({
       items: [
@@ -449,7 +454,7 @@ describe("HealthCheckPanel", () => {
       expect(screen.getByText("Foo")).toBeDefined();
     });
     await userEvent.click(screen.getByText("Foo"));
-    expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "class");
+    expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "other");
   });
 
   it("shows lint configuration hint near Run Lint button", async () => {

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -279,6 +279,66 @@ describe("HealthCheckPanel", () => {
     expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "class");
   });
 
+  it("shows entity type badge based on subject_type", async () => {
+    mockLintApi.getStatus.mockResolvedValue({
+      ...baseSummary,
+      last_run: { ...baseSummary.last_run!, issues_found: 3 },
+    });
+    mockLintApi.getIssues.mockResolvedValue({
+      items: [
+        { ...baseIssues.items[0], subject_type: "class" as const },
+        { ...baseIssues.items[0], id: "i3", subject_iri: "http://example.org/hasFoo", subject_type: "property" as const, rule_id: "R003", message: "Domain violation" },
+        { ...baseIssues.items[0], id: "i4", subject_iri: "http://example.org/foo1", subject_type: "individual" as const, rule_id: "R004", message: "Range violation" },
+      ],
+      total: 3, skip: 0, limit: 500,
+    });
+    setup();
+    await waitFor(() => {
+      expect(screen.getByText("Foo")).toBeDefined();
+    });
+    // Class badge: "C"
+    const classBadge = screen.getByText("C");
+    expect(classBadge).toBeDefined();
+    // Property badge: "P"
+    const propBadge = screen.getByText("P");
+    expect(propBadge).toBeDefined();
+    // Individual badge: "I"
+    const indBadge = screen.getByText("I");
+    expect(indBadge).toBeDefined();
+  });
+
+  it("passes subject_type when navigating to property", async () => {
+    const onNav = vi.fn();
+    mockLintApi.getIssues.mockResolvedValue({
+      items: [
+        { ...baseIssues.items[0], subject_iri: "http://example.org/hasFoo", subject_type: "property" as const },
+      ],
+      total: 1, skip: 0, limit: 500,
+    });
+    setup({ onNavigateToClass: onNav });
+    await waitFor(() => {
+      expect(screen.getByText("hasFoo")).toBeDefined();
+    });
+    await userEvent.click(screen.getByText("hasFoo"));
+    expect(onNav).toHaveBeenCalledWith("http://example.org/hasFoo", "property");
+  });
+
+  it("defaults to class when subject_type is null", async () => {
+    const onNav = vi.fn();
+    mockLintApi.getIssues.mockResolvedValue({
+      items: [
+        { ...baseIssues.items[0], subject_type: null },
+      ],
+      total: 1, skip: 0, limit: 500,
+    });
+    setup({ onNavigateToClass: onNav });
+    await waitFor(() => {
+      expect(screen.getByText("Foo")).toBeDefined();
+    });
+    await userEvent.click(screen.getByText("Foo"));
+    expect(onNav).toHaveBeenCalledWith("http://example.org/Foo", "class");
+  });
+
   it("switches to consistency tab", async () => {
     setup();
     await waitFor(() => {

--- a/__tests__/components/editor/OntologySourceEditor.test.tsx
+++ b/__tests__/components/editor/OntologySourceEditor.test.tsx
@@ -1251,4 +1251,117 @@ describe("OntologySourceEditor", () => {
       expect(screen.queryByText("Loading issues...")).toBeNull();
     });
   });
+
+  // ── Problems panel: duplicate_iris rendering ──
+
+  it("renders duplicate_iris as plain spans when not in the IRI index", async () => {
+    // Worker mock returns an empty iriIndex, so all duplicate IRIs fall into
+    // the "unknown" branch and render as non-interactive spans.
+    mockGetIssues.mockResolvedValue({
+      items: [
+        {
+          id: "i1", run_id: "r1", project_id: "proj-1",
+          issue_type: "warning", rule_id: "duplicate-label",
+          message: "Label 'Foo' shared with 1 other resource",
+          subject_iri: "http://example.org/A",
+          subject_type: "class",
+          details: { duplicate_iris: ["http://example.org/B"] },
+          created_at: "2024-01-01T00:00:00Z", resolved_at: null,
+        },
+      ],
+      total: 1, skip: 0, limit: 200,
+    });
+
+    render(<OntologySourceEditor {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Also:")).toBeDefined();
+    });
+    const dup = screen.getByTitle("http://example.org/B");
+    expect(dup.tagName).toBe("SPAN");
+  });
+
+  it("renders duplicate_iris as buttons when the IRI is indexed in the source", async () => {
+    // Override the global Worker stub for this test so the iriIndex contains
+    // the duplicate IRI — exercising the clickable-button branch.
+    class WorkerWithIndex {
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onerror: ((e: ErrorEvent) => void) | null = null;
+      private _t: ReturnType<typeof setTimeout> | null = null;
+      postMessage() {
+        this._t = setTimeout(() => {
+          this._t = null;
+          this.onmessage?.({
+            data: {
+              diagnostics: [],
+              positions: [],
+              iriIndex: [["http://example.org/B", { line: 5, col: 1, len: 10 }]],
+              iriLabels: [],
+              stats: { linesProcessed: 0, irisIndexed: 1, localNamesIndexed: 0, issuesMatched: 0, timeMs: 0 },
+            },
+          } as unknown as MessageEvent);
+        }, 0);
+      }
+      terminate() {
+        if (this._t !== null) { clearTimeout(this._t); this._t = null; }
+      }
+    }
+    vi.stubGlobal("Worker", WorkerWithIndex);
+
+    mockGetIssues.mockResolvedValue({
+      items: [
+        {
+          id: "i1", run_id: "r1", project_id: "proj-1",
+          issue_type: "warning", rule_id: "duplicate-label",
+          message: "Label 'Foo' shared with 1 other resource",
+          subject_iri: "http://example.org/A",
+          subject_type: "class",
+          details: { duplicate_iris: ["http://example.org/B"] },
+          created_at: "2024-01-01T00:00:00Z", resolved_at: null,
+        },
+      ],
+      total: 1, skip: 0, limit: 200,
+    });
+
+    try {
+      render(<OntologySourceEditor {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        const dup = screen.getByTitle("http://example.org/B");
+        expect(dup.tagName).toBe("BUTTON");
+      });
+    } finally {
+      vi.stubGlobal("Worker", MockWorker);
+    }
+  });
+
+  it("shows '+N more' when duplicate_iris has more than three entries", async () => {
+    mockGetIssues.mockResolvedValue({
+      items: [
+        {
+          id: "i1", run_id: "r1", project_id: "proj-1",
+          issue_type: "warning", rule_id: "duplicate-label",
+          message: "Label 'Foo' shared with 4 other resources",
+          subject_iri: "http://example.org/A",
+          subject_type: "class",
+          details: {
+            duplicate_iris: [
+              "http://example.org/B",
+              "http://example.org/C",
+              "http://example.org/D",
+              "http://example.org/E",
+            ],
+          },
+          created_at: "2024-01-01T00:00:00Z", resolved_at: null,
+        },
+      ],
+      total: 1, skip: 0, limit: 200,
+    });
+
+    render(<OntologySourceEditor {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("+1 more")).toBeDefined();
+    });
+  });
 });

--- a/__tests__/components/editor/developer/DeveloperEditorLayout.test.tsx
+++ b/__tests__/components/editor/developer/DeveloperEditorLayout.test.tsx
@@ -1292,25 +1292,36 @@ describe("DeveloperEditorLayout", () => {
       expect(navigateToNode).toHaveBeenCalledWith("http://example.org/MyClass");
     });
 
-    it("handles property type without error", () => {
+    it("switches to properties tab for property type", async () => {
       const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
-      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
-      // Should not throw when navigating to a property
-      expect(() => ref.current!("http://example.org/hasFoo", "property")).not.toThrow();
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref, nodes: [makeNode()] })} />);
+      ref.current!("http://example.org/hasFoo", "property");
+      await waitFor(() => {
+        expect(screen.getByTestId("property-tree")).toBeDefined();
+        expect(screen.getByTestId("property-detail-panel")).toBeDefined();
+      });
     });
 
-    it("handles individual type without error", () => {
+    it("switches to individuals tab for individual type", async () => {
       const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
-      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
-      expect(() => ref.current!("http://example.org/foo1", "individual")).not.toThrow();
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref, nodes: [makeNode()] })} />);
+      ref.current!("http://example.org/foo1", "individual");
+      await waitFor(() => {
+        expect(screen.getByTestId("individual-list")).toBeDefined();
+        expect(screen.getByTestId("individual-detail-panel")).toBeDefined();
+      });
     });
 
-    it("switches to source view for other type", () => {
+    it("switches to source view for other type", async () => {
       const setPendingScrollIri = vi.fn();
       const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
-      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref, setPendingScrollIri })} />);
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref, setPendingScrollIri, sourceContent: "@prefix : <http://ex.org/> ." })} />);
       ref.current!("http://example.org/Unknown", "other");
       expect(setPendingScrollIri).toHaveBeenCalledWith("http://example.org/Unknown");
+      // Source view hides the entity tab bar
+      await waitFor(() => {
+        expect(screen.queryByTestId("entity-tab-bar")).toBeNull();
+      });
     });
 
     it("defaults to class navigation when type is undefined", () => {

--- a/__tests__/components/editor/developer/DeveloperEditorLayout.test.tsx
+++ b/__tests__/components/editor/developer/DeveloperEditorLayout.test.tsx
@@ -1274,4 +1274,51 @@ describe("DeveloperEditorLayout", () => {
       expect(navigateToNode).toHaveBeenCalledWith("http://example.org/DynTarget");
     });
   });
+
+  describe("entityNavigationRef", () => {
+    it("populates ref on mount and clears on unmount", () => {
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      const { unmount } = render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
+      expect(ref.current).toBeTypeOf("function");
+      unmount();
+      expect(ref.current).toBeNull();
+    });
+
+    it("navigates to class tab for class type", () => {
+      const navigateToNode = vi.fn().mockResolvedValue(undefined);
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref, navigateToNode })} />);
+      ref.current!("http://example.org/MyClass", "class");
+      expect(navigateToNode).toHaveBeenCalledWith("http://example.org/MyClass");
+    });
+
+    it("handles property type without error", () => {
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
+      // Should not throw when navigating to a property
+      expect(() => ref.current!("http://example.org/hasFoo", "property")).not.toThrow();
+    });
+
+    it("handles individual type without error", () => {
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
+      expect(() => ref.current!("http://example.org/foo1", "individual")).not.toThrow();
+    });
+
+    it("switches to source view for other type", () => {
+      const setPendingScrollIri = vi.fn();
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref, setPendingScrollIri })} />);
+      ref.current!("http://example.org/Unknown", "other");
+      expect(setPendingScrollIri).toHaveBeenCalledWith("http://example.org/Unknown");
+    });
+
+    it("defaults to class navigation when type is undefined", () => {
+      const navigateToNode = vi.fn().mockResolvedValue(undefined);
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<DeveloperEditorLayout {...defaultProps({ entityNavigationRef: ref, navigateToNode })} />);
+      ref.current!("http://example.org/ClassA");
+      expect(navigateToNode).toHaveBeenCalledWith("http://example.org/ClassA");
+    });
+  });
 });

--- a/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
+++ b/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
@@ -1023,12 +1023,11 @@ describe("StandardEditorLayout", () => {
       expect(navigateToNode).toHaveBeenCalledWith("http://example.org/ClassA");
     });
 
-    it("falls back to class navigation for 'other' type", () => {
+    it("navigates to class tree for 'other' type (triggers 404 error message)", () => {
       const navigateToNode = vi.fn().mockResolvedValue(undefined);
       const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
       render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref, navigateToNode })} />);
       ref.current!("http://example.org/Unknown", "other");
-      // StandardEditorLayout has no source view, so "other" falls through to class nav
       expect(navigateToNode).toHaveBeenCalledWith("http://example.org/Unknown");
     });
   });

--- a/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
+++ b/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
@@ -1022,5 +1022,14 @@ describe("StandardEditorLayout", () => {
       ref.current!("http://example.org/ClassA");
       expect(navigateToNode).toHaveBeenCalledWith("http://example.org/ClassA");
     });
+
+    it("falls back to class navigation for 'other' type", () => {
+      const navigateToNode = vi.fn().mockResolvedValue(undefined);
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref, navigateToNode })} />);
+      ref.current!("http://example.org/Unknown", "other");
+      // StandardEditorLayout has no source view, so "other" falls through to class nav
+      expect(navigateToNode).toHaveBeenCalledWith("http://example.org/Unknown");
+    });
   });
 });

--- a/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
+++ b/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 // Provide localStorage polyfill
@@ -44,18 +44,14 @@ vi.mock("@/components/editor/ClassDetailPanel", () => ({
   },
 }));
 
-let _tabChangeHandler: ((id: string) => void) | undefined;
 vi.mock("@/components/editor/standard/EntityTabBar", () => ({
-  EntityTabBar: (props: Record<string, unknown>) => {
-    _tabChangeHandler = props.onTabChange as (id: string) => void;
-    return (
-      <div data-testid="entity-tab-bar">
-        <button onClick={() => (props.onTabChange as (id: string) => void)?.("classes")}>Classes</button>
-        <button onClick={() => (props.onTabChange as (id: string) => void)?.("properties")}>Properties</button>
-        <button onClick={() => (props.onTabChange as (id: string) => void)?.("individuals")}>Individuals</button>
-      </div>
-    );
-  },
+  EntityTabBar: (props: Record<string, unknown>) => (
+    <div data-testid="entity-tab-bar">
+      <button onClick={() => (props.onTabChange as (id: string) => void)?.("classes")}>Classes</button>
+      <button onClick={() => (props.onTabChange as (id: string) => void)?.("properties")}>Properties</button>
+      <button onClick={() => (props.onTabChange as (id: string) => void)?.("individuals")}>Individuals</button>
+    </div>
+  ),
 }));
 
 let _propertyTreeProps: Record<string, unknown> = {};
@@ -239,7 +235,6 @@ const sampleNodes: ClassTreeNode[] = [
 describe("StandardEditorLayout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    _tabChangeHandler = undefined;
     _useTreeSearchOverride = null;
     _useTreeDragDropOverride = null;
     _lastDragDropOptions = null;
@@ -1002,17 +997,32 @@ describe("StandardEditorLayout", () => {
 
     it("switches to properties tab when type is property", () => {
       const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
-      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
-      ref.current!("http://example.org/hasFoo", "property");
-      // The tab change handler should have been called
-      expect(_tabChangeHandler).toBeDefined();
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref, nodes: sampleNodes })} />);
+      // Initially on classes tab
+      expect(screen.getByTestId("class-tree")).toBeDefined();
+
+      act(() => {
+        ref.current!("http://example.org/hasFoo", "property");
+      });
+
+      // Property tree + detail panel should now mount, class tree gone
+      expect(screen.getByTestId("property-tree")).toBeDefined();
+      expect(screen.getByTestId("property-detail-panel")).toBeDefined();
+      expect(screen.queryByTestId("class-tree")).toBeNull();
     });
 
     it("switches to individuals tab when type is individual", () => {
       const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
-      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
-      ref.current!("http://example.org/foo1", "individual");
-      expect(_tabChangeHandler).toBeDefined();
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref, nodes: sampleNodes })} />);
+      expect(screen.getByTestId("class-tree")).toBeDefined();
+
+      act(() => {
+        ref.current!("http://example.org/foo1", "individual");
+      });
+
+      expect(screen.getByTestId("individual-list")).toBeDefined();
+      expect(screen.getByTestId("individual-detail-panel")).toBeDefined();
+      expect(screen.queryByTestId("class-tree")).toBeNull();
     });
 
     it("defaults to class navigation when type is undefined", () => {

--- a/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
+++ b/__tests__/components/editor/standard/StandardEditorLayout.test.tsx
@@ -976,4 +976,51 @@ describe("StandardEditorLayout", () => {
 
     expect(_toastErrorFn).toHaveBeenCalledWith("Failed to reparent class", "Unknown error");
   });
+
+  describe("entityNavigationRef", () => {
+    it("populates ref with navigation function on mount", () => {
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
+      expect(ref.current).toBeTypeOf("function");
+    });
+
+    it("clears ref on unmount", () => {
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      const { unmount } = render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
+      expect(ref.current).toBeTypeOf("function");
+      unmount();
+      expect(ref.current).toBeNull();
+    });
+
+    it("navigates to class tab when type is class", () => {
+      const navigateToNode = vi.fn().mockResolvedValue(undefined);
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref, navigateToNode })} />);
+      ref.current!("http://example.org/ClassA", "class");
+      expect(navigateToNode).toHaveBeenCalledWith("http://example.org/ClassA");
+    });
+
+    it("switches to properties tab when type is property", () => {
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
+      ref.current!("http://example.org/hasFoo", "property");
+      // The tab change handler should have been called
+      expect(_tabChangeHandler).toBeDefined();
+    });
+
+    it("switches to individuals tab when type is individual", () => {
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref })} />);
+      ref.current!("http://example.org/foo1", "individual");
+      expect(_tabChangeHandler).toBeDefined();
+    });
+
+    it("defaults to class navigation when type is undefined", () => {
+      const navigateToNode = vi.fn().mockResolvedValue(undefined);
+      const ref = { current: null } as React.RefObject<((iri: string, type?: string) => void) | null>;
+      render(<StandardEditorLayout {...defaultProps({ entityNavigationRef: ref, navigateToNode })} />);
+      ref.current!("http://example.org/ClassA");
+      expect(navigateToNode).toHaveBeenCalledWith("http://example.org/ClassA");
+    });
+  });
 });

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -88,10 +88,10 @@ import type { LintRuleInfo } from "@/lib/api/lint";
 const mockLintApi = vi.mocked(lintApi);
 
 const sampleRules: LintRuleInfo[] = [
-  { rule_id: "R001", name: "Missing label", description: "Class has no rdfs:label", severity: "error" },
-  { rule_id: "R002", name: "Missing comment", description: "Class has no rdfs:comment", severity: "warning" },
-  { rule_id: "R003", name: "Unused import", description: "Prefix declared but unused", severity: "warning" },
-  { rule_id: "R004", name: "Style hint", description: "Consider using camelCase", severity: "info" },
+  { rule_id: "R001", name: "Missing label", description: "Class has no rdfs:label", severity: "error", scope: ["class", "property", "individual"] },
+  { rule_id: "R002", name: "Missing comment", description: "Class has no rdfs:comment", severity: "warning", scope: ["class", "property", "individual"] },
+  { rule_id: "R003", name: "Unused import", description: "Prefix declared but unused", severity: "warning", scope: ["class"] },
+  { rule_id: "R004", name: "Style hint", description: "Consider using camelCase", severity: "info", scope: ["class", "property", "individual"] },
 ];
 
 // --- Pure function tests ---

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { renderWithQueryClient } from "@/__tests__/helpers/renderWithProviders";
 
 // ---- matchMedia polyfill (must be before any import that touches the store) ----
 if (typeof window !== "undefined" && !window.matchMedia) {
@@ -31,11 +32,6 @@ vi.mock("next-auth/react", () => ({
 vi.mock("next/navigation", () => ({
   useRouter: vi.fn(() => ({ push: vi.fn(), back: vi.fn() })),
   useParams: vi.fn(() => ({ id: "p1" })),
-}));
-
-vi.mock("@tanstack/react-query", () => ({
-  useQuery: vi.fn(() => ({ data: null, isLoading: false })),
-  useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
 }));
 
 vi.mock("next/dynamic", () => ({
@@ -161,7 +157,7 @@ describe("LintConfigSection", () => {
 
   it("shows loading spinner initially", () => {
     mockLintApi.getRules.mockReturnValue(new Promise(() => {})); // never resolves
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     expect(screen.getByText("Lint Rule Configuration")).toBeDefined();
     // Loading spinner is present (the animate-spin div)
@@ -173,7 +169,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 2, enabled_rules: [] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       expect(screen.getByText("Missing label")).toBeDefined();
@@ -185,7 +181,7 @@ describe("LintConfigSection", () => {
   it("shows error message when rules fail to load", async () => {
     mockLintApi.getRules.mockRejectedValue(new Error("Network error"));
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       expect(screen.getByText("Failed to load lint rules")).toBeDefined();
@@ -198,7 +194,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 2, enabled_rules: [] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Level 1 — Critical/)).toBeDefined();
@@ -214,7 +210,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 2, enabled_rules: [] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       // Level 2 enables error + warning rules = 3 of 4
@@ -229,7 +225,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 2, enabled_rules: [] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       expect(screen.getByText("Custom")).toBeDefined();
@@ -249,7 +245,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 2, enabled_rules: [] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       const saveBtn = screen.getByText("Save Lint Configuration");
@@ -264,7 +260,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 2, enabled_rules: [] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
@@ -288,7 +284,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 3, enabled_rules: ["R001", "R002", "R003", "R004"] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
@@ -313,7 +309,7 @@ describe("LintConfigSection", () => {
       config: { lint_level: 2, enabled_rules: [] },
     });
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={false} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={false} />);
 
     await waitFor(() => {
       expect(
@@ -329,7 +325,7 @@ describe("LintConfigSection", () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockRejectedValue(new MockApiError(404, "Not Found", "Not found"));
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       // Should default to level 2 (Standard) with error + warning rules enabled
@@ -341,7 +337,7 @@ describe("LintConfigSection", () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockRejectedValue(new MockApiError(500, "Internal Server Error", "Server error"));
 
-    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       expect(screen.getByText("Failed to load lint rules")).toBeDefined();

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -318,7 +318,7 @@ describe("LintConfigSection", () => {
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to load lint rules")).toBeDefined();
+      expect(screen.getByText("Failed to load lint configuration")).toBeDefined();
     });
   });
 

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -83,7 +83,7 @@ import {
   getSeverityColor,
 } from "@/app/projects/[id]/settings/page";
 import { lintApi } from "@/lib/api/lint";
-import type { LintRuleInfo } from "@/lib/api/lint";
+import type { LintLevelsResponse, LintRuleInfo } from "@/lib/api/lint";
 
 const mockLintApi = vi.mocked(lintApi);
 
@@ -122,7 +122,7 @@ const sampleLevels = {
     { level: 2, name: "Consistency", description: "Orphan classes, duplicates", rule_ids: ["R001", "R002", "R003"] },
     { level: 3, name: "Labels", description: "Label checks", rule_ids: ["R001", "R002", "R003", "R004"] },
   ],
-};
+} satisfies LintLevelsResponse;
 
 describe("LintConfigSection", () => {
   beforeEach(() => {
@@ -299,26 +299,28 @@ describe("LintConfigSection", () => {
     expect(screen.queryByText("Save Lint Configuration")).toBeNull();
   });
 
-  it("falls back to defaults when config endpoint returns 404", async () => {
+  it("surfaces the API error when config endpoint returns 404", async () => {
+    // No silent fallback — a 404 from the config endpoint is now reported to
+    // the user instead of fabricating Level 2 defaults that could overwrite
+    // real config on save.
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockRejectedValue(new MockApiError(404, "Not Found", "Not found"));
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
-      // Should default to level 2 (Standard) with error + warning rules enabled
-      expect(screen.getByText("Rules (3 of 4 enabled)")).toBeDefined();
+      expect(screen.getByText("Not found")).toBeDefined();
     });
   });
 
-  it("shows error when config endpoint returns non-404 error", async () => {
+  it("surfaces the API error when config endpoint returns 500", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockRejectedValue(new MockApiError(500, "Internal Server Error", "Server error"));
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to load lint configuration")).toBeDefined();
+      expect(screen.getByText("Server error")).toBeDefined();
     });
   });
 

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -58,14 +58,21 @@ vi.mock("@/lib/api/lint", () => ({
   },
 }));
 
-vi.mock("@/lib/api/client", () => ({
-  ApiError: class ApiError extends Error {
+const { MockApiError } = vi.hoisted(() => {
+  class MockApiError extends Error {
     status: number;
-    constructor(message: string, status: number) {
+    statusText: string;
+    constructor(status: number, statusText: string, message: string) {
       super(message);
       this.status = status;
+      this.statusText = statusText;
     }
-  },
+  }
+  return { MockApiError };
+});
+
+vi.mock("@/lib/api/client", () => ({
+  ApiError: MockApiError,
 }));
 
 vi.mock("@/lib/utils", () => ({
@@ -318,15 +325,26 @@ describe("LintConfigSection", () => {
     expect(screen.queryByText("Save Lint Configuration")).toBeNull();
   });
 
-  it("falls back to defaults when config endpoint returns error", async () => {
+  it("falls back to defaults when config endpoint returns 404", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
-    mockLintApi.getLintConfig.mockRejectedValue(new Error("404"));
+    mockLintApi.getLintConfig.mockRejectedValue(new MockApiError(404, "Not Found", "Not found"));
 
     render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
       // Should default to level 2 (Standard) with error + warning rules enabled
       expect(screen.getByText("Rules (3 of 4 enabled)")).toBeDefined();
+    });
+  });
+
+  it("shows error when config endpoint returns non-404 error", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockRejectedValue(new MockApiError(500, "Internal Server Error", "Server error"));
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load lint rules")).toBeDefined();
     });
   });
 });

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -473,4 +473,48 @@ describe("LintConfigSection", () => {
       expect(screen.getByText(/4 rules/)).toBeDefined();
     });
   });
+
+  it("displays scope badges for rules", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: null, enabled_rules: ["R001", "R003"], effective_rules: ["R001", "R003"], updated_at: null,
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      // R001 has scope ["class", "property", "individual"] → 3 badges (C, P, I)
+      // R003 has scope ["class"] → 1 badge (C)
+      // All rules together: C appears in all 4 rules
+      const allBadges = screen.getAllByTitle("class");
+      expect(allBadges.length).toBe(4); // all 4 rules have "class" scope
+
+      const propBadges = screen.getAllByTitle("property");
+      expect(propBadges.length).toBe(3); // R001, R002, R004 have "property" scope
+
+      const indBadges = screen.getAllByTitle("individual");
+      expect(indBadges.length).toBe(3); // R001, R002, R004 have "individual" scope
+    });
+  });
+
+  it("shows error when clearing results fails", async () => {
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.clearResults.mockRejectedValue(new Error("Server error"));
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Clear Results")).toBeDefined();
+    });
+
+    await user.click(screen.getByText("Clear Results"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Server error")).toBeDefined();
+    });
+  });
 });

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -49,8 +49,11 @@ vi.mock("next/link", () => ({
 vi.mock("@/lib/api/lint", () => ({
   lintApi: {
     getRules: vi.fn(),
+    getLevels: vi.fn(),
     getLintConfig: vi.fn(),
     updateLintConfig: vi.fn(),
+    getStatus: vi.fn(),
+    clearResults: vi.fn(),
   },
 }));
 
@@ -150,9 +153,21 @@ describe("getSeverityColor", () => {
 
 // --- Component tests ---
 
+const sampleLevels = {
+  levels: [
+    { level: 1, name: "Critical", description: "Undefined parents, circular hierarchies", rule_ids: ["R001"] },
+    { level: 2, name: "Consistency", description: "Orphan classes, duplicates", rule_ids: ["R001", "R002", "R003"] },
+    { level: 3, name: "Labels", description: "Label checks", rule_ids: ["R001", "R002", "R003", "R004"] },
+  ],
+};
+
 describe("LintConfigSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLintApi.getLevels.mockResolvedValue(sampleLevels);
+    mockLintApi.getStatus.mockResolvedValue({
+      project_id: "p1", last_run: null, error_count: 0, warning_count: 0, info_count: 0, total_issues: 0,
+    });
   });
 
   it("shows loading spinner initially", () => {
@@ -198,8 +213,8 @@ describe("LintConfigSection", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Level 1 — Critical/)).toBeDefined();
-      expect(screen.getByText(/Level 2 — Standard/)).toBeDefined();
-      expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
+      expect(screen.getByText(/Level 2 — Consistency/)).toBeDefined();
+      expect(screen.getByText(/Level 3 — Labels/)).toBeDefined();
       expect(screen.getByText("Custom")).toBeDefined();
     });
   });
@@ -263,10 +278,10 @@ describe("LintConfigSection", () => {
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
+      expect(screen.getByText(/Level 3 — Labels/)).toBeDefined();
     });
 
-    await user.click(screen.getByText(/Level 3 — Thorough/));
+    await user.click(screen.getByText(/Level 3 — Labels/));
 
     await waitFor(() => {
       const saveBtn = screen.getByText("Save Lint Configuration");
@@ -287,10 +302,10 @@ describe("LintConfigSection", () => {
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
+      expect(screen.getByText(/Level 3 — Labels/)).toBeDefined();
     });
 
-    await user.click(screen.getByText(/Level 3 — Thorough/));
+    await user.click(screen.getByText(/Level 3 — Labels/));
     await user.click(screen.getByText("Save Lint Configuration"));
 
     await waitFor(() => {
@@ -363,8 +378,8 @@ describe("LintConfigSection", () => {
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
 
     await waitFor(() => {
-      const standardBtn = screen.getByText(/Level 2 — Standard/).closest("button")!;
-      expect(standardBtn.getAttribute("aria-pressed")).toBe("true");
+      const consistencyBtn = screen.getByText(/Level 2 — Consistency/).closest("button")!;
+      expect(consistencyBtn.getAttribute("aria-pressed")).toBe("true");
 
       const criticalBtn = screen.getByText(/Level 1 — Critical/).closest("button")!;
       expect(criticalBtn.getAttribute("aria-pressed")).toBe("false");

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderWithQueryClient } from "@/__tests__/helpers/renderWithProviders";
 
 // ---- matchMedia polyfill (must be before any import that touches the store) ----
@@ -279,6 +280,86 @@ describe("LintConfigSection", () => {
       );
       expect(screen.getByText("Lint configuration saved")).toBeDefined();
     });
+  });
+
+  it("saves with lint_level: null when switching from preset to Custom", async () => {
+    // Round-trip the wire format for custom mode: starting from a preset
+    // (Level 2 → R001/R002/R003), switching to Custom and saving must send
+    // `lint_level: null` with the explicit rule list. Without this, the
+    // backend would interpret the request as a preset and ignore enabled_rules.
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: ["R001", "R002", "R003"], updated_at: null,
+    });
+    mockLintApi.updateLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: null, enabled_rules: ["R001", "R002", "R003"], effective_rules: ["R001", "R002", "R003"], updated_at: null,
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Custom")).toBeDefined();
+    });
+
+    await user.click(screen.getByText("Custom"));
+    await user.click(screen.getByText("Save Lint Configuration"));
+
+    await waitFor(() => {
+      expect(mockLintApi.updateLintConfig).toHaveBeenCalledWith(
+        "p1",
+        expect.objectContaining({ lint_level: null }),
+        "tok"
+      );
+    });
+    // The rule list carried over from the preset should be persisted.
+    const [, payload] = mockLintApi.updateLintConfig.mock.calls[0];
+    expect(new Set((payload as { enabled_rules: string[] }).enabled_rules)).toEqual(
+      new Set(["R001", "R002", "R003"])
+    );
+  });
+
+  it("does not overwrite in-progress edits when the config refetches", async () => {
+    // The hasChangesRef short-circuit in the config-sync effect prevents a
+    // background refetch (e.g. on window focus) from clobbering whatever the
+    // user is in the middle of editing. Without it, switching to Level 3 and
+    // then triggering a refetch would silently revert the level to 2.
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: ["R001", "R002", "R003"], updated_at: null,
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LintConfigSection projectId="p1" accessToken="tok" canManage={true} />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Level 3 — Labels/)).toBeDefined();
+    });
+
+    // Make a dirty edit.
+    await user.click(screen.getByText(/Level 3 — Labels/));
+    await waitFor(() => {
+      const lvl3Btn = screen.getByText(/Level 3 — Labels/).closest("button")!;
+      expect(lvl3Btn.getAttribute("aria-pressed")).toBe("true");
+    });
+
+    // Simulate a background refetch that returns the original Level 2 payload.
+    await queryClient.invalidateQueries({ queryKey: ["lintConfig"] });
+
+    // The dirty edit must survive the refetch.
+    await waitFor(() => {
+      const lvl3Btn = screen.getByText(/Level 3 — Labels/).closest("button")!;
+      expect(lvl3Btn.getAttribute("aria-pressed")).toBe("true");
+    });
+    const lvl2Btn = screen.getByText(/Level 2 — Consistency/).closest("button")!;
+    expect(lvl2Btn.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("shows read-only message when canManage is false", async () => {

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -519,7 +519,7 @@ describe("LintConfigSection", () => {
     });
   });
 
-  it("sends null lint_level for custom mode", async () => {
+  it("marks Custom as active when lint_level is null", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
       project_id: "p1", lint_level: null, enabled_rules: ["R001"], effective_rules: ["R001"], updated_at: null,

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -1,0 +1,332 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---- matchMedia polyfill (must be before any import that touches the store) ----
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+// Mock heavy dependencies that the settings page imports but LintConfigSection doesn't use
+vi.mock("@/components/layout/header", () => ({
+  Header: () => null,
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: vi.fn(() => ({ data: null, status: "unauthenticated" })),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn(), back: vi.fn() })),
+  useParams: vi.fn(() => ({ id: "p1" })),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(() => ({ data: null, isLoading: false })),
+  useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
+}));
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => () => null,
+}));
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode; href: string }) =>
+    children,
+}));
+
+// Mock dependencies before imports
+vi.mock("@/lib/api/lint", () => ({
+  lintApi: {
+    getRules: vi.fn(),
+    getLintConfig: vi.fn(),
+    updateLintConfig: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+import {
+  LintConfigSection,
+  getRulesForLevel,
+  getSeverityColor,
+} from "@/app/projects/[id]/settings/page";
+import { lintApi } from "@/lib/api/lint";
+import type { LintRuleInfo } from "@/lib/api/lint";
+
+const mockLintApi = vi.mocked(lintApi);
+
+const sampleRules: LintRuleInfo[] = [
+  { rule_id: "R001", name: "Missing label", description: "Class has no rdfs:label", severity: "error" },
+  { rule_id: "R002", name: "Missing comment", description: "Class has no rdfs:comment", severity: "warning" },
+  { rule_id: "R003", name: "Unused import", description: "Prefix declared but unused", severity: "warning" },
+  { rule_id: "R004", name: "Style hint", description: "Consider using camelCase", severity: "info" },
+];
+
+// --- Pure function tests ---
+
+describe("getRulesForLevel", () => {
+  it("level 1 returns only error-severity rules", () => {
+    const result = getRulesForLevel(sampleRules, 1);
+    expect(result).toEqual(["R001"]);
+  });
+
+  it("level 2 returns error and warning rules", () => {
+    const result = getRulesForLevel(sampleRules, 2);
+    expect(result).toEqual(["R001", "R002", "R003"]);
+  });
+
+  it("level 3 returns all rules", () => {
+    const result = getRulesForLevel(sampleRules, 3);
+    expect(result).toEqual(["R001", "R002", "R003", "R004"]);
+  });
+
+  it("level 4 returns all rules", () => {
+    const result = getRulesForLevel(sampleRules, 4);
+    expect(result).toEqual(["R001", "R002", "R003", "R004"]);
+  });
+
+  it("level 5 returns all rules", () => {
+    const result = getRulesForLevel(sampleRules, 5);
+    expect(result).toEqual(["R001", "R002", "R003", "R004"]);
+  });
+
+  it("level 0 (custom) returns empty array", () => {
+    const result = getRulesForLevel(sampleRules, 0);
+    expect(result).toEqual([]);
+  });
+
+  it("handles empty rules array", () => {
+    expect(getRulesForLevel([], 2)).toEqual([]);
+  });
+});
+
+describe("getSeverityColor", () => {
+  it("returns red classes for error", () => {
+    expect(getSeverityColor("error")).toContain("bg-red-100");
+  });
+
+  it("returns amber classes for warning", () => {
+    expect(getSeverityColor("warning")).toContain("bg-amber-100");
+  });
+
+  it("returns blue classes for info", () => {
+    expect(getSeverityColor("info")).toContain("bg-blue-100");
+  });
+
+  it("returns slate classes for unknown severity", () => {
+    expect(getSeverityColor("unknown")).toContain("bg-slate-100");
+  });
+});
+
+// --- Component tests ---
+
+describe("LintConfigSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading spinner initially", () => {
+    mockLintApi.getRules.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    expect(screen.getByText("Lint Rule Configuration")).toBeDefined();
+    // Loading spinner is present (the animate-spin div)
+  });
+
+  it("renders rules after loading", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Missing label")).toBeDefined();
+      expect(screen.getByText("Missing comment")).toBeDefined();
+      expect(screen.getByText("Style hint")).toBeDefined();
+    });
+  });
+
+  it("shows error message when rules fail to load", async () => {
+    mockLintApi.getRules.mockRejectedValue(new Error("Network error"));
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load lint rules")).toBeDefined();
+    });
+  });
+
+  it("displays lint level options", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Level 1 — Critical/)).toBeDefined();
+      expect(screen.getByText(/Level 2 — Standard/)).toBeDefined();
+      expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
+      expect(screen.getByText("Custom")).toBeDefined();
+    });
+  });
+
+  it("shows enabled rule count", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      // Level 2 enables error + warning rules = 3 of 4
+      expect(screen.getByText("Rules (3 of 4 enabled)")).toBeDefined();
+    });
+  });
+
+  it("switching to custom mode shows enable/disable all buttons", async () => {
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Custom")).toBeDefined();
+    });
+
+    await user.click(screen.getByText("Custom"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Enable all")).toBeDefined();
+      expect(screen.getByText("Disable all")).toBeDefined();
+    });
+  });
+
+  it("save button is disabled when no changes", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      const saveBtn = screen.getByText("Save Lint Configuration");
+      expect(saveBtn.closest("button")?.disabled).toBe(true);
+    });
+  });
+
+  it("save button enables after changing level", async () => {
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
+    });
+
+    await user.click(screen.getByText(/Level 3 — Thorough/));
+
+    await waitFor(() => {
+      const saveBtn = screen.getByText("Save Lint Configuration");
+      expect(saveBtn.closest("button")?.disabled).toBe(false);
+    });
+  });
+
+  it("calls updateLintConfig on save", async () => {
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+    mockLintApi.updateLintConfig.mockResolvedValue({
+      config: { lint_level: 3, enabled_rules: ["R001", "R002", "R003", "R004"] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Level 3 — Thorough/)).toBeDefined();
+    });
+
+    await user.click(screen.getByText(/Level 3 — Thorough/));
+    await user.click(screen.getByText("Save Lint Configuration"));
+
+    await waitFor(() => {
+      expect(mockLintApi.updateLintConfig).toHaveBeenCalledWith(
+        "p1",
+        { lint_level: 3, enabled_rules: ["R001", "R002", "R003", "R004"] },
+        "tok"
+      );
+      expect(screen.getByText("Lint configuration saved")).toBeDefined();
+    });
+  });
+
+  it("shows read-only message when canManage is false", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={false} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Only project owners and admins can modify lint configuration.")
+      ).toBeDefined();
+    });
+
+    // Save button should not be present
+    expect(screen.queryByText("Save Lint Configuration")).toBeNull();
+  });
+
+  it("falls back to defaults when config endpoint returns error", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockRejectedValue(new Error("404"));
+
+    render(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      // Should default to level 2 (Standard) with error + warning rules enabled
+      expect(screen.getByText("Rules (3 of 4 enabled)")).toBeDefined();
+    });
+  });
+});

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -406,4 +406,108 @@ describe("LintConfigSection", () => {
     const toggleR004 = screen.getByLabelText("Toggle Style hint");
     expect(toggleR004.getAttribute("aria-checked")).toBe("false");
   });
+
+  it("shows last run summary when status data is available", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.getStatus.mockResolvedValue({
+      project_id: "p1",
+      last_run: { id: "run1", project_id: "p1", status: "completed", started_at: "2026-04-20T10:00:00Z", completed_at: "2026-04-20T10:01:00Z", issues_found: 5, error_message: null },
+      error_count: 2,
+      warning_count: 2,
+      info_count: 1,
+      total_issues: 5,
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 error/)).toBeDefined();
+      expect(screen.getByText(/2 warning/)).toBeDefined();
+      expect(screen.getByText(/1 info/)).toBeDefined();
+    });
+  });
+
+  it("shows 'No issues' when last run has zero issues", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.getStatus.mockResolvedValue({
+      project_id: "p1",
+      last_run: { id: "run1", project_id: "p1", status: "completed", started_at: "2026-04-20T10:00:00Z", completed_at: "2026-04-20T10:01:00Z", issues_found: 0, error_message: null },
+      error_count: 0,
+      warning_count: 0,
+      info_count: 0,
+      total_issues: 0,
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No issues")).toBeDefined();
+    });
+  });
+
+  it("calls clearResults and shows success message", async () => {
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.clearResults.mockResolvedValue(undefined);
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Clear Results")).toBeDefined();
+    });
+
+    await user.click(screen.getByText("Clear Results"));
+
+    await waitFor(() => {
+      expect(mockLintApi.clearResults).toHaveBeenCalledWith("p1", "tok");
+      expect(screen.getByText("Lint results cleared")).toBeDefined();
+    });
+  });
+
+  it("sends null lint_level for custom mode", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: null, enabled_rules: ["R001"], effective_rules: ["R001"], updated_at: null,
+    });
+    mockLintApi.updateLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: null, enabled_rules: ["R001"], effective_rules: ["R001"], updated_at: null,
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Custom")).toBeDefined();
+    });
+
+    // Should show custom as active (lint_level: null maps to 0)
+    await waitFor(() => {
+      const customBtn = screen.getByText("Custom").closest("button")!;
+      expect(customBtn.getAttribute("aria-pressed")).toBe("true");
+    });
+  });
+
+  it("displays level rule counts from backend", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      // Level 1 has 1 rule, Level 2 has 3, Level 3 has 4
+      expect(screen.getByText(/1 rules/)).toBeDefined();
+      expect(screen.getByText(/3 rules/)).toBeDefined();
+      expect(screen.getByText(/4 rules/)).toBeDefined();
+    });
+  });
 });

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -343,4 +343,52 @@ describe("LintConfigSection", () => {
       expect(screen.getByText("Failed to load lint rules")).toBeDefined();
     });
   });
+
+  it("shows error to read-only users when rules fail to load", async () => {
+    mockLintApi.getRules.mockRejectedValue(new Error("Network error"));
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load lint rules")).toBeDefined();
+    });
+  });
+
+  it("sets aria-pressed on the active lint level button", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      const standardBtn = screen.getByText(/Level 2 — Standard/).closest("button")!;
+      expect(standardBtn.getAttribute("aria-pressed")).toBe("true");
+
+      const criticalBtn = screen.getByText(/Level 1 — Critical/).closest("button")!;
+      expect(criticalBtn.getAttribute("aria-pressed")).toBe("false");
+    });
+  });
+
+  it("uses role=switch and aria-checked on rule toggles", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      config: { lint_level: 2, enabled_rules: [] },
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      const switches = screen.getAllByRole("switch");
+      expect(switches.length).toBe(sampleRules.length);
+    });
+
+    // Level 2 enables error + warning rules (R001, R002, R003), not info (R004)
+    const toggleR001 = screen.getByLabelText("Toggle Missing label");
+    expect(toggleR001.getAttribute("aria-checked")).toBe("true");
+
+    const toggleR004 = screen.getByLabelText("Toggle Style hint");
+    expect(toggleR004.getAttribute("aria-checked")).toBe("false");
+  });
 });

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -55,8 +55,26 @@ vi.mock("@/lib/api/lint", () => ({
     updateLintConfig: vi.fn(),
     getStatus: vi.fn(),
     clearResults: vi.fn(),
+    triggerLint: vi.fn(),
   },
 }));
+
+const summaryWithResults = {
+  project_id: "p1",
+  last_run: {
+    id: "run1",
+    project_id: "p1",
+    status: "completed" as const,
+    started_at: "2026-04-20T10:00:00Z",
+    completed_at: "2026-04-20T10:01:00Z",
+    issues_found: 5,
+    error_message: null,
+  },
+  error_count: 2,
+  warning_count: 2,
+  info_count: 1,
+  total_issues: 5,
+};
 
 const { MockApiError } = vi.hoisted(() => {
   class MockApiError extends Error {
@@ -503,6 +521,8 @@ describe("LintConfigSection", () => {
     mockLintApi.getLintConfig.mockResolvedValue({
       project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
+    // Clear Results only renders when there's something to clear.
+    mockLintApi.getStatus.mockResolvedValue(summaryWithResults);
     mockLintApi.clearResults.mockResolvedValue(undefined);
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -586,6 +606,7 @@ describe("LintConfigSection", () => {
     mockLintApi.getLintConfig.mockResolvedValue({
       project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
+    mockLintApi.getStatus.mockResolvedValue(summaryWithResults);
     mockLintApi.clearResults.mockRejectedValue(new Error("Server error"));
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -598,6 +619,89 @@ describe("LintConfigSection", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Server error")).toBeDefined();
+    });
+  });
+
+  it("shows Run Lint when no run exists, and triggers a run on click", async () => {
+    // Default status mock has last_run: null — so the Run Lint variant should
+    // render in place of Clear Results.
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.triggerLint.mockResolvedValue({
+      job_id: "j1", status: "pending", message: "started",
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Run Lint")).toBeDefined();
+    });
+    expect(screen.queryByText("Clear Results")).toBeNull();
+
+    await user.click(screen.getByText("Run Lint"));
+
+    await waitFor(() => {
+      expect(mockLintApi.triggerLint).toHaveBeenCalledWith("p1", "tok");
+      expect(screen.getByText("Lint run started")).toBeDefined();
+    });
+  });
+
+  it("shows Run Lint (not Clear) when last run completed with zero issues", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.getStatus.mockResolvedValue({
+      ...summaryWithResults,
+      error_count: 0, warning_count: 0, info_count: 0, total_issues: 0,
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Run Lint")).toBeDefined();
+    });
+    expect(screen.queryByText("Clear Results")).toBeNull();
+  });
+
+  it("disables Run Lint while a run is pending or running", async () => {
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.getStatus.mockResolvedValue({
+      ...summaryWithResults,
+      last_run: { ...summaryWithResults.last_run, status: "running" as const },
+    });
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Running...")).toBeDefined();
+    });
+    const btn = screen.getByText("Running...").closest("button")!;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("shows error when triggerLint fails", async () => {
+    const user = userEvent.setup();
+    mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
+    mockLintApi.getLintConfig.mockResolvedValue({
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
+    });
+    mockLintApi.triggerLint.mockRejectedValue(new Error("Backend down"));
+
+    renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Run Lint")).toBeDefined();
+    });
+    await user.click(screen.getByText("Run Lint"));
+    await waitFor(() => {
+      expect(screen.getByText("Backend down")).toBeDefined();
     });
   });
 });

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -166,7 +166,7 @@ describe("LintConfigSection", () => {
   it("renders rules after loading", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -191,7 +191,7 @@ describe("LintConfigSection", () => {
   it("displays lint level options", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -207,7 +207,7 @@ describe("LintConfigSection", () => {
   it("shows enabled rule count", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -222,7 +222,7 @@ describe("LintConfigSection", () => {
     const user = userEvent.setup();
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -242,7 +242,7 @@ describe("LintConfigSection", () => {
   it("save button is disabled when no changes", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -257,7 +257,7 @@ describe("LintConfigSection", () => {
     const user = userEvent.setup();
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -278,10 +278,10 @@ describe("LintConfigSection", () => {
     const user = userEvent.setup();
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
     mockLintApi.updateLintConfig.mockResolvedValue({
-      config: { lint_level: 3, enabled_rules: ["R001", "R002", "R003", "R004"] },
+      project_id: "p1", lint_level: 3, enabled_rules: ["R001", "R002", "R003", "R004"], effective_rules: ["R001", "R002", "R003", "R004"], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -306,7 +306,7 @@ describe("LintConfigSection", () => {
   it("shows read-only message when canManage is false", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={false} />);
@@ -357,7 +357,7 @@ describe("LintConfigSection", () => {
   it("sets aria-pressed on the active lint level button", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);
@@ -374,7 +374,7 @@ describe("LintConfigSection", () => {
   it("uses role=switch and aria-checked on rule toggles", async () => {
     mockLintApi.getRules.mockResolvedValue({ rules: sampleRules });
     mockLintApi.getLintConfig.mockResolvedValue({
-      config: { lint_level: 2, enabled_rules: [] },
+      project_id: "p1", lint_level: 2, enabled_rules: [], effective_rules: [], updated_at: null,
     });
 
     renderWithQueryClient(<LintConfigSection projectId="p1" accessToken="tok" canManage={true} />);

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -80,7 +80,6 @@ vi.mock("@/lib/utils", () => ({
 
 import {
   LintConfigSection,
-  getRulesForLevel,
   getSeverityColor,
 } from "@/app/projects/[id]/settings/page";
 import { lintApi } from "@/lib/api/lint";
@@ -96,42 +95,6 @@ const sampleRules: LintRuleInfo[] = [
 ];
 
 // --- Pure function tests ---
-
-describe("getRulesForLevel", () => {
-  it("level 1 returns only error-severity rules", () => {
-    const result = getRulesForLevel(sampleRules, 1);
-    expect(result).toEqual(["R001"]);
-  });
-
-  it("level 2 returns error and warning rules", () => {
-    const result = getRulesForLevel(sampleRules, 2);
-    expect(result).toEqual(["R001", "R002", "R003"]);
-  });
-
-  it("level 3 returns all rules", () => {
-    const result = getRulesForLevel(sampleRules, 3);
-    expect(result).toEqual(["R001", "R002", "R003", "R004"]);
-  });
-
-  it("level 4 returns all rules", () => {
-    const result = getRulesForLevel(sampleRules, 4);
-    expect(result).toEqual(["R001", "R002", "R003", "R004"]);
-  });
-
-  it("level 5 returns all rules", () => {
-    const result = getRulesForLevel(sampleRules, 5);
-    expect(result).toEqual(["R001", "R002", "R003", "R004"]);
-  });
-
-  it("level 0 (custom) returns empty array", () => {
-    const result = getRulesForLevel(sampleRules, 0);
-    expect(result).toEqual([]);
-  });
-
-  it("handles empty rules array", () => {
-    expect(getRulesForLevel([], 2)).toEqual([]);
-  });
-});
 
 describe("getSeverityColor", () => {
   it("returns red classes for error", () => {

--- a/__tests__/components/projects/lint-config-section.test.tsx
+++ b/__tests__/components/projects/lint-config-section.test.tsx
@@ -291,9 +291,10 @@ describe("LintConfigSection", () => {
     await user.click(screen.getByText("Save Lint Configuration"));
 
     await waitFor(() => {
+      // Preset mode must not include enabled_rules (backend's enforce_xor).
       expect(mockLintApi.updateLintConfig).toHaveBeenCalledWith(
         "p1",
-        { lint_level: 3, enabled_rules: ["R001", "R002", "R003", "R004"] },
+        { lint_level: 3 },
         "tok"
       );
       expect(screen.getByText("Lint configuration saved")).toBeDefined();

--- a/__tests__/lib/api/lint.test.ts
+++ b/__tests__/lib/api/lint.test.ts
@@ -269,7 +269,7 @@ describe("lintApi", () => {
     });
 
     it("omits auth header when no token", async () => {
-      const config: LintConfig = { lint_level: 2, enabled_rules: [] };
+      const config: LintConfig = { lint_level: 2 };
       mockOk({ config });
 
       await lintApi.updateLintConfig("p1", config);
@@ -282,7 +282,7 @@ describe("lintApi", () => {
       mockError(404, "Not Found", "Endpoint not available");
 
       try {
-        const config: LintConfig = { lint_level: 2, enabled_rules: [] };
+        const config: LintConfig = { lint_level: 2 };
         await lintApi.updateLintConfig("p1", config, "tok");
         expect.unreachable("should have thrown");
       } catch (err) {

--- a/__tests__/lib/api/lint.test.ts
+++ b/__tests__/lib/api/lint.test.ts
@@ -207,7 +207,7 @@ describe("lintApi", () => {
     it("calls GET /api/v1/projects/lint/rules without auth", async () => {
       const rules = {
         rules: [
-          { rule_id: "R001", name: "Missing label", description: "Class has no label", severity: "warning" },
+          { rule_id: "R001", name: "Missing label", description: "Class has no label", severity: "warning", scope: ["class", "property", "individual"] },
         ],
       };
       mockOk(rules);

--- a/__tests__/lib/api/lint.test.ts
+++ b/__tests__/lib/api/lint.test.ts
@@ -220,6 +220,75 @@ describe("lintApi", () => {
       expect(options.method).toBe("GET");
     });
   });
+
+  // --- getLintConfig ---
+
+  describe("getLintConfig", () => {
+    it("calls GET /api/v1/projects/:id/lint/config with auth", async () => {
+      const config = { config: { lint_level: 2, enabled_rules: ["R001", "R002"] } };
+      mockOk(config);
+
+      const result = await lintApi.getLintConfig("p1", "tok");
+      expect(result).toEqual(config);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain("/api/v1/projects/p1/lint/config");
+      expect(options.method).toBe("GET");
+      expect(options.headers.get("Authorization")).toBe("Bearer tok");
+    });
+
+    it("omits auth header when no token", async () => {
+      mockOk({ config: { lint_level: 2, enabled_rules: [] } });
+
+      await lintApi.getLintConfig("p1");
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers.has("Authorization")).toBe(false);
+    });
+  });
+
+  // --- updateLintConfig ---
+
+  describe("updateLintConfig", () => {
+    it("calls PUT /api/v1/projects/:id/lint/config with config body", async () => {
+      const config = { lint_level: 0, enabled_rules: ["R001"] };
+      const response = { config };
+      mockOk(response);
+
+      const result = await lintApi.updateLintConfig("p1", config, "tok");
+      expect(result).toEqual(response);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain("/api/v1/projects/p1/lint/config");
+      expect(options.method).toBe("PUT");
+      expect(options.headers.get("Authorization")).toBe("Bearer tok");
+
+      const body = JSON.parse(options.body);
+      expect(body).toEqual(config);
+    });
+
+    it("omits auth header when no token", async () => {
+      const config = { lint_level: 2, enabled_rules: [] };
+      mockOk({ config });
+
+      await lintApi.updateLintConfig("p1", config);
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers.has("Authorization")).toBe(false);
+    });
+
+    it("throws ApiError on 404", async () => {
+      mockError(404, "Not Found", "Endpoint not available");
+
+      try {
+        await lintApi.updateLintConfig("p1", { lint_level: 2, enabled_rules: [] }, "tok");
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).status).toBe(404);
+      }
+    });
+  });
 });
 
 // --- WebSocket mock ---

--- a/__tests__/lib/api/lint.test.ts
+++ b/__tests__/lib/api/lint.test.ts
@@ -4,6 +4,7 @@ import {
   lintApi,
   createLintWebSocket,
   LintWebSocketManager,
+  type LintConfig,
 } from "@/lib/api/lint";
 
 const mockFetch = vi.fn();
@@ -251,7 +252,7 @@ describe("lintApi", () => {
 
   describe("updateLintConfig", () => {
     it("calls PUT /api/v1/projects/:id/lint/config with config body", async () => {
-      const config = { lint_level: 0, enabled_rules: ["R001"] };
+      const config: LintConfig = { lint_level: null, enabled_rules: ["R001"] };
       const response = { config };
       mockOk(response);
 
@@ -268,7 +269,7 @@ describe("lintApi", () => {
     });
 
     it("omits auth header when no token", async () => {
-      const config = { lint_level: 2, enabled_rules: [] };
+      const config: LintConfig = { lint_level: 2, enabled_rules: [] };
       mockOk({ config });
 
       await lintApi.updateLintConfig("p1", config);
@@ -281,7 +282,8 @@ describe("lintApi", () => {
       mockError(404, "Not Found", "Endpoint not available");
 
       try {
-        await lintApi.updateLintConfig("p1", { lint_level: 2, enabled_rules: [] }, "tok");
+        const config: LintConfig = { lint_level: 2, enabled_rules: [] };
+        await lintApi.updateLintConfig("p1", config, "tok");
         expect.unreachable("should have thrown");
       } catch (err) {
         expect(err).toBeInstanceOf(ApiError);

--- a/__tests__/lib/api/lint.test.ts
+++ b/__tests__/lib/api/lint.test.ts
@@ -289,6 +289,42 @@ describe("lintApi", () => {
       }
     });
   });
+
+  // --- getLevels ---
+
+  describe("getLevels", () => {
+    it("calls GET /api/v1/projects/lint/levels", async () => {
+      const levels = {
+        levels: [
+          { level: 1, name: "Critical", description: "Structural errors", rule_ids: ["R001"] },
+          { level: 2, name: "Consistency", description: "Orphan classes", rule_ids: ["R001", "R002"] },
+        ],
+      };
+      mockOk(levels);
+
+      const result = await lintApi.getLevels();
+      expect(result).toEqual(levels);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain("/api/v1/projects/lint/levels");
+      expect(options.method).toBe("GET");
+    });
+  });
+
+  // --- clearResults ---
+
+  describe("clearResults", () => {
+    it("calls DELETE /api/v1/projects/:id/lint/results with auth", async () => {
+      mockEmpty();
+
+      await lintApi.clearResults("p1", "tok");
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain("/api/v1/projects/p1/lint/results");
+      expect(options.method).toBe("DELETE");
+      expect(options.headers.get("Authorization")).toBe("Bearer tok");
+    });
+  });
 });
 
 // --- WebSocket mock ---

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -1015,6 +1015,7 @@ export default function EditorPage() {
                   accessToken={session?.accessToken}
                   activeBranch={activeBranch}
                   canEdit={!!canEdit}
+                  entityNavigationRef={entityNavigationRef}
                   canSuggest={!!canSuggest}
                   isSuggestionMode={isSuggestionMode}
                   nodes={nodes}

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -101,6 +101,7 @@ export default function EditorPage() {
   const [showHistory, setShowHistory] = useState(false);
   const [showHealthCheck, setShowHealthCheck] = useState(false);
   const sourceEditorRef = useRef<OntologySourceEditorRef>(null);
+  const entityNavigationRef = useRef<((iri: string, type?: string) => void) | null>(null);
 
   // Commit dialog
   const [commitDialogOpen, setCommitDialogOpen] = useState(false);
@@ -1062,6 +1063,7 @@ export default function EditorPage() {
                 activeBranch={activeBranch}
                 canEdit={!!canEdit}
                 canSuggest={!!canSuggest}
+                entityNavigationRef={entityNavigationRef}
                 isSuggestionMode={isSuggestionMode}
                 nodes={nodes}
                 isTreeLoading={isTreeLoading}
@@ -1103,7 +1105,13 @@ export default function EditorPage() {
                 branch={activeBranch}
                 isOpen={showHealthCheck}
                 onClose={() => setShowHealthCheck(false)}
-                onNavigateToClass={(iri) => navigateToNode(iri)}
+                onNavigateToClass={(iri, subjectType) => {
+                  if (entityNavigationRef.current) {
+                    entityNavigationRef.current(iri, subjectType);
+                  } else {
+                    navigateToNode(iri);
+                  }
+                }}
                 canRunLint={!!canManage}
               />
             </div>

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3607,6 +3607,7 @@ export function LintConfigSection({
                   key={opt.value}
                   onClick={() => canManage && handleLevelChange(opt.value)}
                   disabled={!canManage}
+                  aria-pressed={lintLevel === opt.value}
                   className={cn(
                     "rounded-lg border p-3 text-left transition-all",
                     lintLevel === opt.value
@@ -3665,6 +3666,8 @@ export function LintConfigSection({
                   >
                     {/* Toggle */}
                     <button
+                      role="switch"
+                      aria-checked={enabled}
                       onClick={() => handleRuleToggle(rule.rule_id)}
                       disabled={!canManage || !isCustom}
                       className={cn(
@@ -3713,14 +3716,16 @@ export function LintConfigSection({
             </div>
           </div>
 
+          {/* Error/success messages — visible to all users */}
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          )}
+
           {/* Save button */}
           {canManage && (
             <div className="flex items-center justify-end gap-3">
               {success && (
                 <p className="text-sm text-green-600 dark:text-green-400">{success}</p>
-              )}
-              {error && (
-                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
               )}
               <Button
                 onClick={handleSave}

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -921,12 +921,18 @@ export default function ProjectSettingsPage() {
                 View project configuration (read-only)
               </p>
             </div>
-            {project.source_file_path && (
+            {project.source_file_path ? (
               <LintConfigSection
                 projectId={projectId}
                 accessToken={session?.accessToken}
                 canManage={false}
               />
+            ) : (
+              <div className="rounded-lg border border-slate-200 bg-white p-6 text-center dark:border-slate-700 dark:bg-slate-800">
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  No ontology source file has been configured for this project.
+                </p>
+              </div>
             )}
           </div>
         </main>
@@ -3382,6 +3388,7 @@ function EmbeddingSettingsSection({
 
 const SEVERITY_ORDER: Record<string, number> = { error: 0, warning: 1, info: 2 };
 
+/** @deprecated Superseded by backend-driven levelRuleMap. Kept for test compatibility. */
 export function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
   const maxOrder: Record<number, number> = {
     1: 0,                                                              // error only
@@ -3492,6 +3499,8 @@ export function LintConfigSection({
   // Sync config data into local editable state
   useEffect(() => {
     if (!configQuery.data && !configQuery.isError) return;
+    // Don't overwrite in-progress edits from background refetches
+    if (hasChanges) return;
 
     if (configQuery.data) {
       const cfg = configQuery.data;
@@ -3520,7 +3529,7 @@ export function LintConfigSection({
     }
   }, [configQuery.data, configQuery.isError, configQuery.error, rules, levelRuleMap]);
 
-  const isLoading = rulesQuery.isLoading || (!!accessToken && rules.length > 0 && configQuery.isLoading);
+  const isLoading = rulesQuery.isLoading || levelsQuery.isLoading || (!!accessToken && rules.length > 0 && configQuery.isLoading);
 
   // Detect changes
   useEffect(() => {
@@ -3570,7 +3579,7 @@ export function LintConfigSection({
     try {
       const config: LintConfig = {
         lint_level: lintLevel === 0 ? null : lintLevel,
-        enabled_rules: lintLevel === 0 ? [...enabledRules] : [...(levelRuleMap.get(lintLevel) ?? [])],
+        enabled_rules: [...enabledRules],
       };
       await lintApi.updateLintConfig(projectId, config, accessToken);
       setSavedLevel(lintLevel);

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -876,7 +876,7 @@ export default function ProjectSettingsPage() {
     );
   }
 
-  if (!project || !canManage) {
+  if (!project) {
     return (
       <>
         <Header />
@@ -893,6 +893,40 @@ export default function ProjectSettingsPage() {
                 <Button variant="outline">Back to Project</Button>
               </Link>
             </div>
+          </div>
+        </main>
+      </>
+    );
+  }
+
+  if (!canManage) {
+    return (
+      <>
+        <Header />
+        <main id="main-content" className="min-h-[calc(100vh-4rem)] bg-slate-50 dark:bg-slate-900">
+          <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+            <Link
+              href={`/projects/${projectId}`}
+              className="mb-6 inline-flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to project
+            </Link>
+            <div className="mb-8">
+              <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+                Project Settings
+              </h1>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                View project configuration (read-only)
+              </p>
+            </div>
+            {project.source_file_path && (
+              <LintConfigSection
+                projectId={projectId}
+                accessToken={session?.accessToken}
+                canManage={false}
+              />
+            )}
           </div>
         </main>
       </>
@@ -3357,21 +3391,20 @@ const LINT_LEVEL_OPTIONS = [
 const SEVERITY_ORDER: Record<string, number> = { error: 0, warning: 1, info: 2 };
 
 export function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
-  switch (level) {
-    case 1:
-      return allRules.filter((r) => r.severity === "error").map((r) => r.rule_id);
-    case 2:
-      return allRules
-        .filter((r) => r.severity === "error" || r.severity === "warning")
-        .map((r) => r.rule_id);
-    case 3:
-      return allRules.map((r) => r.rule_id); // error + warning + info = all
-    case 4:
-    case 5:
-      return allRules.map((r) => r.rule_id);
-    default:
-      return [];
-  }
+  const maxOrder: Record<number, number> = {
+    1: 0,                                                              // error only
+    2: 1,                                                              // error + warning
+    3: 2,                                                              // error + warning + info
+    4: Math.max(...allRules.map((r) => SEVERITY_ORDER[r.severity] ?? 0), 0), // all known
+    5: Number.POSITIVE_INFINITY,                                       // everything (future-proof)
+  };
+
+  const threshold = maxOrder[level];
+  if (threshold === undefined) return [];
+
+  return allRules
+    .filter((r) => (SEVERITY_ORDER[r.severity] ?? Number.POSITIVE_INFINITY) <= threshold)
+    .map((r) => r.rule_id);
 }
 
 export function getSeverityColor(severity: string) {
@@ -3438,11 +3471,15 @@ export function LintConfigSection({
               setEnabledRules(presetRules);
               setSavedRules(presetRules);
             }
-          } catch {
-            // Backend config endpoint may not exist yet — use defaults
-            const defaultRules = new Set(getRulesForLevel(sortedRules, 2));
-            setEnabledRules(defaultRules);
-            setSavedRules(defaultRules);
+          } catch (err) {
+            // Only fall back to defaults when config endpoint is missing (404/501)
+            if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
+              const defaultRules = new Set(getRulesForLevel(sortedRules, 2));
+              setEnabledRules(defaultRules);
+              setSavedRules(defaultRules);
+            } else {
+              throw err;
+            }
           }
         }
       } catch {

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3413,6 +3413,7 @@ export function LintConfigSection({
   const queryClient = useQueryClient();
   const [isSaving, setIsSaving] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
+  const [isRunningLint, setIsRunningLint] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -3604,7 +3605,29 @@ export function LintConfigSection({
     }
   };
 
+  const handleRunLint = async () => {
+    if (!accessToken) return;
+    setIsRunningLint(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await lintApi.triggerLint(projectId, accessToken);
+      setSuccess("Lint run started");
+      queryClient.invalidateQueries({ queryKey: ["lintSummary", projectId] });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start lint run");
+    } finally {
+      setIsRunningLint(false);
+    }
+  };
+
   const isCustom = lintLevel === null;
+  // Mirror HealthCheckPanel: offer Clear only when there's something to clear,
+  // otherwise the action button re-prompts a fresh Run Lint.
+  const lastRunStatus = statusQuery.data?.last_run?.status;
+  const hasResultsToClear =
+    lastRunStatus === "completed" && (statusQuery.data?.total_issues ?? 0) > 0;
+  const isLintInProgress = lastRunStatus === "pending" || lastRunStatus === "running";
 
   return (
     <section
@@ -3834,14 +3857,25 @@ export function LintConfigSection({
               {success && (
                 <p className="text-sm text-green-600 dark:text-green-400">{success}</p>
               )}
-              <Button
-                onClick={handleClearResults}
-                disabled={isClearing}
-                size="sm"
-                variant="outline"
-              >
-                {isClearing ? "Clearing..." : "Clear Results"}
-              </Button>
+              {hasResultsToClear ? (
+                <Button
+                  onClick={handleClearResults}
+                  disabled={isClearing}
+                  size="sm"
+                  variant="outline"
+                >
+                  {isClearing ? "Clearing..." : "Clear Results"}
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleRunLint}
+                  disabled={isRunningLint || isLintInProgress}
+                  size="sm"
+                  variant="outline"
+                >
+                  {isRunningLint || isLintInProgress ? "Running..." : "Run Lint"}
+                </Button>
+              )}
               <Button
                 onClick={handleSave}
                 disabled={isSaving || !hasChanges}

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -77,6 +77,7 @@ import {
 import {
   lintApi,
   type LintConfig,
+  type LintLevel,
   type LintSummary,
 } from "@/lib/api/lint";
 
@@ -3415,13 +3416,13 @@ export function LintConfigSection({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  // Editable state
-  const [lintLevel, setLintLevel] = useState<number>(2); // Default: Standard
+  // Editable state. `lintLevel === null` means custom mode (explicit rule list).
+  const [lintLevel, setLintLevel] = useState<LintLevel | null>(2); // Default: Standard
   const [enabledRules, setEnabledRules] = useState<Set<string>>(new Set());
   const [hasChanges, setHasChanges] = useState(false);
 
   // Track saved state to detect changes
-  const [savedLevel, setSavedLevel] = useState<number>(2);
+  const [savedLevel, setSavedLevel] = useState<LintLevel | null>(2);
   const [savedRules, setSavedRules] = useState<Set<string>>(new Set());
 
   // Fetch available lint rules
@@ -3440,8 +3441,8 @@ export function LintConfigSection({
 
   // Build a map of level -> rule_ids from backend definitions
   const levelRuleMap = useMemo(() => {
-    if (!levelsQuery.data) return new Map<number, Set<string>>();
-    const map = new Map<number, Set<string>>();
+    if (!levelsQuery.data) return new Map<LintLevel, Set<string>>();
+    const map = new Map<LintLevel, Set<string>>();
     for (const level of levelsQuery.data.levels) {
       map.set(level.level, new Set(level.rule_ids));
     }
@@ -3489,10 +3490,10 @@ export function LintConfigSection({
 
     if (configQuery.data) {
       const cfg = configQuery.data;
-      const level = cfg.lint_level ?? 0; // null means custom
+      const level = cfg.lint_level;
       setLintLevel(level);
       setSavedLevel(level);
-      if (level === 0) {
+      if (level === null) {
         const ruleSet = new Set(cfg.enabled_rules ?? []);
         setEnabledRules(ruleSet);
         setSavedRules(ruleSet);
@@ -3502,17 +3503,11 @@ export function LintConfigSection({
         setSavedRules(presetRules);
       }
     } else if (configQuery.isError) {
-      const err = configQuery.error;
-      // Fall back to defaults only when config endpoint is missing (404/501)
-      if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
-        const defaultRules = levelRuleMap.get(2) ?? new Set<string>();
-        setLintLevel(2);
-        setSavedLevel(2);
-        setEnabledRules(defaultRules);
-        setSavedRules(defaultRules);
-      } else {
-        setError("Failed to load lint configuration");
-      }
+      setError(
+        configQuery.error instanceof Error
+          ? configQuery.error.message
+          : "Failed to load lint configuration"
+      );
     }
   }, [configQuery.data, configQuery.isError, configQuery.error, levelRuleMap]);
 
@@ -3524,7 +3519,7 @@ export function LintConfigSection({
       setHasChanges(true);
       return;
     }
-    if (lintLevel === 0) {
+    if (lintLevel === null) {
       // Custom mode: compare rule sets
       const currentIds = [...enabledRules].sort().join(",");
       const savedIds = [...savedRules].sort().join(",");
@@ -3534,17 +3529,17 @@ export function LintConfigSection({
     }
   }, [lintLevel, enabledRules, savedLevel, savedRules]);
 
-  const handleLevelChange = (level: number) => {
+  const handleLevelChange = (level: LintLevel | null) => {
     setLintLevel(level);
     setError(null);
     setSuccess(null);
-    if (level !== 0) {
+    if (level !== null) {
       setEnabledRules(levelRuleMap.get(level) ?? new Set<string>());
     }
   };
 
   const handleRuleToggle = (ruleId: string) => {
-    if (lintLevel !== 0) return; // Only toggle in custom mode
+    if (lintLevel !== null) return; // Only toggle in custom mode
     setError(null);
     setSuccess(null);
     setEnabledRules((prev) => {
@@ -3565,7 +3560,7 @@ export function LintConfigSection({
     setSuccess(null);
     try {
       const config: LintConfig = {
-        lint_level: lintLevel === 0 ? null : lintLevel,
+        lint_level: lintLevel,
         enabled_rules: [...enabledRules],
       };
       await lintApi.updateLintConfig(projectId, config, accessToken);
@@ -3576,11 +3571,7 @@ export function LintConfigSection({
       // Invalidate queries so cache stays fresh
       queryClient.invalidateQueries({ queryKey: ["lintConfig", projectId] });
     } catch (err) {
-      if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
-        setError("Backend lint config endpoint is not yet available");
-      } else {
-        setError(err instanceof Error ? err.message : "Failed to save lint configuration");
-      }
+      setError(err instanceof Error ? err.message : "Failed to save lint configuration");
     } finally {
       setIsSaving(false);
     }
@@ -3604,7 +3595,7 @@ export function LintConfigSection({
     }
   };
 
-  const isCustom = lintLevel === 0;
+  const isCustom = lintLevel === null;
 
   return (
     <section
@@ -3697,12 +3688,12 @@ export function LintConfigSection({
               ))}
               <button
                 type="button"
-                onClick={() => canManage && handleLevelChange(0)}
+                onClick={() => canManage && handleLevelChange(null)}
                 disabled={!canManage}
-                aria-pressed={lintLevel === 0}
+                aria-pressed={lintLevel === null}
                 className={cn(
                   "rounded-lg border p-3 text-left transition-all",
-                  lintLevel === 0
+                  lintLevel === null
                     ? "border-primary-500 bg-primary-50 ring-1 ring-primary-500 dark:border-primary-400 dark:bg-primary-900/20"
                     : "border-slate-200 hover:border-slate-300 dark:border-slate-600 dark:hover:border-slate-500",
                   !canManage && "cursor-not-allowed opacity-60"

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3569,10 +3569,12 @@ export function LintConfigSection({
     setError(null);
     setSuccess(null);
     try {
-      const config: LintConfig = {
-        lint_level: lintLevel,
-        enabled_rules: [...enabledRules],
-      };
+      // The backend's enforce_xor validator rejects payloads that set both
+      // lint_level AND enabled_rules — preset mode must omit enabled_rules.
+      const config: LintConfig =
+        lintLevel === null
+          ? { lint_level: null, enabled_rules: [...enabledRules] }
+          : { lint_level: lintLevel };
       await lintApi.updateLintConfig(projectId, config, accessToken);
       setSavedLevel(lintLevel);
       setSavedRules(new Set(enabledRules));

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -9,7 +9,7 @@ function isHttpUrl(url: string): boolean {
   }
 }
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter, useParams } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -3429,8 +3429,7 @@ export function LintConfigSection({
   accessToken?: string;
   canManage: boolean;
 }) {
-  const [rules, setRules] = useState<LintRuleInfo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -3444,52 +3443,66 @@ export function LintConfigSection({
   const [savedLevel, setSavedLevel] = useState<number>(2);
   const [savedRules, setSavedRules] = useState<Set<string>>(new Set());
 
-  useEffect(() => {
-    const load = async () => {
-      setIsLoading(true);
-      try {
-        // Always fetch available rules
-        const rulesRes = await lintApi.getRules();
-        const sortedRules = [...rulesRes.rules].sort(
-          (a, b) => (SEVERITY_ORDER[a.severity] ?? 3) - (SEVERITY_ORDER[b.severity] ?? 3)
-        );
-        setRules(sortedRules);
+  // Fetch available lint rules
+  const rulesQuery = useQuery({
+    queryKey: ["lintRules"],
+    queryFn: () => lintApi.getRules(),
+    retry: false,
+  });
 
-        // Try to fetch existing config
-        if (accessToken) {
-          try {
-            const configRes = await lintApi.getLintConfig(projectId, accessToken);
-            const cfg = configRes.config;
-            setLintLevel(cfg.lint_level);
-            setSavedLevel(cfg.lint_level);
-            if (cfg.lint_level === 0) {
-              const ruleSet = new Set(cfg.enabled_rules);
-              setEnabledRules(ruleSet);
-              setSavedRules(ruleSet);
-            } else {
-              const presetRules = new Set(getRulesForLevel(sortedRules, cfg.lint_level));
-              setEnabledRules(presetRules);
-              setSavedRules(presetRules);
-            }
-          } catch (err) {
-            // Only fall back to defaults when config endpoint is missing (404/501)
-            if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
-              const defaultRules = new Set(getRulesForLevel(sortedRules, 2));
-              setEnabledRules(defaultRules);
-              setSavedRules(defaultRules);
-            } else {
-              throw err;
-            }
-          }
-        }
-      } catch {
-        setError("Failed to load lint rules");
-      } finally {
-        setIsLoading(false);
+  const rules = useMemo(() => {
+    if (!rulesQuery.data) return [];
+    return [...rulesQuery.data.rules].sort(
+      (a, b) => (SEVERITY_ORDER[a.severity] ?? 3) - (SEVERITY_ORDER[b.severity] ?? 3)
+    );
+  }, [rulesQuery.data]);
+
+  // Fetch project lint config (depends on rules being loaded)
+  const configQuery = useQuery({
+    queryKey: ["lintConfig", projectId, accessToken],
+    queryFn: () => lintApi.getLintConfig(projectId, accessToken),
+    enabled: !!accessToken && rules.length > 0,
+    retry: false,
+  });
+
+  // Sync rules query error
+  useEffect(() => {
+    if (rulesQuery.isError) {
+      setError("Failed to load lint rules");
+    }
+  }, [rulesQuery.isError]);
+
+  // Sync config data into local editable state
+  useEffect(() => {
+    if (!configQuery.data && !configQuery.isError) return;
+
+    if (configQuery.data) {
+      const cfg = configQuery.data.config;
+      setLintLevel(cfg.lint_level);
+      setSavedLevel(cfg.lint_level);
+      if (cfg.lint_level === 0) {
+        const ruleSet = new Set(cfg.enabled_rules);
+        setEnabledRules(ruleSet);
+        setSavedRules(ruleSet);
+      } else {
+        const presetRules = new Set(getRulesForLevel(rules, cfg.lint_level));
+        setEnabledRules(presetRules);
+        setSavedRules(presetRules);
       }
-    };
-    load();
-  }, [projectId, accessToken]);
+    } else if (configQuery.isError) {
+      const err = configQuery.error;
+      // Fall back to defaults only when config endpoint is missing (404/501)
+      if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
+        const defaultRules = new Set(getRulesForLevel(rules, 2));
+        setEnabledRules(defaultRules);
+        setSavedRules(defaultRules);
+      } else {
+        setError("Failed to load lint rules");
+      }
+    }
+  }, [configQuery.data, configQuery.isError, configQuery.error, rules]);
+
+  const isLoading = rulesQuery.isLoading || (!!accessToken && rules.length > 0 && configQuery.isLoading);
 
   // Detect changes
   useEffect(() => {
@@ -3546,6 +3559,8 @@ export function LintConfigSection({
       setSavedRules(new Set(enabledRules));
       setHasChanges(false);
       setSuccess("Lint configuration saved");
+      // Invalidate queries so cache stays fresh
+      queryClient.invalidateQueries({ queryKey: ["lintConfig", projectId] });
     } catch (err) {
       if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
         setError("Backend lint config endpoint is not yet available");

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -882,15 +882,15 @@ export default function ProjectSettingsPage() {
         <Header />
         <main id="main-content" className="min-h-[calc(100vh-4rem)] bg-slate-50 dark:bg-slate-900">
           <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-8 text-center dark:border-amber-900/50 dark:bg-amber-900/20">
-              <h2 className="text-xl font-semibold text-amber-700 dark:text-amber-400">
-                Access Denied
+            <div className="rounded-lg border border-slate-200 bg-white p-8 text-center dark:border-slate-700 dark:bg-slate-800">
+              <h2 className="text-xl font-semibold text-slate-700 dark:text-slate-200">
+                Project not found
               </h2>
-              <p className="mt-2 text-amber-600 dark:text-amber-300">
-                Only project owners and admins can access settings.
+              <p className="mt-2 text-slate-600 dark:text-slate-400">
+                This project could not be loaded. It may have been deleted, or you may not have access.
               </p>
-              <Link href={`/projects/${projectId}`} className="mt-4 inline-block">
-                <Button variant="outline">Back to Project</Button>
+              <Link href="/projects" className="mt-4 inline-block">
+                <Button variant="outline">Back to Projects</Button>
               </Link>
             </div>
           </div>

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -14,7 +14,7 @@ import { useSession } from "next-auth/react";
 import { useRouter, useParams } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
-import { ArrowLeft, UserPlus, Trash2, Tag, Check, GitPullRequest, AlertCircle, FileText, RefreshCw, History, Play, Inbox, CheckCircle, XCircle, Download, Copy, Eye, EyeOff, Database, ExternalLink } from "lucide-react";
+import { ArrowLeft, UserPlus, Trash2, Tag, Check, GitPullRequest, AlertCircle, FileText, RefreshCw, History, Play, Inbox, CheckCircle, XCircle, Download, Copy, Eye, EyeOff, Database, ExternalLink, Shield } from "lucide-react";
 import { GithubIcon as Github } from "@/components/icons/github";
 import { Header } from "@/components/layout/header";
 import { Button } from "@/components/ui/button";
@@ -74,6 +74,11 @@ import {
   type EmbeddingProvider,
   type EmbeddingStatus,
 } from "@/lib/api/embeddings";
+import {
+  lintApi,
+  type LintConfig,
+  type LintRuleInfo,
+} from "@/lib/api/lint";
 
 // Dynamically import the diff viewer to avoid SSR issues with Monaco
 const NormalizationDiffViewer = dynamic(
@@ -1957,6 +1962,15 @@ export default function ProjectSettingsPage() {
             />
           )}
 
+          {/* Lint Rule Configuration - only for projects with an ontology */}
+          {project.source_file_path && (
+            <LintConfigSection
+              projectId={projectId}
+              accessToken={session?.accessToken}
+              canManage={canManage ?? false}
+            />
+          )}
+
           {/* Danger Zone — hidden for exemplar projects unless superadmin */}
           {(isOwner || project?.is_superadmin) && !(project?.is_exemplar && !project?.is_superadmin) && (
             <section className="rounded-lg border border-red-200 bg-white p-6 dark:border-red-900/50 dark:bg-slate-800">
@@ -3322,6 +3336,354 @@ function EmbeddingSettingsSection({
           )}
           {success && (
             <p className="text-sm text-green-600 dark:text-green-400">{success}</p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// --- Lint Level Presets ---
+
+const LINT_LEVEL_OPTIONS = [
+  { value: 1, label: "Critical", description: "Only error-severity rules" },
+  { value: 2, label: "Standard", description: "Error and warning rules" },
+  { value: 3, label: "Thorough", description: "Error, warning, and info rules" },
+  { value: 4, label: "Strict", description: "All available rules" },
+  { value: 5, label: "Maximum", description: "All rules (future-proof)" },
+  { value: 0, label: "Custom", description: "Choose rules individually" },
+] as const;
+
+const SEVERITY_ORDER: Record<string, number> = { error: 0, warning: 1, info: 2 };
+
+function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
+  switch (level) {
+    case 1:
+      return allRules.filter((r) => r.severity === "error").map((r) => r.rule_id);
+    case 2:
+      return allRules
+        .filter((r) => r.severity === "error" || r.severity === "warning")
+        .map((r) => r.rule_id);
+    case 3:
+      return allRules.map((r) => r.rule_id); // error + warning + info = all
+    case 4:
+    case 5:
+      return allRules.map((r) => r.rule_id);
+    default:
+      return [];
+  }
+}
+
+function getSeverityColor(severity: string) {
+  switch (severity) {
+    case "error":
+      return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    case "warning":
+      return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400";
+    case "info":
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
+    default:
+      return "bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300";
+  }
+}
+
+function LintConfigSection({
+  projectId,
+  accessToken,
+  canManage,
+}: {
+  projectId: string;
+  accessToken?: string;
+  canManage: boolean;
+}) {
+  const [rules, setRules] = useState<LintRuleInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Editable state
+  const [lintLevel, setLintLevel] = useState<number>(2); // Default: Standard
+  const [enabledRules, setEnabledRules] = useState<Set<string>>(new Set());
+  const [hasChanges, setHasChanges] = useState(false);
+
+  // Track saved state to detect changes
+  const [savedLevel, setSavedLevel] = useState<number>(2);
+  const [savedRules, setSavedRules] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        // Always fetch available rules
+        const rulesRes = await lintApi.getRules();
+        const sortedRules = [...rulesRes.rules].sort(
+          (a, b) => (SEVERITY_ORDER[a.severity] ?? 3) - (SEVERITY_ORDER[b.severity] ?? 3)
+        );
+        setRules(sortedRules);
+
+        // Try to fetch existing config
+        if (accessToken) {
+          try {
+            const configRes = await lintApi.getLintConfig(projectId, accessToken);
+            const cfg = configRes.config;
+            setLintLevel(cfg.lint_level);
+            setSavedLevel(cfg.lint_level);
+            if (cfg.lint_level === 0) {
+              const ruleSet = new Set(cfg.enabled_rules);
+              setEnabledRules(ruleSet);
+              setSavedRules(ruleSet);
+            } else {
+              const presetRules = new Set(getRulesForLevel(sortedRules, cfg.lint_level));
+              setEnabledRules(presetRules);
+              setSavedRules(presetRules);
+            }
+          } catch {
+            // Backend config endpoint may not exist yet — use defaults
+            const defaultRules = new Set(getRulesForLevel(sortedRules, 2));
+            setEnabledRules(defaultRules);
+            setSavedRules(defaultRules);
+          }
+        }
+      } catch {
+        setError("Failed to load lint rules");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, [projectId, accessToken]);
+
+  // Detect changes
+  useEffect(() => {
+    if (lintLevel !== savedLevel) {
+      setHasChanges(true);
+      return;
+    }
+    if (lintLevel === 0) {
+      // Custom mode: compare rule sets
+      const currentIds = [...enabledRules].sort().join(",");
+      const savedIds = [...savedRules].sort().join(",");
+      setHasChanges(currentIds !== savedIds);
+    } else {
+      setHasChanges(false);
+    }
+  }, [lintLevel, enabledRules, savedLevel, savedRules]);
+
+  const handleLevelChange = (level: number) => {
+    setLintLevel(level);
+    setError(null);
+    setSuccess(null);
+    if (level !== 0) {
+      setEnabledRules(new Set(getRulesForLevel(rules, level)));
+    }
+  };
+
+  const handleRuleToggle = (ruleId: string) => {
+    if (lintLevel !== 0) return; // Only toggle in custom mode
+    setError(null);
+    setSuccess(null);
+    setEnabledRules((prev) => {
+      const next = new Set(prev);
+      if (next.has(ruleId)) {
+        next.delete(ruleId);
+      } else {
+        next.add(ruleId);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!accessToken) return;
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const config: LintConfig = {
+        lint_level: lintLevel,
+        enabled_rules: lintLevel === 0 ? [...enabledRules] : getRulesForLevel(rules, lintLevel),
+      };
+      await lintApi.updateLintConfig(projectId, config, accessToken);
+      setSavedLevel(lintLevel);
+      setSavedRules(new Set(enabledRules));
+      setHasChanges(false);
+      setSuccess("Lint configuration saved");
+    } catch (err) {
+      if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
+        setError("Backend lint config endpoint is not yet available");
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to save lint configuration");
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const isCustom = lintLevel === 0;
+
+  return (
+    <section
+      id="lint-config"
+      className="mb-8 rounded-lg border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-800"
+    >
+      <div className="mb-4 flex items-center gap-2">
+        <Shield className="h-5 w-5 text-slate-500" />
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+          Lint Rule Configuration
+        </h2>
+      </div>
+      <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
+        Configure which lint rules are applied during ontology health checks.
+        Choose a preset level or customize individual rules.
+      </p>
+
+      {isLoading ? (
+        <div className="flex h-16 items-center justify-center">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary-200 border-t-primary-600" />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* Lint Level Selector */}
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
+              Lint Level
+            </label>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {LINT_LEVEL_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => canManage && handleLevelChange(opt.value)}
+                  disabled={!canManage}
+                  className={cn(
+                    "rounded-lg border p-3 text-left transition-all",
+                    lintLevel === opt.value
+                      ? "border-primary-500 bg-primary-50 ring-1 ring-primary-500 dark:border-primary-400 dark:bg-primary-900/20"
+                      : "border-slate-200 hover:border-slate-300 dark:border-slate-600 dark:hover:border-slate-500",
+                    !canManage && "cursor-not-allowed opacity-60"
+                  )}
+                >
+                  <p className="text-sm font-medium text-slate-900 dark:text-white">
+                    {opt.value === 0 ? opt.label : `Level ${opt.value} — ${opt.label}`}
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    {opt.description}
+                  </p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Rule List */}
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                Rules ({enabledRules.size} of {rules.length} enabled)
+              </label>
+              {isCustom && canManage && (
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setEnabledRules(new Set(rules.map((r) => r.rule_id)))}
+                    className="text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                  >
+                    Enable all
+                  </button>
+                  <span className="text-xs text-slate-300 dark:text-slate-600">|</span>
+                  <button
+                    onClick={() => setEnabledRules(new Set())}
+                    className="text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                  >
+                    Disable all
+                  </button>
+                </div>
+              )}
+            </div>
+            <div className="max-h-80 space-y-1 overflow-y-auto rounded-lg border border-slate-200 p-2 dark:border-slate-600">
+              {rules.map((rule) => {
+                const enabled = enabledRules.has(rule.rule_id);
+                return (
+                  <div
+                    key={rule.rule_id}
+                    className={cn(
+                      "flex items-center gap-3 rounded-md px-3 py-2 transition-colors",
+                      enabled
+                        ? "bg-slate-50 dark:bg-slate-700/50"
+                        : "bg-transparent opacity-60"
+                    )}
+                  >
+                    {/* Toggle */}
+                    <button
+                      onClick={() => handleRuleToggle(rule.rule_id)}
+                      disabled={!canManage || !isCustom}
+                      className={cn(
+                        "relative h-5 w-9 shrink-0 rounded-full transition-colors",
+                        enabled
+                          ? "bg-primary-600 dark:bg-primary-500"
+                          : "bg-slate-300 dark:bg-slate-600",
+                        (!canManage || !isCustom) && "cursor-not-allowed opacity-60"
+                      )}
+                      aria-label={`Toggle ${rule.name}`}
+                    >
+                      <span
+                        className={cn(
+                          "absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform",
+                          enabled && "translate-x-4"
+                        )}
+                      />
+                    </button>
+                    {/* Rule info */}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-slate-900 dark:text-white">
+                          {rule.name}
+                        </span>
+                        <span
+                          className={cn(
+                            "inline-flex rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none",
+                            getSeverityColor(rule.severity)
+                          )}
+                        >
+                          {rule.severity}
+                        </span>
+                      </div>
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
+                        {rule.description}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+              {rules.length === 0 && (
+                <p className="py-4 text-center text-sm text-slate-500 dark:text-slate-400">
+                  No lint rules available.
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Save button */}
+          {canManage && (
+            <div className="flex items-center justify-end gap-3">
+              {success && (
+                <p className="text-sm text-green-600 dark:text-green-400">{success}</p>
+              )}
+              {error && (
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+              )}
+              <Button
+                onClick={handleSave}
+                disabled={isSaving || !hasChanges}
+                size="sm"
+              >
+                {isSaving ? "Saving..." : "Save Lint Configuration"}
+              </Button>
+            </div>
+          )}
+
+          {!canManage && (
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Only project owners and admins can modify lint configuration.
+            </p>
           )}
         </div>
       )}

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3477,11 +3477,15 @@ export function LintConfigSection({
     }
   }, [rulesQuery.isError]);
 
+  // Stable ref for hasChanges so the sync effect can read it without re-running
+  const hasChangesRef = useRef(hasChanges);
+  hasChangesRef.current = hasChanges;
+
   // Sync config data into local editable state
   useEffect(() => {
     if (!configQuery.data && !configQuery.isError) return;
     // Don't overwrite in-progress edits from background refetches
-    if (hasChanges) return;
+    if (hasChangesRef.current) return;
 
     if (configQuery.data) {
       const cfg = configQuery.data;
@@ -3502,13 +3506,15 @@ export function LintConfigSection({
       // Fall back to defaults only when config endpoint is missing (404/501)
       if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
         const defaultRules = levelRuleMap.get(2) ?? new Set<string>();
+        setLintLevel(2);
+        setSavedLevel(2);
         setEnabledRules(defaultRules);
         setSavedRules(defaultRules);
       } else {
-        setError("Failed to load lint rules");
+        setError("Failed to load lint configuration");
       }
     }
-  }, [configQuery.data, configQuery.isError, configQuery.error, rules, levelRuleMap]);
+  }, [configQuery.data, configQuery.isError, configQuery.error, levelRuleMap]);
 
   const isLoading = rulesQuery.isLoading || levelsQuery.isLoading || (!!accessToken && rules.length > 0 && configQuery.isLoading);
 

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -77,7 +77,6 @@ import {
 import {
   lintApi,
   type LintConfig,
-  type LintRuleInfo,
   type LintSummary,
 } from "@/lib/api/lint";
 
@@ -3387,24 +3386,6 @@ function EmbeddingSettingsSection({
 // --- Lint Level Presets ---
 
 const SEVERITY_ORDER: Record<string, number> = { error: 0, warning: 1, info: 2 };
-
-/** @deprecated Superseded by backend-driven levelRuleMap. Kept for test compatibility. */
-export function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
-  const maxOrder: Record<number, number> = {
-    1: 0,                                                              // error only
-    2: 1,                                                              // error + warning
-    3: 2,                                                              // error + warning + info
-    4: Math.max(...allRules.map((r) => SEVERITY_ORDER[r.severity] ?? 0), 0), // all known
-    5: Number.POSITIVE_INFINITY,                                       // everything (future-proof)
-  };
-
-  const threshold = maxOrder[level];
-  if (threshold === undefined) return [];
-
-  return allRules
-    .filter((r) => (SEVERITY_ORDER[r.severity] ?? Number.POSITIVE_INFINITY) <= threshold)
-    .map((r) => r.rule_id);
-}
 
 export function getSeverityColor(severity: string) {
   switch (severity) {

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3456,9 +3456,11 @@ export function LintConfigSection({
     );
   }, [rulesQuery.data]);
 
-  // Fetch project lint config (depends on rules being loaded)
+  // Fetch project lint config (depends on rules being loaded). The access
+  // token is only used inside the queryFn; keeping it out of the queryKey
+  // means a token rotation does not invalidate the cache.
   const configQuery = useQuery({
-    queryKey: ["lintConfig", projectId, accessToken],
+    queryKey: ["lintConfig", projectId],
     queryFn: () => lintApi.getLintConfig(projectId, accessToken),
     enabled: !!accessToken && rules.length > 0,
     retry: false,
@@ -3466,17 +3468,19 @@ export function LintConfigSection({
 
   // Fetch lint status summary
   const statusQuery = useQuery<LintSummary>({
-    queryKey: ["lintSummary", projectId, accessToken],
+    queryKey: ["lintSummary", projectId],
     queryFn: () => lintApi.getStatus(projectId, accessToken),
     enabled: !!accessToken,
   });
 
-  // Sync rules query error
+  // Sync rules / levels query errors
   useEffect(() => {
     if (rulesQuery.isError) {
       setError("Failed to load lint rules");
+    } else if (levelsQuery.isError) {
+      setError("Failed to load lint levels");
     }
-  }, [rulesQuery.isError]);
+  }, [rulesQuery.isError, levelsQuery.isError]);
 
   // Stable ref for hasChanges so the sync effect can read it without re-running
   const hasChangesRef = useRef(hasChanges);
@@ -3718,6 +3722,7 @@ export function LintConfigSection({
               {isCustom && canManage && (
                 <div className="flex gap-2">
                   <button
+                    type="button"
                     onClick={() => setEnabledRules(new Set(rules.map((r) => r.rule_id)))}
                     className="text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
                   >
@@ -3725,6 +3730,7 @@ export function LintConfigSection({
                   </button>
                   <span className="text-xs text-slate-300 dark:text-slate-600">|</span>
                   <button
+                    type="button"
                     onClick={() => setEnabledRules(new Set())}
                     className="text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
                   >

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -78,6 +78,7 @@ import {
   lintApi,
   type LintConfig,
   type LintRuleInfo,
+  type LintSummary,
 } from "@/lib/api/lint";
 
 // Dynamically import the diff viewer to avoid SSR issues with Monaco
@@ -3379,15 +3380,6 @@ function EmbeddingSettingsSection({
 
 // --- Lint Level Presets ---
 
-const LINT_LEVEL_OPTIONS = [
-  { value: 1, label: "Critical", description: "Only error-severity rules" },
-  { value: 2, label: "Standard", description: "Error and warning rules" },
-  { value: 3, label: "Thorough", description: "Error, warning, and info rules" },
-  { value: 4, label: "Strict", description: "All available rules" },
-  { value: 5, label: "Maximum", description: "All rules (future-proof)" },
-  { value: 0, label: "Custom", description: "Choose rules individually" },
-] as const;
-
 const SEVERITY_ORDER: Record<string, number> = { error: 0, warning: 1, info: 2 };
 
 export function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
@@ -3431,6 +3423,7 @@ export function LintConfigSection({
 }) {
   const queryClient = useQueryClient();
   const [isSaving, setIsSaving] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -3450,6 +3443,23 @@ export function LintConfigSection({
     retry: false,
   });
 
+  // Fetch lint level definitions from backend
+  const levelsQuery = useQuery({
+    queryKey: ["lintLevels"],
+    queryFn: () => lintApi.getLevels(),
+    retry: false,
+  });
+
+  // Build a map of level -> rule_ids from backend definitions
+  const levelRuleMap = useMemo(() => {
+    if (!levelsQuery.data) return new Map<number, Set<string>>();
+    const map = new Map<number, Set<string>>();
+    for (const level of levelsQuery.data.levels) {
+      map.set(level.level, new Set(level.rule_ids));
+    }
+    return map;
+  }, [levelsQuery.data]);
+
   const rules = useMemo(() => {
     if (!rulesQuery.data) return [];
     return [...rulesQuery.data.rules].sort(
@@ -3465,6 +3475,13 @@ export function LintConfigSection({
     retry: false,
   });
 
+  // Fetch lint status summary
+  const statusQuery = useQuery<LintSummary>({
+    queryKey: ["lintSummary", projectId, accessToken],
+    queryFn: () => lintApi.getStatus(projectId, accessToken),
+    enabled: !!accessToken,
+  });
+
   // Sync rules query error
   useEffect(() => {
     if (rulesQuery.isError) {
@@ -3477,15 +3494,16 @@ export function LintConfigSection({
     if (!configQuery.data && !configQuery.isError) return;
 
     if (configQuery.data) {
-      const cfg = configQuery.data.config;
-      setLintLevel(cfg.lint_level);
-      setSavedLevel(cfg.lint_level);
-      if (cfg.lint_level === 0) {
-        const ruleSet = new Set(cfg.enabled_rules);
+      const cfg = configQuery.data;
+      const level = cfg.lint_level ?? 0; // null means custom
+      setLintLevel(level);
+      setSavedLevel(level);
+      if (level === 0) {
+        const ruleSet = new Set(cfg.enabled_rules ?? []);
         setEnabledRules(ruleSet);
         setSavedRules(ruleSet);
       } else {
-        const presetRules = new Set(getRulesForLevel(rules, cfg.lint_level));
+        const presetRules = levelRuleMap.get(level) ?? new Set<string>();
         setEnabledRules(presetRules);
         setSavedRules(presetRules);
       }
@@ -3493,14 +3511,14 @@ export function LintConfigSection({
       const err = configQuery.error;
       // Fall back to defaults only when config endpoint is missing (404/501)
       if (err instanceof ApiError && (err.status === 404 || err.status === 501)) {
-        const defaultRules = new Set(getRulesForLevel(rules, 2));
+        const defaultRules = levelRuleMap.get(2) ?? new Set<string>();
         setEnabledRules(defaultRules);
         setSavedRules(defaultRules);
       } else {
         setError("Failed to load lint rules");
       }
     }
-  }, [configQuery.data, configQuery.isError, configQuery.error, rules]);
+  }, [configQuery.data, configQuery.isError, configQuery.error, rules, levelRuleMap]);
 
   const isLoading = rulesQuery.isLoading || (!!accessToken && rules.length > 0 && configQuery.isLoading);
 
@@ -3525,7 +3543,7 @@ export function LintConfigSection({
     setError(null);
     setSuccess(null);
     if (level !== 0) {
-      setEnabledRules(new Set(getRulesForLevel(rules, level)));
+      setEnabledRules(levelRuleMap.get(level) ?? new Set<string>());
     }
   };
 
@@ -3551,8 +3569,8 @@ export function LintConfigSection({
     setSuccess(null);
     try {
       const config: LintConfig = {
-        lint_level: lintLevel,
-        enabled_rules: lintLevel === 0 ? [...enabledRules] : getRulesForLevel(rules, lintLevel),
+        lint_level: lintLevel === 0 ? null : lintLevel,
+        enabled_rules: lintLevel === 0 ? [...enabledRules] : [...(levelRuleMap.get(lintLevel) ?? [])],
       };
       await lintApi.updateLintConfig(projectId, config, accessToken);
       setSavedLevel(lintLevel);
@@ -3569,6 +3587,24 @@ export function LintConfigSection({
       }
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const handleClearResults = async () => {
+    if (!accessToken) return;
+    setIsClearing(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await lintApi.clearResults(projectId, accessToken);
+      setSuccess("Lint results cleared");
+      queryClient.invalidateQueries({ queryKey: ["lintSummary", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["lintIssues", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["lintRuns", projectId] });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to clear lint results");
+    } finally {
+      setIsClearing(false);
     }
   };
 
@@ -3590,6 +3626,44 @@ export function LintConfigSection({
         Choose a preset level or customize individual rules.
       </p>
 
+      {/* Last run summary */}
+      {statusQuery.data?.last_run && (
+        <div className="mb-4 rounded-md border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-600 dark:bg-slate-700/50">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-slate-600 dark:text-slate-300">
+              Last run: {new Date(statusQuery.data.last_run.completed_at || statusQuery.data.last_run.started_at).toLocaleString()}
+              {statusQuery.data.last_run.status !== "completed" && (
+                <span className="ml-2 text-amber-600 dark:text-amber-400">
+                  ({statusQuery.data.last_run.status})
+                </span>
+              )}
+            </span>
+            <div className="flex items-center gap-3 text-xs">
+              {statusQuery.data.error_count > 0 && (
+                <span className="font-medium text-red-600 dark:text-red-400">
+                  {statusQuery.data.error_count} error{statusQuery.data.error_count !== 1 && "s"}
+                </span>
+              )}
+              {statusQuery.data.warning_count > 0 && (
+                <span className="font-medium text-amber-600 dark:text-amber-400">
+                  {statusQuery.data.warning_count} warning{statusQuery.data.warning_count !== 1 && "s"}
+                </span>
+              )}
+              {statusQuery.data.info_count > 0 && (
+                <span className="font-medium text-blue-600 dark:text-blue-400">
+                  {statusQuery.data.info_count} info
+                </span>
+              )}
+              {statusQuery.data.total_issues === 0 && (
+                <span className="font-medium text-green-600 dark:text-green-400">
+                  No issues
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
       {isLoading ? (
         <div className="flex h-16 items-center justify-center">
           <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary-200 border-t-primary-600" />
@@ -3602,28 +3676,47 @@ export function LintConfigSection({
               Lint Level
             </label>
             <div className="grid gap-2 sm:grid-cols-3">
-              {LINT_LEVEL_OPTIONS.map((opt) => (
+              {(levelsQuery.data?.levels ?? []).map((lvl) => (
                 <button
-                  key={opt.value}
-                  onClick={() => canManage && handleLevelChange(opt.value)}
+                  key={lvl.level}
+                  onClick={() => canManage && handleLevelChange(lvl.level)}
                   disabled={!canManage}
-                  aria-pressed={lintLevel === opt.value}
+                  aria-pressed={lintLevel === lvl.level}
                   className={cn(
                     "rounded-lg border p-3 text-left transition-all",
-                    lintLevel === opt.value
+                    lintLevel === lvl.level
                       ? "border-primary-500 bg-primary-50 ring-1 ring-primary-500 dark:border-primary-400 dark:bg-primary-900/20"
                       : "border-slate-200 hover:border-slate-300 dark:border-slate-600 dark:hover:border-slate-500",
                     !canManage && "cursor-not-allowed opacity-60"
                   )}
                 >
                   <p className="text-sm font-medium text-slate-900 dark:text-white">
-                    {opt.value === 0 ? opt.label : `Level ${opt.value} — ${opt.label}`}
+                    Level {lvl.level} — {lvl.name}
                   </p>
                   <p className="text-xs text-slate-500 dark:text-slate-400">
-                    {opt.description}
+                    {lvl.description} ({lvl.rule_ids.length} rules)
                   </p>
                 </button>
               ))}
+              <button
+                onClick={() => canManage && handleLevelChange(0)}
+                disabled={!canManage}
+                aria-pressed={lintLevel === 0}
+                className={cn(
+                  "rounded-lg border p-3 text-left transition-all",
+                  lintLevel === 0
+                    ? "border-primary-500 bg-primary-50 ring-1 ring-primary-500 dark:border-primary-400 dark:bg-primary-900/20"
+                    : "border-slate-200 hover:border-slate-300 dark:border-slate-600 dark:hover:border-slate-500",
+                  !canManage && "cursor-not-allowed opacity-60"
+                )}
+              >
+                <p className="text-sm font-medium text-slate-900 dark:text-white">
+                  Custom
+                </p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Choose rules individually
+                </p>
+              </button>
             </div>
           </div>
 
@@ -3721,12 +3814,20 @@ export function LintConfigSection({
             <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
           )}
 
-          {/* Save button */}
+          {/* Action buttons */}
           {canManage && (
             <div className="flex items-center justify-end gap-3">
               {success && (
                 <p className="text-sm text-green-600 dark:text-green-400">{success}</p>
               )}
+              <Button
+                onClick={handleClearResults}
+                disabled={isClearing}
+                size="sm"
+                variant="outline"
+              >
+                {isClearing ? "Clearing..." : "Clear Results"}
+              </Button>
               <Button
                 onClick={handleSave}
                 disabled={isSaving || !hasChanges}

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3675,6 +3675,7 @@ export function LintConfigSection({
               {(levelsQuery.data?.levels ?? []).map((lvl) => (
                 <button
                   key={lvl.level}
+                  type="button"
                   onClick={() => canManage && handleLevelChange(lvl.level)}
                   disabled={!canManage}
                   aria-pressed={lintLevel === lvl.level}
@@ -3695,6 +3696,7 @@ export function LintConfigSection({
                 </button>
               ))}
               <button
+                type="button"
                 onClick={() => canManage && handleLevelChange(0)}
                 disabled={!canManage}
                 aria-pressed={lintLevel === 0}
@@ -3755,6 +3757,7 @@ export function LintConfigSection({
                   >
                     {/* Toggle */}
                     <button
+                      type="button"
                       role="switch"
                       aria-checked={enabled}
                       onClick={() => handleRuleToggle(rule.rule_id)}

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -9,7 +9,7 @@ function isHttpUrl(url: string): boolean {
   }
 }
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, type SyntheticEvent } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter, useParams } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -353,7 +353,7 @@ export default function ProjectSettingsPage() {
     }
   };
 
-  const handleAddMember = async (e: React.FormEvent) => {
+  const handleAddMember = async (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!session?.accessToken || !project || !newMemberUserId) return;
 

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3495,6 +3495,11 @@ export function LintConfigSection({
     if (configQuery.data) {
       const cfg = configQuery.data;
       const level = cfg.lint_level;
+      // For preset mode, defer until levelsQuery has resolved — otherwise
+      // levelRuleMap.get(level) returns undefined and we'd flash an
+      // all-disabled state until levels load. The effect re-runs when
+      // levelRuleMap changes.
+      if (level !== null && levelRuleMap.size === 0) return;
       setLintLevel(level);
       setSavedLevel(level);
       if (level === null) {

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3356,7 +3356,7 @@ const LINT_LEVEL_OPTIONS = [
 
 const SEVERITY_ORDER: Record<string, number> = { error: 0, warning: 1, info: 2 };
 
-function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
+export function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
   switch (level) {
     case 1:
       return allRules.filter((r) => r.severity === "error").map((r) => r.rule_id);
@@ -3374,7 +3374,7 @@ function getRulesForLevel(allRules: LintRuleInfo[], level: number): string[] {
   }
 }
 
-function getSeverityColor(severity: string) {
+export function getSeverityColor(severity: string) {
   switch (severity) {
     case "error":
       return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
@@ -3387,7 +3387,7 @@ function getSeverityColor(severity: string) {
   }
 }
 
-function LintConfigSection({
+export function LintConfigSection({
   projectId,
   accessToken,
   canManage,

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -3783,6 +3783,19 @@ export function LintConfigSection({
                         >
                           {rule.severity}
                         </span>
+                        {rule.scope && (
+                          <span className="inline-flex gap-0.5">
+                            {rule.scope.map((s) => (
+                              <span
+                                key={s}
+                                className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-slate-300 text-[8px] font-bold text-slate-500 dark:border-slate-500 dark:text-slate-400"
+                                title={s}
+                              >
+                                {s[0].toUpperCase()}
+                              </span>
+                            ))}
+                          </span>
+                        )}
                       </div>
                       <p className="text-xs text-slate-500 dark:text-slate-400">
                         {rule.description}

--- a/components/editor/ClassDetailPanel.tsx
+++ b/components/editor/ClassDetailPanel.tsx
@@ -299,10 +299,8 @@ export function ClassDetailPanel({
         if (is404 && selectedNodeFallback?.iri === classIri) {
           setError(null);
         } else if (is404) {
-          const localName = classIri.includes('#')
-            ? classIri.split('#').pop()
-            : classIri.split('/').pop();
-          setError(`"${localName}" is not an OWL Class, or an individual, or a property. Enable Developer mode to see the entity in the source view.`);
+          const localName = getLocalName(classIri);
+          setError(`Could not load "${localName}" as an OWL Class. Enable Developer mode to see the entity in the source view.`);
         } else {
           setError(err instanceof Error ? err.message : "Failed to load class details");
         }

--- a/components/editor/ClassDetailPanel.tsx
+++ b/components/editor/ClassDetailPanel.tsx
@@ -302,7 +302,7 @@ export function ClassDetailPanel({
           const localName = classIri.includes('#')
             ? classIri.split('#').pop()
             : classIri.split('/').pop();
-          setError(`"${localName}" is not an OWL Class. It may be an individual, property, or other entity type.`);
+          setError(`"${localName}" is not an OWL Class, or an individual, or a property. Enable Developer mode to see the entity in the source view.`);
         } else {
           setError(err instanceof Error ? err.message : "Failed to load class details");
         }

--- a/components/editor/ClassDetailPanel.tsx
+++ b/components/editor/ClassDetailPanel.tsx
@@ -300,7 +300,7 @@ export function ClassDetailPanel({
           setError(null);
         } else if (is404) {
           const localName = getLocalName(classIri);
-          setError(`Could not load "${localName}" as an OWL Class. Enable Developer mode to see the entity in the source view.`);
+          setError(`Could not load "${localName}" as an OWL Class, or a Property, or an Individual. Enable Developer mode to see the entity in the source view.`);
         } else {
           setError(err instanceof Error ? err.message : "Failed to load class details");
         }

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -239,7 +239,14 @@ export function HealthCheckPanel({
     setIsClearing(true);
     try {
       await lintApi.clearResults(projectId, accessToken);
-      setSummary(null);
+      setSummary((prev) => prev ? {
+        ...prev,
+        last_run: null,
+        error_count: 0,
+        warning_count: 0,
+        info_count: 0,
+        total_issues: 0,
+      } : null);
       setIssues([]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to clear results");
@@ -757,8 +764,8 @@ export function HealthCheckPanel({
         </div>
       )}
 
-      {/* No issues */}
-      {!isLoading && summary && summary.total_issues === 0 && (
+      {/* No issues (only after a completed run) */}
+      {!isLoading && summary?.last_run?.status === "completed" && summary.total_issues === 0 && (
         <div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
           <CheckCircle2 className="h-12 w-12 text-green-500" />
           <p className="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -232,6 +232,22 @@ export function HealthCheckPanel({
     };
   }, [isOpen, projectId, accessToken]);
 
+  // Clear lint results
+  const [isClearing, setIsClearing] = useState(false);
+  const handleClearResults = async () => {
+    if (!accessToken) return;
+    setIsClearing(true);
+    try {
+      await lintApi.clearResults(projectId, accessToken);
+      setSummary(null);
+      setIssues([]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to clear results");
+    } finally {
+      setIsClearing(false);
+    }
+  };
+
   // Trigger a new lint run
   const handleRunLint = async () => {
     if (!accessToken) {
@@ -589,16 +605,29 @@ export function HealthCheckPanel({
           </div>
           <div className="flex items-center gap-2">
             {activeTab === "lint" && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleRunLint}
-                disabled={isRunning || !accessToken || !canRunLint}
-                className="gap-1"
-              >
-                <RefreshCw className={cn("h-4 w-4", isRunning && "animate-spin")} />
-                {isRunning ? "Running..." : "Run Lint"}
-              </Button>
+              summary?.last_run?.status === "completed" && !isRunning ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearResults}
+                  disabled={isClearing || !accessToken || !canRunLint}
+                  className="gap-1"
+                >
+                  <X className="h-4 w-4" />
+                  {isClearing ? "Clearing..." : "Clear"}
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleRunLint}
+                  disabled={isRunning || !accessToken || !canRunLint}
+                  className="gap-1"
+                >
+                  <RefreshCw className={cn("h-4 w-4", isRunning && "animate-spin")} />
+                  {isRunning ? "Running..." : "Run Lint"}
+                </Button>
+              )
             )}
             {activeTab === "consistency" && (
               <Button

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -439,7 +439,7 @@ export function HealthCheckPanel({
         setIsLoadingCachedConsistency(true);
         qualityApi.getConsistencyIssues(projectId, accessToken, branch)
           .then((r) => { if (!cancelled) setConsistencyIssues(r.issues); })
-          .catch((err) => { console.error(`Failed to load cached consistency issues for project ${projectId}:`, err); })
+          .catch((err) => { console.error("Failed to load cached consistency issues", { projectId, err }); })
           .finally(() => { if (!cancelled) setIsLoadingCachedConsistency(false); });
       });
     }
@@ -449,7 +449,7 @@ export function HealthCheckPanel({
         setIsLoadingCachedDuplicates(true);
         qualityApi.getLatestDuplicates(projectId, accessToken, branch)
           .then((r) => { if (!cancelled) setDuplicateClusters(r.clusters); })
-          .catch((err) => { console.error(`Failed to load cached duplicates for project ${projectId}:`, err); })
+          .catch((err) => { console.error("Failed to load cached duplicates", { projectId, err }); })
           .finally(() => { if (!cancelled) setIsLoadingCachedDuplicates(false); });
       });
     }

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -615,7 +615,9 @@ export function HealthCheckPanel({
           </div>
           <div className="flex items-center gap-2">
             {activeTab === "lint" && (
-              summary?.last_run?.status === "completed" && !isRunning ? (
+              // Only offer Clear when there's actually something to clear.
+              // A completed run with zero issues should re-prompt Run Lint.
+              summary?.last_run?.status === "completed" && !isRunning && summary.total_issues > 0 ? (
                 <Button
                   variant="outline"
                   size="sm"

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -22,6 +22,7 @@ import {
   type LintIssueType,
   type LintSummary,
   type LintWebSocketMessage,
+  type SubjectType,
 } from "@/lib/api/lint";
 import {
   qualityApi,
@@ -169,8 +170,9 @@ export function HealthCheckPanel({
           const allRulesCount = levels.levels.at(-1)?.rule_ids.length ?? 0;
           setLintConfigHint(`All rules (${allRulesCount})`);
         }
-      } catch {
-        // Silently ignore — hint is non-critical
+      } catch (err) {
+        // Hint is non-critical UI, but the failure must be observable.
+        console.error("Failed to fetch lint config hint:", err);
       }
     })();
     return () => { cancelled = true; };
@@ -976,12 +978,20 @@ interface IssueCardProps {
   onDismiss?: () => void;
 }
 
-const SUBJECT_TYPE_BADGE: Record<string, { letter: string; colorClass: string }> = {
+const SUBJECT_TYPE_BADGE: Record<SubjectType, { letter: string; colorClass: string }> = {
   class: { letter: "C", colorClass: "text-owl-class bg-owl-class/10 border-owl-class/50" },
   property: { letter: "P", colorClass: "text-emerald-600 bg-emerald-100/50 border-emerald-500/50 dark:text-emerald-400 dark:bg-emerald-900/20 dark:border-emerald-400/50" },
   individual: { letter: "I", colorClass: "text-violet-600 bg-violet-100/50 border-violet-500/50 dark:text-violet-400 dark:bg-violet-900/20 dark:border-violet-400/50" },
   other: { letter: "?", colorClass: "text-slate-500 bg-slate-100/50 border-slate-400/50 dark:text-slate-400 dark:bg-slate-700/50 dark:border-slate-500/50" },
 };
+
+function resolveBadgeKey(subjectType: SubjectType | null): SubjectType {
+  if (subjectType === null) return "other";
+  if (subjectType in SUBJECT_TYPE_BADGE) return subjectType;
+  // Unknown SubjectType from backend (schema drift) — surface for observability.
+  console.error("Unknown lint issue subject_type:", subjectType);
+  return "other";
+}
 
 function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
   return (
@@ -1003,11 +1013,11 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
             {issue.message}
           </p>
           {issue.subject_iri && (() => {
-            const key = issue.subject_type ?? "class";
-            const badge = SUBJECT_TYPE_BADGE[key] ?? SUBJECT_TYPE_BADGE["other"];
+            const key = resolveBadgeKey(issue.subject_type);
+            const badge = SUBJECT_TYPE_BADGE[key];
             return (
               <button
-                onClick={() => onNavigate?.(issue.subject_iri!, issue.subject_type ?? "class")}
+                onClick={() => onNavigate?.(issue.subject_iri!, key)}
                 className="mt-2 flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
                 title={issue.subject_iri}
               >
@@ -1020,10 +1030,10 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
             );
           })()}
           {/* Related entities from issue details */}
-          {issue.details && Array.isArray(issue.details.duplicate_iris) && (issue.details.duplicate_iris as string[]).length > 0 && (
+          {issue.details?.duplicate_iris && issue.details.duplicate_iris.length > 0 && (
             <div className="mt-1.5 flex flex-wrap items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
               <span>Also:</span>
-              {(issue.details.duplicate_iris as string[]).slice(0, 3).map((iri) => (
+              {issue.details.duplicate_iris.slice(0, 3).map((iri) => (
                 <button
                   key={iri}
                   onClick={() => onNavigate?.(iri, "class")}
@@ -1033,16 +1043,16 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
                   {getLocalName(iri)}
                 </button>
               ))}
-              {(issue.details.duplicate_iris as string[]).length > 3 && (
-                <span>+{(issue.details.duplicate_iris as string[]).length - 3} more</span>
+              {issue.details.duplicate_iris.length > 3 && (
+                <span>+{issue.details.duplicate_iris.length - 3} more</span>
               )}
             </div>
           )}
           {/* Conflicting values from label-per-language */}
-          {issue.details && Array.isArray(issue.details.labels) && (issue.details.labels as string[]).length > 1 && (
+          {issue.details?.labels && issue.details.labels.length > 1 && (
             <div className="mt-1.5 text-xs text-slate-500 dark:text-slate-400">
               <span>Values: </span>
-              {(issue.details.labels as string[]).map((label, i) => (
+              {issue.details.labels.map((label, i) => (
                 <span key={i}>
                   {i > 0 && ", "}
                   <span className="font-mono text-slate-600 dark:text-slate-300">&ldquo;{label}&rdquo;</span>

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -913,7 +913,8 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
             {issue.message}
           </p>
           {issue.subject_iri && (() => {
-            const badge = SUBJECT_TYPE_BADGE[issue.subject_type ?? "class"];
+            const key = issue.subject_type ?? "class";
+            const badge = SUBJECT_TYPE_BADGE[key] ?? SUBJECT_TYPE_BADGE["other"];
             return (
               <button
                 onClick={() => onNavigate?.(issue.subject_iri!, issue.subject_type ?? "class")}

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -29,6 +29,7 @@ import {
   type QualityWebSocketMessage,
 } from "@/lib/api/quality";
 import type { ConsistencyCheckResult, ConsistencyIssue, DuplicateCluster, DuplicateDetectionResult } from "@/lib/ontology/qualityTypes";
+import Link from "next/link";
 import { cn, formatDateTime, getLocalName } from "@/lib/utils";
 
 interface HealthCheckPanelProps {
@@ -89,6 +90,9 @@ export function HealthCheckPanel({
   const [isLoadingCachedConsistency, setIsLoadingCachedConsistency] = useState(false);
   const [isLoadingCachedDuplicates, setIsLoadingCachedDuplicates] = useState(false);
 
+  // Lint config hint (level name + rule count)
+  const [lintConfigHint, setLintConfigHint] = useState<string | null>(null);
+
   // Track whether the quality WebSocket is connected
   const qualityWsConnected = useRef(false);
   // Cancellation flag for the polling fallback loop
@@ -140,6 +144,37 @@ export function HealthCheckPanel({
   // Stable ref for fetchData so the WebSocket effect can call it without re-running
   const fetchDataRef = useRef(fetchData);
   useEffect(() => { fetchDataRef.current = fetchData; }, [fetchData]);
+
+  // Fetch lint config hint (level name + rule count)
+  useEffect(() => {
+    if (!isOpen || !accessToken) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [config, levels] = await Promise.all([
+          lintApi.getLintConfig(projectId, accessToken),
+          lintApi.getLevels(),
+        ]);
+        if (cancelled) return;
+        if (config.lint_level != null) {
+          const level = levels.levels.find((l) => l.level === config.lint_level);
+          if (level) {
+            setLintConfigHint(`Level ${level.level} — ${level.name} (${level.rule_ids.length} rules)`);
+          } else {
+            setLintConfigHint(`Level ${config.lint_level} (${config.effective_rules.length} rules)`);
+          }
+        } else if (config.enabled_rules) {
+          setLintConfigHint(`Custom (${config.enabled_rules.length} rules)`);
+        } else {
+          const allRulesCount = levels.levels.at(-1)?.rule_ids.length ?? 0;
+          setLintConfigHint(`All rules (${allRulesCount})`);
+        }
+      } catch {
+        // Silently ignore — hint is non-critical
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [isOpen, projectId, accessToken]);
 
   // Initial load
   useEffect(() => {
@@ -649,18 +684,33 @@ export function HealthCheckPanel({
               onClick={() => handleFilterChange("all")}
             />
           </div>
-          {summary.last_run && (
-            <div className="mt-2 flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
-              <Clock className="h-3 w-3" />
-              Last run: {formatDateTime(summary.last_run.started_at)}
-              {summary.last_run.status === "completed" && (
-                <CheckCircle2 className="ml-1 h-3 w-3 text-green-500" />
-              )}
-              {summary.last_run.status === "failed" && (
-                <XCircle className="ml-1 h-3 w-3 text-red-500" />
-              )}
-            </div>
-          )}
+          <div className="mt-2 space-y-0.5">
+            {summary.last_run && (
+              <div className="flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
+                <Clock className="h-3 w-3" />
+                Last run: {formatDateTime(summary.last_run.started_at)}
+                {summary.last_run.status === "completed" && (
+                  <CheckCircle2 className="ml-1 h-3 w-3 text-green-500" />
+                )}
+                {summary.last_run.status === "failed" && (
+                  <XCircle className="ml-1 h-3 w-3 text-red-500" />
+                )}
+              </div>
+            )}
+            {lintConfigHint && (
+              <div className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-500">
+                <Info className="h-3 w-3" />
+                {lintConfigHint}
+                <span className="mx-0.5">&mdash;</span>
+                <Link
+                  href={`/projects/${projectId}/settings#lint-config`}
+                  className="text-primary-600 hover:underline dark:text-primary-400"
+                >
+                  configure
+                </Link>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -167,8 +167,9 @@ export function HealthCheckPanel({
         } else if (config.enabled_rules) {
           setLintConfigHint(`Custom (${config.enabled_rules.length} rules)`);
         } else {
-          const allRulesCount = levels.levels.at(-1)?.rule_ids.length ?? 0;
-          setLintConfigHint(`All rules (${allRulesCount})`);
+          // No explicit config — backend's effective_rules is the authoritative
+          // count of what the linter will actually run for this project.
+          setLintConfigHint(`All rules (${config.effective_rules.length})`);
         }
       } catch (err) {
         // Hint is non-critical UI, but the failure must be observable.
@@ -994,6 +995,11 @@ function resolveBadgeKey(subjectType: SubjectType | null): SubjectType {
 }
 
 function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
+  // Resolved once so the subject button and the related-entity buttons agree
+  // on the entity type when navigating. duplicate-label and similar rules
+  // emit `duplicate_iris` for entities of the same kind as `subject_type`.
+  const subjectTypeKey = resolveBadgeKey(issue.subject_type);
+  const subjectBadge = SUBJECT_TYPE_BADGE[subjectTypeKey];
   return (
     <div
       className={cn(
@@ -1012,23 +1018,19 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
           <p className="mt-1 text-sm text-slate-700 dark:text-slate-300">
             {issue.message}
           </p>
-          {issue.subject_iri && (() => {
-            const key = resolveBadgeKey(issue.subject_type);
-            const badge = SUBJECT_TYPE_BADGE[key];
-            return (
-              <button
-                onClick={() => onNavigate?.(issue.subject_iri!, key)}
-                className="mt-2 flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
-                title={issue.subject_iri}
-              >
-                <span className={cn("flex h-4 w-4 items-center justify-center rounded-full border", badge.colorClass)}>
-                  <span className="text-[8px] font-bold">{badge.letter}</span>
-                </span>
-                {getLocalName(issue.subject_iri)}
-                <ExternalLink className="h-3 w-3 opacity-50" />
-              </button>
-            );
-          })()}
+          {issue.subject_iri && (
+            <button
+              onClick={() => onNavigate?.(issue.subject_iri!, subjectTypeKey)}
+              className="mt-2 flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
+              title={issue.subject_iri}
+            >
+              <span className={cn("flex h-4 w-4 items-center justify-center rounded-full border", subjectBadge.colorClass)}>
+                <span className="text-[8px] font-bold">{subjectBadge.letter}</span>
+              </span>
+              {getLocalName(issue.subject_iri)}
+              <ExternalLink className="h-3 w-3 opacity-50" />
+            </button>
+          )}
           {/* Related entities from issue details */}
           {issue.details?.duplicate_iris && issue.details.duplicate_iris.length > 0 && (
             <div className="mt-1.5 flex flex-wrap items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
@@ -1036,7 +1038,7 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
               {issue.details.duplicate_iris.slice(0, 3).map((iri) => (
                 <button
                   key={iri}
-                  onClick={() => onNavigate?.(iri, "class")}
+                  onClick={() => onNavigate?.(iri, subjectTypeKey)}
                   className="text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
                   title={iri}
                 >

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -137,6 +137,10 @@ export function HealthCheckPanel({
     }
   }, [projectId, accessToken, isOpen, filter]);
 
+  // Stable ref for fetchData so the WebSocket effect can call it without re-running
+  const fetchDataRef = useRef(fetchData);
+  useEffect(() => { fetchDataRef.current = fetchData; }, [fetchData]);
+
   // Initial load
   useEffect(() => {
     if (isOpen) {
@@ -158,7 +162,7 @@ export function HealthCheckPanel({
         setIsRunning(true);
       } else if (message.type === "lint_complete" || message.type === "lint_failed") {
         setIsRunning(false);
-        fetchData();
+        fetchDataRef.current();
       }
     };
 
@@ -191,7 +195,7 @@ export function HealthCheckPanel({
         ws.close();
       }
     };
-  }, [isOpen, projectId, accessToken, fetchData]);
+  }, [isOpen, projectId, accessToken]);
 
   // Trigger a new lint run
   const handleRunLint = async () => {

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -94,6 +94,9 @@ export function HealthCheckPanel({
   // Lint config hint (level name + rule count)
   const [lintConfigHint, setLintConfigHint] = useState<string | null>(null);
 
+  // Clear lint results
+  const [isClearing, setIsClearing] = useState(false);
+
   // Track whether the quality WebSocket is connected
   const qualityWsConnected = useRef(false);
   // Cancellation flag for the polling fallback loop
@@ -235,8 +238,6 @@ export function HealthCheckPanel({
     };
   }, [isOpen, projectId, accessToken]);
 
-  // Clear lint results
-  const [isClearing, setIsClearing] = useState(false);
   const handleClearResults = async () => {
     if (!accessToken) return;
     setIsClearing(true);
@@ -1026,7 +1027,11 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
               className="mt-2 flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
               title={issue.subject_iri}
             >
-              <span className={cn("flex h-4 w-4 items-center justify-center rounded-full border", subjectBadge.colorClass)}>
+              <span
+                aria-label={`subject type: ${subjectTypeKey}`}
+                data-testid={`subject-type-badge-${subjectTypeKey}`}
+                className={cn("flex h-4 w-4 items-center justify-center rounded-full border", subjectBadge.colorClass)}
+              >
                 <span className="text-[8px] font-bold">{subjectBadge.letter}</span>
               </span>
               {getLocalName(issue.subject_iri)}

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -37,7 +37,7 @@ interface HealthCheckPanelProps {
   branch?: string;
   isOpen: boolean;
   onClose: () => void;
-  onNavigateToClass?: (iri: string) => void;
+  onNavigateToClass?: (iri: string, subjectType?: string) => void;
   /** Whether the current user can trigger a lint run (requires admin/manager role) */
   canRunLint?: boolean;
 }
@@ -882,9 +882,16 @@ function SummaryCard({ label, count, color, active, onClick }: SummaryCardProps)
 
 interface IssueCardProps {
   issue: LintIssue;
-  onNavigate?: (iri: string) => void;
+  onNavigate?: (iri: string, subjectType?: string) => void;
   onDismiss?: () => void;
 }
+
+const SUBJECT_TYPE_BADGE: Record<string, { letter: string; colorClass: string }> = {
+  class: { letter: "C", colorClass: "text-owl-class bg-owl-class/10 border-owl-class/50" },
+  property: { letter: "P", colorClass: "text-emerald-600 bg-emerald-100/50 border-emerald-500/50 dark:text-emerald-400 dark:bg-emerald-900/20 dark:border-emerald-400/50" },
+  individual: { letter: "I", colorClass: "text-violet-600 bg-violet-100/50 border-violet-500/50 dark:text-violet-400 dark:bg-violet-900/20 dark:border-violet-400/50" },
+  other: { letter: "?", colorClass: "text-slate-500 bg-slate-100/50 border-slate-400/50 dark:text-slate-400 dark:bg-slate-700/50 dark:border-slate-500/50" },
+};
 
 function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
   return (
@@ -905,19 +912,22 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
           <p className="mt-1 text-sm text-slate-700 dark:text-slate-300">
             {issue.message}
           </p>
-          {issue.subject_iri && (
-            <button
-              onClick={() => onNavigate?.(issue.subject_iri!)}
-              className="mt-2 flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
-              title={issue.subject_iri}
-            >
-              <span className="flex h-4 w-4 items-center justify-center rounded-full bg-owl-class/10 border border-owl-class/50">
-                <span className="text-[8px] font-bold text-owl-class">C</span>
-              </span>
-              {getLocalName(issue.subject_iri)}
-              <ExternalLink className="h-3 w-3 opacity-50" />
-            </button>
-          )}
+          {issue.subject_iri && (() => {
+            const badge = SUBJECT_TYPE_BADGE[issue.subject_type ?? "class"];
+            return (
+              <button
+                onClick={() => onNavigate?.(issue.subject_iri!, issue.subject_type ?? "class")}
+                className="mt-2 flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
+                title={issue.subject_iri}
+              >
+                <span className={cn("flex h-4 w-4 items-center justify-center rounded-full border", badge.colorClass)}>
+                  <span className="text-[8px] font-bold">{badge.letter}</span>
+                </span>
+                {getLocalName(issue.subject_iri)}
+                <ExternalLink className="h-3 w-3 opacity-50" />
+              </button>
+            );
+          })()}
         </div>
         {onDismiss && (
           <button

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -767,7 +767,7 @@ export function HealthCheckPanel({
                       </p>
                       {issue.entity_iri && (
                         <button
-                          onClick={() => onNavigateToClass?.(issue.entity_iri)}
+                          onClick={() => onNavigateToClass?.(issue.entity_iri, issue.entity_type)}
                           className="mt-1 text-xs text-primary-600 hover:underline dark:text-primary-400"
                         >
                           {getLocalName(issue.entity_iri)}
@@ -820,7 +820,7 @@ export function HealthCheckPanel({
                     {cluster.entities.map((entity) => (
                       <button
                         key={entity.iri}
-                        onClick={() => onNavigateToClass?.(entity.iri)}
+                        onClick={() => onNavigateToClass?.(entity.iri, entity.entity_type)}
                         className="flex w-full items-center gap-2 text-left text-sm text-primary-600 hover:underline dark:text-primary-400"
                       >
                         <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-owl-class/10 border border-owl-class/50">

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -929,6 +929,37 @@ function IssueCard({ issue, onNavigate, onDismiss }: IssueCardProps) {
               </button>
             );
           })()}
+          {/* Related entities from issue details */}
+          {issue.details && Array.isArray(issue.details.duplicate_iris) && (issue.details.duplicate_iris as string[]).length > 0 && (
+            <div className="mt-1.5 flex flex-wrap items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
+              <span>Also:</span>
+              {(issue.details.duplicate_iris as string[]).slice(0, 3).map((iri) => (
+                <button
+                  key={iri}
+                  onClick={() => onNavigate?.(iri, "class")}
+                  className="text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400"
+                  title={iri}
+                >
+                  {getLocalName(iri)}
+                </button>
+              ))}
+              {(issue.details.duplicate_iris as string[]).length > 3 && (
+                <span>+{(issue.details.duplicate_iris as string[]).length - 3} more</span>
+              )}
+            </div>
+          )}
+          {/* Conflicting values from label-per-language */}
+          {issue.details && Array.isArray(issue.details.labels) && (issue.details.labels as string[]).length > 1 && (
+            <div className="mt-1.5 text-xs text-slate-500 dark:text-slate-400">
+              <span>Values: </span>
+              {(issue.details.labels as string[]).map((label, i) => (
+                <span key={i}>
+                  {i > 0 && ", "}
+                  <span className="font-mono text-slate-600 dark:text-slate-300">&ldquo;{label}&rdquo;</span>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         {onDismiss && (
           <button

--- a/components/editor/OntologySourceEditor.tsx
+++ b/components/editor/OntologySourceEditor.tsx
@@ -573,10 +573,10 @@ export const OntologySourceEditor = forwardRef<OntologySourceEditorRef, Ontology
                       </span>
                     )}
                   </div>
-                  {issue.details && Array.isArray(issue.details.duplicate_iris) && (issue.details.duplicate_iris as string[]).length > 0 && (
+                  {issue.details?.duplicate_iris && issue.details.duplicate_iris.length > 0 && (
                     <div className="mt-0.5 flex flex-wrap items-center gap-x-1 text-xs text-slate-400 dark:text-slate-500">
                       <span>Also:</span>
-                      {(issue.details.duplicate_iris as string[]).slice(0, 3).map((iri: string) => {
+                      {issue.details.duplicate_iris.slice(0, 3).map((iri) => {
                         const pos = iriIndex.get(iri);
                         return pos ? (
                           <button
@@ -592,8 +592,8 @@ export const OntologySourceEditor = forwardRef<OntologySourceEditorRef, Ontology
                           <span key={iri} title={iri}>{getLocalName(iri)}</span>
                         );
                       })}
-                      {(issue.details.duplicate_iris as string[]).length > 3 && (
-                        <span>+{(issue.details.duplicate_iris as string[]).length - 3} more</span>
+                      {issue.details.duplicate_iris.length > 3 && (
+                        <span>+{issue.details.duplicate_iris.length - 3} more</span>
                       )}
                     </div>
                   )}

--- a/components/editor/OntologySourceEditor.tsx
+++ b/components/editor/OntologySourceEditor.tsx
@@ -264,7 +264,7 @@ export const OntologySourceEditor = forwardRef<OntologySourceEditorRef, Ontology
 
     // Create Web Worker for indexing
     const worker = new Worker(
-      new URL('@/lib/editor/indexWorker.ts', import.meta.url)
+      new URL('../../lib/editor/indexWorker.ts', import.meta.url)
     );
     workerRef.current = worker;
 

--- a/components/editor/OntologySourceEditor.tsx
+++ b/components/editor/OntologySourceEditor.tsx
@@ -572,6 +572,14 @@ export const OntologySourceEditor = forwardRef<OntologySourceEditorRef, Ontology
                       </span>
                     )}
                   </div>
+                  {issue.details && Array.isArray(issue.details.duplicate_iris) && (issue.details.duplicate_iris as string[]).length > 0 && (
+                    <p className="mt-0.5 truncate text-xs text-slate-400 dark:text-slate-500">
+                      Also: {(issue.details.duplicate_iris as string[]).slice(0, 3).map((iri: string) =>
+                        iri.includes("#") ? iri.split("#").pop() : iri.split("/").pop()
+                      ).join(", ")}
+                      {(issue.details.duplicate_iris as string[]).length > 3 && ` +${(issue.details.duplicate_iris as string[]).length - 3} more`}
+                    </p>
+                  )}
                 </div>
                 <span className="flex-shrink-0 rounded-sm bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600 dark:bg-slate-700 dark:text-slate-400">
                   {issue.rule_id}

--- a/components/editor/OntologySourceEditor.tsx
+++ b/components/editor/OntologySourceEditor.tsx
@@ -7,6 +7,7 @@ import { TurtleEditor, type TurtleDiagnostic } from "./TurtleEditor";
 import { Button } from "@/components/ui/button";
 import { lintApi, type LintIssue } from "@/lib/api/lint";
 import type { IndexWorkerResult, IriPosition } from "@/lib/editor/indexWorker";
+import { getLocalName } from "@/lib/utils";
 
 export interface OntologySourceEditorProps {
   /** Project ID for lint integration */
@@ -573,12 +574,28 @@ export const OntologySourceEditor = forwardRef<OntologySourceEditorRef, Ontology
                     )}
                   </div>
                   {issue.details && Array.isArray(issue.details.duplicate_iris) && (issue.details.duplicate_iris as string[]).length > 0 && (
-                    <p className="mt-0.5 truncate text-xs text-slate-400 dark:text-slate-500">
-                      Also: {(issue.details.duplicate_iris as string[]).slice(0, 3).map((iri: string) =>
-                        iri.includes("#") ? iri.split("#").pop() : iri.split("/").pop()
-                      ).join(", ")}
-                      {(issue.details.duplicate_iris as string[]).length > 3 && ` +${(issue.details.duplicate_iris as string[]).length - 3} more`}
-                    </p>
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-1 text-xs text-slate-400 dark:text-slate-500">
+                      <span>Also:</span>
+                      {(issue.details.duplicate_iris as string[]).slice(0, 3).map((iri: string) => {
+                        const pos = iriIndex.get(iri);
+                        return pos ? (
+                          <button
+                            key={iri}
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); scrollToLine(pos.line, pos.col); }}
+                            className="text-primary-600 hover:underline dark:text-primary-400"
+                            title={iri}
+                          >
+                            {getLocalName(iri)}
+                          </button>
+                        ) : (
+                          <span key={iri} title={iri}>{getLocalName(iri)}</span>
+                        );
+                      })}
+                      {(issue.details.duplicate_iris as string[]).length > 3 && (
+                        <span>+{(issue.details.duplicate_iris as string[]).length - 3} more</span>
+                      )}
+                    </div>
                   )}
                 </div>
                 <span className="flex-shrink-0 rounded-sm bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600 dark:bg-slate-700 dark:text-slate-400">

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -256,29 +256,34 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
   const [selectedIndividualIri, setSelectedIndividualIri] = useState<string | null>(null);
 
   // Expose entity navigation to parent via ref
+  const { entityNavigationRef, navigateToNode: navToNode, setPendingScrollIri: setScrollIri } = props;
   useEffect(() => {
-    if (props.entityNavigationRef) {
-      props.entityNavigationRef.current = (iri: string, type?: string) => {
-        if (type === "property") {
-          setActiveTab("properties");
-          setSelectedPropertyIri(iri);
-        } else if (type === "individual") {
-          setActiveTab("individuals");
-          setSelectedIndividualIri(iri);
-        } else if (type === "other") {
-          // Untyped entities: switch to source view and scroll to IRI
-          setViewMode("source");
-          props.setPendingScrollIri(iri);
-        } else {
-          setActiveTab("classes");
-          props.navigateToNode(iri);
-        }
-      };
-    }
-    return () => {
-      if (props.entityNavigationRef) props.entityNavigationRef.current = null;
+    if (!entityNavigationRef) return;
+
+    const handler = (iri: string, type?: string) => {
+      if (type === "property") {
+        setActiveTab("properties");
+        setSelectedPropertyIri(iri);
+      } else if (type === "individual") {
+        setActiveTab("individuals");
+        setSelectedIndividualIri(iri);
+      } else if (type === "other") {
+        // Untyped entities: switch to source view and scroll to IRI
+        setViewMode("source");
+        setScrollIri(iri);
+      } else {
+        setActiveTab("classes");
+        navToNode(iri);
+      }
     };
-  }, [props.entityNavigationRef, props.navigateToNode, props.setPendingScrollIri]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    entityNavigationRef.current = handler;
+    return () => {
+      if (entityNavigationRef.current === handler) {
+        entityNavigationRef.current = null;
+      }
+    };
+  }, [entityNavigationRef, navToNode, setScrollIri]);
 
   // Shared search state
   const {

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -113,6 +113,9 @@ export interface DeveloperEditorLayoutProps {
   onReparentClass?: (classIri: string, oldParentIris: string[], newParentIris: string[], mode: DragMode) => Promise<void>;
   reparentOptimistic?: (iri: string, oldParentIri: string | null, newParentIri: string | null) => { previousNodes: ClassTreeNode[] };
   rollbackReparent?: (snapshot: { previousNodes: ClassTreeNode[] }) => void;
+
+  /** Ref populated with a function to navigate to any entity type */
+  entityNavigationRef?: React.RefObject<((iri: string, type?: string) => void) | null>;
 }
 
 export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
@@ -251,6 +254,27 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
   // Track selected entity per tab (properties/individuals have their own selection)
   const [selectedPropertyIri, setSelectedPropertyIri] = useState<string | null>(null);
   const [selectedIndividualIri, setSelectedIndividualIri] = useState<string | null>(null);
+
+  // Expose entity navigation to parent via ref
+  useEffect(() => {
+    if (props.entityNavigationRef) {
+      props.entityNavigationRef.current = (iri: string, type?: string) => {
+        if (type === "property") {
+          setActiveTab("properties");
+          setSelectedPropertyIri(iri);
+        } else if (type === "individual") {
+          setActiveTab("individuals");
+          setSelectedIndividualIri(iri);
+        } else {
+          setActiveTab("classes");
+          props.navigateToNode(iri);
+        }
+      };
+    }
+    return () => {
+      if (props.entityNavigationRef) props.entityNavigationRef.current = null;
+    };
+  }, [props.entityNavigationRef, props.navigateToNode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Shared search state
   const {

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -265,6 +265,9 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
         } else if (type === "individual") {
           setActiveTab("individuals");
           setSelectedIndividualIri(iri);
+        } else if (type === "other") {
+          // Untyped entities: scroll to them in the source view
+          props.setPendingScrollIri(iri);
         } else {
           setActiveTab("classes");
           props.navigateToNode(iri);
@@ -274,7 +277,7 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
     return () => {
       if (props.entityNavigationRef) props.entityNavigationRef.current = null;
     };
-  }, [props.entityNavigationRef, props.navigateToNode]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [props.entityNavigationRef, props.navigateToNode, props.setPendingScrollIri]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Shared search state
   const {

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -266,7 +266,8 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
           setActiveTab("individuals");
           setSelectedIndividualIri(iri);
         } else if (type === "other") {
-          // Untyped entities: scroll to them in the source view
+          // Untyped entities: switch to source view and scroll to IRI
+          setViewMode("source");
           props.setPendingScrollIri(iri);
         } else {
           setActiveTab("classes");

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -230,6 +230,10 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
         } else if (type === "individual") {
           setActiveTab("individuals");
           setSelectedIndividualIri(iri);
+        } else if (type === "other") {
+          // Untyped entities can't be shown in Standard mode — navigating
+          // to the class tree would show a misleading error. Do nothing;
+          // the ClassDetailPanel already shows a helpful message.
         } else {
           setActiveTab("classes");
           props.navigateToNode(iri);

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -96,8 +96,7 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
     accessToken,
     activeBranch,
     canEdit,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    canSuggest = false,
+    canSuggest: _canSuggest = false,
     isSuggestionMode = false,
     nodes,
     isTreeLoading,

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -221,27 +221,32 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
   const [selectedIndividualIri, setSelectedIndividualIri] = useState<string | null>(null);
 
   // Expose entity navigation to parent via ref
+  const { entityNavigationRef, navigateToNode: navToNode } = props;
   useEffect(() => {
-    if (props.entityNavigationRef) {
-      props.entityNavigationRef.current = (iri: string, type?: string) => {
-        if (type === "property") {
-          setActiveTab("properties");
-          setSelectedPropertyIri(iri);
-        } else if (type === "individual") {
-          setActiveTab("individuals");
-          setSelectedIndividualIri(iri);
-        } else {
-          // For "other" (untyped) entities, navigate to class tree which
-          // triggers ClassDetailPanel's 404 handler with a helpful message
-          setActiveTab("classes");
-          props.navigateToNode(iri);
-        }
-      };
-    }
-    return () => {
-      if (props.entityNavigationRef) props.entityNavigationRef.current = null;
+    if (!entityNavigationRef) return;
+
+    const handler = (iri: string, type?: string) => {
+      if (type === "property") {
+        setActiveTab("properties");
+        setSelectedPropertyIri(iri);
+      } else if (type === "individual") {
+        setActiveTab("individuals");
+        setSelectedIndividualIri(iri);
+      } else {
+        // For "other" (untyped) entities, navigate to class tree which
+        // triggers ClassDetailPanel's 404 handler with a helpful message
+        setActiveTab("classes");
+        navToNode(iri);
+      }
     };
-  }, [props.entityNavigationRef, props.navigateToNode]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    entityNavigationRef.current = handler;
+    return () => {
+      if (entityNavigationRef.current === handler) {
+        entityNavigationRef.current = null;
+      }
+    };
+  }, [entityNavigationRef, navToNode]);
 
   // Shared search state
   const {

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -85,6 +85,9 @@ export interface StandardEditorLayoutProps {
   onReparentClass?: (classIri: string, oldParentIris: string[], newParentIris: string[], mode: DragMode) => Promise<void>;
   reparentOptimistic?: (iri: string, oldParentIri: string | null, newParentIri: string | null) => { previousNodes: ClassTreeNode[] };
   rollbackReparent?: (snapshot: { previousNodes: ClassTreeNode[] }) => void;
+
+  /** Ref populated with a function to navigate to any entity type */
+  entityNavigationRef?: React.RefObject<((iri: string, type?: string) => void) | null>;
 }
 
 export function StandardEditorLayout(props: StandardEditorLayoutProps) {
@@ -216,6 +219,27 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
   // Track selected entity per tab (properties/individuals have their own selection)
   const [selectedPropertyIri, setSelectedPropertyIri] = useState<string | null>(null);
   const [selectedIndividualIri, setSelectedIndividualIri] = useState<string | null>(null);
+
+  // Expose entity navigation to parent via ref
+  useEffect(() => {
+    if (props.entityNavigationRef) {
+      props.entityNavigationRef.current = (iri: string, type?: string) => {
+        if (type === "property") {
+          setActiveTab("properties");
+          setSelectedPropertyIri(iri);
+        } else if (type === "individual") {
+          setActiveTab("individuals");
+          setSelectedIndividualIri(iri);
+        } else {
+          setActiveTab("classes");
+          props.navigateToNode(iri);
+        }
+      };
+    }
+    return () => {
+      if (props.entityNavigationRef) props.entityNavigationRef.current = null;
+    };
+  }, [props.entityNavigationRef, props.navigateToNode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Shared search state
   const {

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -230,11 +230,9 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
         } else if (type === "individual") {
           setActiveTab("individuals");
           setSelectedIndividualIri(iri);
-        } else if (type === "other") {
-          // Untyped entities can't be shown in Standard mode — navigating
-          // to the class tree would show a misleading error. Do nothing;
-          // the ClassDetailPanel already shows a helpful message.
         } else {
+          // For "other" (untyped) entities, navigate to class tree which
+          // triggers ClassDetailPanel's 404 handler with a helpful message
           setActiveTab("classes");
           props.navigateToNode(iri);
         }

--- a/components/editor/standard/StandardEditorLayout.tsx
+++ b/components/editor/standard/StandardEditorLayout.tsx
@@ -226,6 +226,9 @@ export function StandardEditorLayout(props: StandardEditorLayoutProps) {
     if (!entityNavigationRef) return;
 
     const handler = (iri: string, type?: string) => {
+      // Always exit graph view first — otherwise the user clicks a lint issue
+      // and stays staring at the graph instead of the entity they navigated to.
+      setShowGraph(false);
       if (type === "property") {
         setActiveTab("properties");
         setSelectedPropertyIri(iri);

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -108,14 +108,17 @@ export interface LintLevelsResponse {
 }
 
 /**
- * Lint configuration payload. `lint_level: null` discriminates "custom" mode,
- * where `enabled_rules` is the explicit rule list to apply. When `lint_level`
- * is set, the backend ignores `enabled_rules`.
+ * Lint configuration payload. The two modes are mutually exclusive — the
+ * backend's `enforce_xor` validator rejects requests that set both fields.
+ * Modeling this as a discriminated union prevents the bad combination from
+ * compiling.
+ *
+ * - **preset**: `{ lint_level: 1..5 }` — backend computes effective_rules.
+ * - **custom**: `{ lint_level: null, enabled_rules: [...] }` — explicit rules.
  */
-export interface LintConfig {
-  lint_level: LintLevel | null;
-  enabled_rules: string[];
-}
+export type LintConfig =
+  | { lint_level: LintLevel; enabled_rules?: never }
+  | { lint_level: null; enabled_rules: string[] };
 
 export interface LintConfigResponse {
   project_id: string;

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -75,13 +75,28 @@ export interface LintRulesResponse {
   rules: LintRuleInfo[];
 }
 
+export interface LintLevelInfo {
+  level: number;
+  name: string;
+  description: string;
+  rule_ids: string[];
+}
+
+export interface LintLevelsResponse {
+  levels: LintLevelInfo[];
+}
+
 export interface LintConfig {
-  lint_level: number; // 1-5 for presets, 0 for custom
-  enabled_rules: string[]; // rule_id list (used when lint_level is 0/custom)
+  lint_level: number | null; // 1-5 for presets, null for custom
+  enabled_rules: string[]; // rule_id list (used when lint_level is null/custom)
 }
 
 export interface LintConfigResponse {
-  config: LintConfig;
+  project_id: string;
+  lint_level: number | null;
+  enabled_rules: string[] | null;
+  effective_rules: string[];
+  updated_at: string | null;
 }
 
 // WebSocket message types
@@ -176,6 +191,11 @@ export const lintApi = {
   getRules: () => api.get<LintRulesResponse>("/api/v1/projects/lint/rules"),
 
   /**
+   * Get lint level definitions (which rules are in each level)
+   */
+  getLevels: () => api.get<LintLevelsResponse>("/api/v1/projects/lint/levels"),
+
+  /**
    * Get lint configuration for a project
    */
   getLintConfig: (projectId: string, token?: string) =>
@@ -194,6 +214,14 @@ export const lintApi = {
         headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       }
     ),
+
+  /**
+   * Clear all lint results (runs and issues) for a project
+   */
+  clearResults: (projectId: string, token: string) =>
+    api.delete(`/api/v1/projects/${projectId}/lint/results`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
 };
 
 /**

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -8,6 +8,8 @@ import { api } from "./client";
 export type LintIssueType = "error" | "warning" | "info";
 export type LintRunStatus = "pending" | "running" | "completed" | "failed";
 export type SubjectType = "class" | "property" | "individual" | "other";
+/** Numeric preset levels exposed by the backend's `/lint/levels` endpoint. */
+export type LintLevel = 1 | 2 | 3 | 4 | 5;
 
 /**
  * Known fields the backend populates inside `LintIssue.details`.
@@ -95,7 +97,7 @@ export interface LintRulesResponse {
 }
 
 export interface LintLevelInfo {
-  level: number;
+  level: LintLevel;
   name: string;
   description: string;
   rule_ids: string[];
@@ -105,14 +107,19 @@ export interface LintLevelsResponse {
   levels: LintLevelInfo[];
 }
 
+/**
+ * Lint configuration payload. `lint_level: null` discriminates "custom" mode,
+ * where `enabled_rules` is the explicit rule list to apply. When `lint_level`
+ * is set, the backend ignores `enabled_rules`.
+ */
 export interface LintConfig {
-  lint_level: number | null; // 1-5 for presets, null for custom
-  enabled_rules: string[]; // rule_id list (used when lint_level is null/custom)
+  lint_level: LintLevel | null;
+  enabled_rules: string[];
 }
 
 export interface LintConfigResponse {
   project_id: string;
-  lint_level: number | null;
+  lint_level: LintLevel | null;
   enabled_rules: string[] | null;
   effective_rules: string[];
   updated_at: string | null;

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -7,6 +7,7 @@ import { api } from "./client";
 // Types
 export type LintIssueType = "error" | "warning" | "info";
 export type LintRunStatus = "pending" | "running" | "completed" | "failed";
+export type SubjectType = "class" | "property" | "individual" | "other";
 
 export interface LintIssue {
   id: string;
@@ -16,6 +17,7 @@ export interface LintIssue {
   rule_id: string;
   message: string;
   subject_iri: string | null;
+  subject_type: SubjectType | null;
   details: Record<string, unknown> | null;
   created_at: string;
   resolved_at: string | null;

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -75,6 +75,15 @@ export interface LintRulesResponse {
   rules: LintRuleInfo[];
 }
 
+export interface LintConfig {
+  lint_level: number; // 1-5 for presets, 0 for custom
+  enabled_rules: string[]; // rule_id list (used when lint_level is 0/custom)
+}
+
+export interface LintConfigResponse {
+  config: LintConfig;
+}
+
 // WebSocket message types
 export interface LintWebSocketMessage {
   type: "lint_started" | "lint_complete" | "lint_failed";
@@ -165,6 +174,26 @@ export const lintApi = {
    * Get the list of available lint rules
    */
   getRules: () => api.get<LintRulesResponse>("/api/v1/projects/lint/rules"),
+
+  /**
+   * Get lint configuration for a project
+   */
+  getLintConfig: (projectId: string, token?: string) =>
+    api.get<LintConfigResponse>(`/api/v1/projects/${projectId}/lint/config`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    }),
+
+  /**
+   * Update lint configuration for a project
+   */
+  updateLintConfig: (projectId: string, config: LintConfig, token?: string) =>
+    api.put<LintConfigResponse>(
+      `/api/v1/projects/${projectId}/lint/config`,
+      config,
+      {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      }
+    ),
 };
 
 /**

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -71,6 +71,7 @@ export interface LintRuleInfo {
   name: string;
   description: string;
   severity: LintIssueType;
+  scope: string[];
 }
 
 export interface LintRulesResponse {

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -9,6 +9,22 @@ export type LintIssueType = "error" | "warning" | "info";
 export type LintRunStatus = "pending" | "running" | "completed" | "failed";
 export type SubjectType = "class" | "property" | "individual" | "other";
 
+/**
+ * Known fields the backend populates inside `LintIssue.details`.
+ *
+ * Add fields here when introducing a new lint rule that emits structured
+ * payload data. The index signature keeps the type forward-compatible with
+ * unknown rules, but consumers should validate at runtime before reading
+ * unknown keys.
+ */
+export interface LintIssueDetails {
+  /** Other entity IRIs that share the offending property (duplicate-label, etc.) */
+  duplicate_iris?: string[];
+  /** Conflicting label values (label-per-language) */
+  labels?: string[];
+  [key: string]: unknown;
+}
+
 export interface LintIssue {
   id: string;
   run_id: string;
@@ -18,7 +34,7 @@ export interface LintIssue {
   message: string;
   subject_iri: string | null;
   subject_type: SubjectType | null;
-  details: Record<string, unknown> | null;
+  details: LintIssueDetails | null;
   created_at: string;
   resolved_at: string | null;
 }


### PR DESCRIPTION
## Summary

Adds a lint rule configuration UI in project settings, along with several bug fixes and improvements to the linting system.

### Lint Configuration UI
- New **LintConfigSection** component in project settings with level presets and custom rule selection
- Level definitions fetched from the backend `/lint/levels` endpoint (not computed by severity)
- Five progressive levels grouped by concern: Critical, Consistency, Labels, Quality, All
- Custom mode sends `lint_level: null` with explicit `enabled_rules` list
- Last run summary (error/warning/info counts) displayed in settings
- **Clear Results** button to wipe lint runs before re-running with different rules
- Read-only view for non-admin users; empty-state when no source file exists
- Guard against background refetches overwriting unsaved edits

### Lint Rule Fixes (backend, paired with ontokit-api PR)
- **label-per-language**: Check each predicate independently (rdfs:label, skos:prefLabel only); exclude skos:altLabel and skos:hiddenLabel which are unconstrained per SKOS spec
- **duplicate-triple**: Use `o.n3()` instead of `str(o)` to preserve language tags in comparisons
- **missing-language-tag**: New rule warning when label/annotation predicates lack language tags
- **missing-type-declaration**: New rule warning when resources have no `rdf:type` declaration
- **missing-comment**: Moved from Level 4 to Level 3 (label quality checks)
- Level metadata renamed for clarity (Level 2: "Consistency" instead of "Structural")
- Rule scope metadata added (class/property/individual) displayed as badges

### Entity-Aware Navigation (Closes #173)
- Lint issues now carry `subject_type` ("class", "property", "individual", "other")
- Health check IssueCard shows entity type badge (C/P/I/?) with distinct colors
- Clicking a lint issue navigates to the correct detail view tab (classes, properties, or individuals)
- `entityNavigationRef` on StandardEditorLayout and DeveloperEditorLayout routes to the appropriate tab
- "Other" (untyped) entities: Developer mode scrolls to source view; Standard mode shows helpful error

### Related Entities in Lint Issues (Closes #172)
- **duplicate-label**: Shows clickable links to other resources sharing the label (from `details.duplicate_iris`)
- **label-per-language**: Shows the conflicting label values inline
- Source editor problems panel: shows duplicate IRIs in compact form
- "+N more" indicator when there are many related entities

### Other Fixes
- Fix `LintConfigResponse` type to match flat backend response (was incorrectly nested under `.config`, causing the original TypeError)
- Fix web worker URL for Turbopack compatibility (relative path instead of `@/` alias)
- Add `skos:hiddenLabel` to backend annotation extraction (Closes CatholicOS/ontokit-api#95)
- Consistency and Duplicates tab navigation now passes entity type
- Defensive `SUBJECT_TYPE_BADGE` lookup with fallback to "other"
- `type="button"` on all non-submit buttons in lint config UI

## Test Plan

- [x] Select each lint level preset and verify correct rules are toggled
- [x] Select Custom mode, enable a single rule, save — verify config persists on reload
- [x] Clear results, re-run lint, verify fresh results
- [x] Verify last run summary counts display in settings
- [x] Verify non-admin users see read-only lint config
- [x] Verify entity type badges (C/P/I/?) appear on lint issues
- [x] Click a property/individual lint issue and verify navigation to correct tab
- [x] Click an "other" (untyped) entity — Developer mode scrolls to source, Standard mode shows error
- [x] Verify `skos:hiddenLabel` appears in class detail panel after reindex
- [x] Verify duplicate-label issues show clickable related entity links
- [x] Verify label-per-language issues show conflicting values
- [x] All 2656 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lint configuration UI: severity presets, custom rule mode, severity styling, header icon, save/clear/run actions
  * Read-only project settings that surface lint config when management is unavailable
  * Imperative editor navigation ref to jump to classes/properties/individuals/other

* **Bug Fixes**
  * Clearer entity-loading error messages
  * Improved duplicate-entity display with related-item navigation and “+N more” collapsing

* **Tests**
  * Expanded test coverage for lint UI, API endpoints, health checks, editor navigation, and problem panel behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->