### PR TITLE
docs: add v0.3.0 changelog and release checklist reminder

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,6 +60,10 @@ OntoKit Web uses a two-branch model:
 
 Releases follow a Weblate-inspired workflow. All commands below are run from the `ontokit-web/` directory.
 
+### 0. Update the documentation changelog
+
+Before preparing the release, add an entry for the new version to the in-app changelog at `app/docs/changelog/page.tsx`. Summarize the release highlights (new features, improvements, bug fixes) so users can see what changed at `/docs/changelog`.
+
 ### 1. Prepare the release (on `dev`)
 
 ```bash

--- a/app/docs/changelog/page.tsx
+++ b/app/docs/changelog/page.tsx
@@ -11,6 +11,65 @@ interface ChangelogEntry {
 
 const changelog: ChangelogEntry[] = [
   {
+    version: "0.3.0",
+    date: "2026-04-09",
+    categories: [
+      {
+        title: "New features",
+        items: [
+          "Projects list as landing page with Public, My Projects, Private, and All tabs.",
+          "Separate viewer and editor routes for projects with role-appropriate default views.",
+          "Ontology search index management UI for PostgreSQL-backed entity indexing.",
+          "Multi-page Ontology Guide documentation accessible from the app.",
+          "Upstream source loop prevention UI with informational banners when sync config matches GitHub integration.",
+          "Exemplar ontology support in project UI for template-based project creation.",
+          "Explicit Save button in detail panel edit mode.",
+          "Branch topology visualization in revision history graph.",
+          "Share button to copy project permalink.",
+          "Unfiltered project count shown when search or filter is active.",
+        ],
+      },
+      {
+        title: "Improvements",
+        items: [
+          "Upgraded to Next.js 16, Tailwind CSS 4, Zod 4, and lucide-react 1.7.",
+          "Renamed 'upstream sync' to 'remote sync' / 'Sync from Remote' for clarity.",
+          "Renamed misleading 'Private' tab to 'My Projects'.",
+          "Skip project dashboard — navigate directly to editor.",
+          "Improved auth UX for private projects in the editor.",
+          "Improved import error UX with server-reachability probe.",
+          "Improved lint issue display consistency and prevented UI freeze on large rule sets.",
+          "Replaced window.location.reload() with React Query refetch for smoother navigation.",
+          "Removed accessToken from React Query keys to prevent unnecessary refetches.",
+          "Disabled branch switching for unauthenticated users.",
+          "Moved Tooltip provider to app level for shared usage.",
+          "Docker deployment configuration with multi-stage build.",
+          "Test coverage increased to 80% with 2400+ tests.",
+        ],
+      },
+      {
+        title: "Bug fixes",
+        items: [
+          "Fixed viewer source tab appearing empty in developer mode.",
+          "Fixed total project count not shown with Load More pagination.",
+          "Fixed duplicate BranchBadge in editor header.",
+          "Fixed nullable index fields from API causing runtime errors.",
+          "Fixed manualSave prop renamed to hideSaveButton with correct default behavior.",
+          "Fixed exhaustive-deps false positive in useProjectViewer.",
+          "Resolved Dependabot security alerts and CodeQL findings.",
+        ],
+      },
+      {
+        title: "CI/CD & Quality",
+        items: [
+          "Split CI quality gate into parallel lint, type-check, test, and build jobs.",
+          "Added Codecov bundle analysis and test coverage reporting.",
+          "Upgraded Vite to 8.0.7 for security fix.",
+        ],
+      },
+    ],
+  },
+  {
     version: "0.2.0",
     date: "2026-03-09",
     categories: [


### PR DESCRIPTION
## Summary

- Add v0.3.0 entry to the in-app documentation changelog (`/docs/changelog`) covering new features, improvements, bug fixes, and CI/CD changes
- Add step 0 to `RELEASING.md` reminding maintainers to update the documentation changelog before preparing a release, so this doesn't get missed again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version 0.3.0 changelog entry to in-app documentation, featuring new features, improvements, bug fixes, and quality updates now visible at `/docs/changelog`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->