### PR TITLE
feat: replace index status polling with WebSocket updates

### DIFF
--- a/__tests__/lib/api/indexStatus.test.ts
+++ b/__tests__/lib/api/indexStatus.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  createIndexWebSocket,
+  IndexWebSocketManager,
+} from "@/lib/api/indexStatus";
+
+// --- WebSocket mock ---
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onclose: ((ev: { code: number }) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+
+  close = vi.fn();
+  send = vi.fn();
+
+  constructor(public url: string) {}
+}
+
+// --- createIndexWebSocket ---
+
+describe("createIndexWebSocket", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    delete process.env.NEXT_PUBLIC_WS_URL;
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("creates WebSocket with NEXT_PUBLIC_WS_URL when set", () => {
+    process.env.NEXT_PUBLIC_WS_URL = "ws://custom:9000";
+    const onMessage = vi.fn();
+
+    const ws = createIndexWebSocket("p1", onMessage);
+
+    expect(ws.url).toBe("ws://custom:9000/api/v1/projects/p1/ontology/index-ws");
+  });
+
+  it("falls back to NEXT_PUBLIC_API_URL with ws:// replacement", () => {
+    process.env.NEXT_PUBLIC_API_URL = "http://api-host:8080";
+    const onMessage = vi.fn();
+
+    const ws = createIndexWebSocket("p1", onMessage);
+
+    expect(ws.url).toBe("ws://api-host:8080/api/v1/projects/p1/ontology/index-ws");
+  });
+
+  it("falls back to ws://localhost:8000 when no env vars set", () => {
+    const onMessage = vi.fn();
+
+    const ws = createIndexWebSocket("p1", onMessage);
+
+    expect(ws.url).toBe("ws://localhost:8000/api/v1/projects/p1/ontology/index-ws");
+  });
+
+  it("calls onMessage with parsed JSON data on ws.onmessage", () => {
+    const onMessage = vi.fn();
+    const ws = createIndexWebSocket("p1", onMessage);
+
+    const msg = { type: "index_started", project_id: "p1" };
+    ws.onmessage!({ data: JSON.stringify(msg) } as MessageEvent);
+
+    expect(onMessage).toHaveBeenCalledWith(msg);
+  });
+
+  it("handles JSON parse error in onmessage gracefully", () => {
+    const onMessage = vi.fn();
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const ws = createIndexWebSocket("p1", onMessage);
+    ws.onmessage!({ data: "not-json" } as MessageEvent);
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Failed to parse index WebSocket message:",
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("calls onError when ws.onerror fires", () => {
+    const onMessage = vi.fn();
+    const onError = vi.fn();
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const ws = createIndexWebSocket("p1", onMessage, onError);
+    const errorEvent = new Event("error");
+    ws.onerror!(errorEvent);
+
+    expect(onError).toHaveBeenCalledWith(errorEvent);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("calls onClose when ws.onclose fires", () => {
+    const onMessage = vi.fn();
+    const onClose = vi.fn();
+
+    const ws = createIndexWebSocket("p1", onMessage, undefined, onClose);
+    const closeEvent = { code: 1000 } as CloseEvent;
+    ws.onclose!(closeEvent);
+
+    expect(onClose).toHaveBeenCalledWith(closeEvent);
+  });
+});
+
+// --- IndexWebSocketManager ---
+
+describe("IndexWebSocketManager", () => {
+  let constructedInstances: MockWebSocket[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    constructedInstances = [];
+
+    const OrigMock = MockWebSocket;
+    global.WebSocket = class extends OrigMock {
+      constructor(url: string) {
+        super(url);
+        constructedInstances.push(this);
+      }
+    } as unknown as typeof WebSocket;
+
+    // Suppress console.error from onerror handler
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    delete process.env.NEXT_PUBLIC_WS_URL;
+    delete process.env.NEXT_PUBLIC_API_URL;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("connect() creates a WebSocket", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    expect(constructedInstances).toHaveLength(1);
+    expect(constructedInstances[0].url).toBe(
+      "ws://localhost:8000/api/v1/projects/p1/ontology/index-ws"
+    );
+  });
+
+  it("connect() does not create duplicate if already OPEN", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    // First WebSocket is OPEN by default (MockWebSocket.readyState = OPEN)
+    mgr.connect();
+
+    expect(constructedInstances).toHaveLength(1);
+  });
+
+  it("disconnect() closes WebSocket and resets state", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    const ws = constructedInstances[0];
+    mgr.disconnect();
+
+    expect(ws.close).toHaveBeenCalledWith(1000, "Client closing connection");
+  });
+
+  it("reconnects on error with exponential backoff up to 5 attempts", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const ws = constructedInstances[constructedInstances.length - 1];
+      ws.readyState = MockWebSocket.CLOSED;
+
+      ws.onerror!(new Event("error"));
+
+      const delay = 1000 * Math.pow(2, attempt - 1);
+      vi.advanceTimersByTime(delay);
+    }
+
+    // 1 initial + 5 reconnect attempts = 6 total
+    expect(constructedInstances).toHaveLength(6);
+  });
+
+  it("does not exceed maxReconnectAttempts (5)", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const ws = constructedInstances[constructedInstances.length - 1];
+      ws.readyState = MockWebSocket.CLOSED;
+      ws.onerror!(new Event("error"));
+      vi.advanceTimersByTime(1000 * Math.pow(2, attempt - 1));
+    }
+
+    // 6th error should not trigger another reconnect
+    const ws = constructedInstances[constructedInstances.length - 1];
+    ws.readyState = MockWebSocket.CLOSED;
+    ws.onerror!(new Event("error"));
+    vi.advanceTimersByTime(100000);
+
+    // Still 6 total (1 initial + 5 reconnects), no 7th
+    expect(constructedInstances).toHaveLength(6);
+  });
+
+  it("does NOT reconnect after disconnect() is called", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    mgr.disconnect();
+
+    const ws = constructedInstances[0];
+    ws.readyState = MockWebSocket.CLOSED;
+    ws.onerror!(new Event("error"));
+    vi.advanceTimersByTime(10000);
+
+    expect(constructedInstances).toHaveLength(1);
+  });
+
+  it("does NOT reconnect on normal close (code 1000)", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    const ws = constructedInstances[0];
+    ws.readyState = MockWebSocket.CLOSED;
+
+    ws.onclose!({ code: 1000 } as CloseEvent);
+    vi.advanceTimersByTime(10000);
+
+    expect(constructedInstances).toHaveLength(1);
+  });
+
+  it("reconnects on abnormal close (code !== 1000)", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    const ws = constructedInstances[0];
+    ws.readyState = MockWebSocket.CLOSED;
+
+    ws.onclose!({ code: 1006 } as CloseEvent);
+    vi.advanceTimersByTime(1000);
+
+    expect(constructedInstances).toHaveLength(2);
+  });
+});

--- a/__tests__/lib/api/indexStatus.test.ts
+++ b/__tests__/lib/api/indexStatus.test.ts
@@ -12,16 +12,34 @@ class MockWebSocket {
   static CLOSING = 2;
   static CLOSED = 3;
 
-  readyState = MockWebSocket.OPEN;
+  readyState = MockWebSocket.CONNECTING;
   onopen: (() => void) | null = null;
   onclose: ((ev: { code: number }) => void) | null = null;
   onerror: ((ev: Event) => void) | null = null;
   onmessage: ((ev: { data: string }) => void) | null = null;
 
+  private listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+
   close = vi.fn();
   send = vi.fn();
 
   constructor(public url: string) {}
+
+  addEventListener(event: string, cb: (...args: unknown[]) => void) {
+    (this.listeners[event] ??= []).push(cb);
+  }
+
+  dispatchEvent(event: Event) {
+    for (const cb of this.listeners[event.type] ?? []) cb(event);
+    return true;
+  }
+
+  /** Test helper: simulate successful open */
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+    this.dispatchEvent(new Event("open"));
+  }
 }
 
 // --- createIndexWebSocket ---
@@ -63,6 +81,32 @@ describe("createIndexWebSocket", () => {
     const ws = createIndexWebSocket("p1", onMessage);
 
     expect(ws.url).toBe("ws://localhost:8000/api/v1/projects/p1/ontology/index-ws");
+  });
+
+  it("appends encoded token query param when token is provided", () => {
+    const onMessage = vi.fn();
+
+    const ws = createIndexWebSocket("p1", onMessage, undefined, undefined, "my-secret-token");
+
+    expect(ws.url).toBe(
+      "ws://localhost:8000/api/v1/projects/p1/ontology/index-ws?token=my-secret-token"
+    );
+  });
+
+  it("encodes special characters in token", () => {
+    const onMessage = vi.fn();
+
+    const ws = createIndexWebSocket("p1", onMessage, undefined, undefined, "tok en+foo=bar");
+
+    expect(ws.url).toContain(`?token=${encodeURIComponent("tok en+foo=bar")}`);
+  });
+
+  it("omits token query param when token is undefined", () => {
+    const onMessage = vi.fn();
+
+    const ws = createIndexWebSocket("p1", onMessage);
+
+    expect(ws.url).not.toContain("?token=");
   });
 
   it("calls onMessage with parsed JSON data on ws.onmessage", () => {
@@ -156,11 +200,28 @@ describe("IndexWebSocketManager", () => {
     );
   });
 
+  it("connect() passes token to the WebSocket URL", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn(), "my-token");
+    mgr.connect();
+
+    expect(constructedInstances[0].url).toContain("?token=my-token");
+  });
+
   it("connect() does not create duplicate if already OPEN", () => {
     const mgr = new IndexWebSocketManager("p1", vi.fn());
     mgr.connect();
 
-    // First WebSocket is OPEN by default (MockWebSocket.readyState = OPEN)
+    constructedInstances[0].simulateOpen();
+    mgr.connect();
+
+    expect(constructedInstances).toHaveLength(1);
+  });
+
+  it("connect() does not create duplicate if still CONNECTING", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+
+    // readyState is CONNECTING by default, second connect should be a no-op
     mgr.connect();
 
     expect(constructedInstances).toHaveLength(1);
@@ -179,6 +240,7 @@ describe("IndexWebSocketManager", () => {
   it("reconnects on error with exponential backoff up to 5 attempts", () => {
     const mgr = new IndexWebSocketManager("p1", vi.fn());
     mgr.connect();
+    constructedInstances[0].simulateOpen();
 
     for (let attempt = 1; attempt <= 5; attempt++) {
       const ws = constructedInstances[constructedInstances.length - 1];
@@ -197,6 +259,7 @@ describe("IndexWebSocketManager", () => {
   it("does not exceed maxReconnectAttempts (5)", () => {
     const mgr = new IndexWebSocketManager("p1", vi.fn());
     mgr.connect();
+    constructedInstances[0].simulateOpen();
 
     for (let attempt = 1; attempt <= 5; attempt++) {
       const ws = constructedInstances[constructedInstances.length - 1];
@@ -215,9 +278,41 @@ describe("IndexWebSocketManager", () => {
     expect(constructedInstances).toHaveLength(6);
   });
 
+  it("resets retry budget on successful reconnection", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+    constructedInstances[0].simulateOpen();
+
+    // Use 3 reconnect attempts
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const ws = constructedInstances[constructedInstances.length - 1];
+      ws.readyState = MockWebSocket.CLOSED;
+      ws.onerror!(new Event("error"));
+      vi.advanceTimersByTime(1000 * Math.pow(2, attempt - 1));
+    }
+
+    // 1 initial + 3 reconnects = 4
+    expect(constructedInstances).toHaveLength(4);
+
+    // Simulate successful open on the last reconnect
+    constructedInstances[constructedInstances.length - 1].simulateOpen();
+
+    // Now fail again — should get another full 5 attempts
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const ws = constructedInstances[constructedInstances.length - 1];
+      ws.readyState = MockWebSocket.CLOSED;
+      ws.onerror!(new Event("error"));
+      vi.advanceTimersByTime(1000 * Math.pow(2, attempt - 1));
+    }
+
+    // 4 from before + 5 new reconnects = 9
+    expect(constructedInstances).toHaveLength(9);
+  });
+
   it("does NOT reconnect after disconnect() is called", () => {
     const mgr = new IndexWebSocketManager("p1", vi.fn());
     mgr.connect();
+    constructedInstances[0].simulateOpen();
 
     mgr.disconnect();
 
@@ -229,9 +324,46 @@ describe("IndexWebSocketManager", () => {
     expect(constructedInstances).toHaveLength(1);
   });
 
+  it("disconnect() cancels a pending reconnect timer", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+    constructedInstances[0].simulateOpen();
+
+    // Trigger reconnect scheduling
+    const ws = constructedInstances[0];
+    ws.readyState = MockWebSocket.CLOSED;
+    ws.onerror!(new Event("error"));
+
+    // Disconnect before the timer fires
+    mgr.disconnect();
+    vi.advanceTimersByTime(10000);
+
+    // Only the initial connection, no reconnect
+    expect(constructedInstances).toHaveLength(1);
+  });
+
+  it("does not double-reconnect when both onerror and onclose fire", () => {
+    const mgr = new IndexWebSocketManager("p1", vi.fn());
+    mgr.connect();
+    constructedInstances[0].simulateOpen();
+
+    const ws = constructedInstances[0];
+    ws.readyState = MockWebSocket.CLOSED;
+
+    // Both onerror and onclose fire (typical browser behavior)
+    ws.onerror!(new Event("error"));
+    ws.onclose!({ code: 1006 } as CloseEvent);
+
+    vi.advanceTimersByTime(1000);
+
+    // Only one reconnect, not two
+    expect(constructedInstances).toHaveLength(2);
+  });
+
   it("does NOT reconnect on normal close (code 1000)", () => {
     const mgr = new IndexWebSocketManager("p1", vi.fn());
     mgr.connect();
+    constructedInstances[0].simulateOpen();
 
     const ws = constructedInstances[0];
     ws.readyState = MockWebSocket.CLOSED;
@@ -245,6 +377,7 @@ describe("IndexWebSocketManager", () => {
   it("reconnects on abnormal close (code !== 1000)", () => {
     const mgr = new IndexWebSocketManager("p1", vi.fn());
     mgr.connect();
+    constructedInstances[0].simulateOpen();
 
     const ws = constructedInstances[0];
     ws.readyState = MockWebSocket.CLOSED;

--- a/__tests__/lib/hooks/useIndexStatus.test.ts
+++ b/__tests__/lib/hooks/useIndexStatus.test.ts
@@ -1,0 +1,99 @@
+import React, { type ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useIndexStatus } from "@/lib/hooks/useIndexStatus";
+
+// Mock the projectOntologyApi
+vi.mock("@/lib/api/client", () => ({
+  projectOntologyApi: {
+    getIndexStatus: vi.fn(),
+  },
+}));
+
+import { projectOntologyApi } from "@/lib/api/client";
+
+const mockedGetIndexStatus = projectOntologyApi.getIndexStatus as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // eslint-disable-next-line react/display-name
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useIndexStatus", () => {
+  it("fetches index status when projectId and accessToken are provided", async () => {
+    const statusData = { status: "idle", entity_count: 42 };
+    mockedGetIndexStatus.mockResolvedValueOnce(statusData);
+
+    const { result } = renderHook(
+      () => useIndexStatus("proj-1", "token-123"),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(statusData);
+    expect(mockedGetIndexStatus).toHaveBeenCalledWith("proj-1", "token-123");
+  });
+
+  it("does not fetch when projectId is empty", () => {
+    renderHook(
+      () => useIndexStatus("", "token-123"),
+      { wrapper: createWrapper() }
+    );
+
+    expect(mockedGetIndexStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when accessToken is undefined", () => {
+    renderHook(
+      () => useIndexStatus("proj-1", undefined),
+      { wrapper: createWrapper() }
+    );
+
+    expect(mockedGetIndexStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when enabled option is false", () => {
+    renderHook(
+      () => useIndexStatus("proj-1", "token-123", { enabled: false }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(mockedGetIndexStatus).not.toHaveBeenCalled();
+  });
+
+  it("fetches when enabled option is true", async () => {
+    const statusData = { status: "indexing" };
+    mockedGetIndexStatus.mockResolvedValueOnce(statusData);
+
+    const { result } = renderHook(
+      () => useIndexStatus("proj-1", "token-123", { enabled: true }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(statusData);
+  });
+
+  it("returns error state when API call fails", async () => {
+    mockedGetIndexStatus.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(
+      () => useIndexStatus("proj-1", "token-123"),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe("Network error");
+  });
+});

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -68,6 +68,7 @@ export default function EditorPage() {
     accessToken: session?.accessToken,
     sessionStatus: status,
     activeBranch,
+    enableWebSocket: true,
   });
 
   const {

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -13,7 +13,6 @@ import { DeveloperEditorLayout } from "@/components/editor/developer/DeveloperEd
 import { StandardEditorLayout } from "@/components/editor/standard/StandardEditorLayout";
 import { BranchProvider, useBranch } from "@/lib/context/BranchContext";
 import { useProjectViewer } from "@/lib/hooks/useProjectViewer";
-import { ConnectionStatus } from "@/components/ui/ConnectionStatus";
 import { useEditorModeStore } from "@/lib/stores/editorModeStore";
 import { useToast } from "@/lib/context/ToastContext";
 import { useProject, derivePermissions } from "@/lib/hooks/useProject";
@@ -183,7 +182,6 @@ function ViewerContent({
     selectedNodeFallback,
     sourceContent, setSourceContent, isLoadingSource, sourceError, isPreloading,
     loadSourceContent, sourceIriIndex,
-    connectionStatus, wsEndpoint, wsPurpose,
   } = viewer;
 
   const sourceEditorRef = useRef<OntologySourceEditorRef>(null);
@@ -228,20 +226,6 @@ function ViewerContent({
               <ModeSwitcher />
             </div>
             <div className="flex items-center gap-2">
-              {/* WebSocket Connection Status */}
-              <div className="flex items-center gap-1">
-                <ConnectionStatus
-                  state="disabled"
-                  purpose="Real-time collaboration (coming soon)"
-                  endpoint="/api/v1/collab/ws"
-                />
-                <ConnectionStatus
-                  state={connectionStatus}
-                  purpose={wsPurpose}
-                  endpoint={wsEndpoint}
-                />
-              </div>
-
               {/* Share */}
               <ShareButton
                 projectId={projectId}

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -23,7 +23,7 @@ import { MemberList } from "@/components/projects/member-list";
 import { UserSearchInput } from "@/components/projects/user-search-input";
 import { LabelPreferences } from "@/components/projects/label-preferences";
 import { ApiError, projectOntologyApi, type IndexStatusResponse, type IndexStatus } from "@/lib/api/client";
-import { createIndexWebSocket, type IndexWebSocketMessage } from "@/lib/api/indexStatus";
+import { IndexWebSocketManager, type IndexWebSocketMessage } from "@/lib/api/indexStatus";
 import {
   projectApi,
   type Project,
@@ -184,46 +184,33 @@ export default function ProjectSettingsPage() {
 
   // WebSocket for real-time index status updates
   useEffect(() => {
-    if (!project?.id) return;
+    if (!project?.id || !session?.accessToken) return;
 
-    let isActive = true;
-    let ws: WebSocket | null = null;
+    const manager = new IndexWebSocketManager(
+      project.id,
+      (message: IndexWebSocketMessage) => {
+        if (message.type === "index_started") {
+          setIsReindexing(true);
+          setIndexStatus((prev) =>
+            prev ? { ...prev, status: "indexing" as IndexStatus } : prev
+          );
+        } else if (message.type === "index_complete" || message.type === "index_failed") {
+          setIsReindexing(false);
+          const token = accessTokenRef.current;
+          queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId, token) });
+        }
+      },
+      session.accessToken
+    );
 
-    const handleMessage = (message: IndexWebSocketMessage) => {
-      if (!isActive) return;
-      if (message.type === "index_started") {
-        setIsReindexing(true);
-        setIndexStatus((prev) =>
-          prev ? { ...prev, status: "indexing" as IndexStatus } : prev
-        );
-      } else if (message.type === "index_complete" || message.type === "index_failed") {
-        setIsReindexing(false);
-        // Refresh from server to get the full status record
-        const token = accessTokenRef.current;
-        queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId, token) });
-      }
-    };
-
-    const timeoutId = setTimeout(() => {
-      if (isActive) {
-        ws = createIndexWebSocket(
-          project.id,
-          handleMessage,
-          undefined,
-          undefined,
-          accessTokenRef.current
-        );
-      }
-    }, 100);
+    // Small delay to avoid spurious connections during Strict Mode remounts
+    const timeoutId = setTimeout(() => manager.connect(), 100);
 
     return () => {
-      isActive = false;
       clearTimeout(timeoutId);
-      if (ws) {
-        ws.close();
-      }
+      manager.disconnect();
     };
-  }, [project?.id, projectId, queryClient]);
+  }, [project?.id, session?.accessToken, projectId, queryClient]);
 
   // Clean up normalization polling on unmount
   useEffect(() => {

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -23,6 +23,7 @@ import { MemberList } from "@/components/projects/member-list";
 import { UserSearchInput } from "@/components/projects/user-search-input";
 import { LabelPreferences } from "@/components/projects/label-preferences";
 import { ApiError, projectOntologyApi, type IndexStatusResponse, type IndexStatus } from "@/lib/api/client";
+import { createIndexWebSocket, type IndexWebSocketMessage } from "@/lib/api/indexStatus";
 import {
   projectApi,
   type Project,
@@ -180,14 +181,47 @@ export default function ProjectSettingsPage() {
   }, [indexQueryData]);
 
   const [isReindexing, setIsReindexing] = useState(false);
-  const reindexPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Clean up polling on unmount
+  // WebSocket for real-time index status updates
+  useEffect(() => {
+    if (!project?.id) return;
+
+    let isActive = true;
+    let ws: WebSocket | null = null;
+
+    const handleMessage = (message: IndexWebSocketMessage) => {
+      if (!isActive) return;
+      if (message.type === "index_started") {
+        setIsReindexing(true);
+        setIndexStatus((prev) =>
+          prev ? { ...prev, status: "indexing" as IndexStatus } : prev
+        );
+      } else if (message.type === "index_complete" || message.type === "index_failed") {
+        setIsReindexing(false);
+        // Refresh from server to get the full status record
+        const token = accessTokenRef.current;
+        queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId, token) });
+      }
+    };
+
+    const timeoutId = setTimeout(() => {
+      if (isActive) {
+        ws = createIndexWebSocket(project.id, handleMessage);
+      }
+    }, 100);
+
+    return () => {
+      isActive = false;
+      clearTimeout(timeoutId);
+      if (ws) {
+        ws.close();
+      }
+    };
+  }, [project?.id, projectId, queryClient]);
+
+  // Clean up normalization polling on unmount
   useEffect(() => {
     return () => {
-      if (reindexPollRef.current) {
-        clearInterval(reindexPollRef.current);
-      }
       if (normalizationPollRef.current) {
         clearInterval(normalizationPollRef.current);
       }
@@ -666,33 +700,7 @@ export default function ProjectSettingsPage() {
       );
       setSuccessMessage("Reindex job queued. The index will update in the background.");
       setTimeout(() => setSuccessMessage(null), 5000);
-
-      // Clear any existing poll before starting a new one
-      if (reindexPollRef.current) {
-        clearInterval(reindexPollRef.current);
-      }
-
-      // Poll for completion (read token from ref to avoid stale closure)
-      reindexPollRef.current = setInterval(async () => {
-        try {
-          const token = accessTokenRef.current;
-          const status = await projectOntologyApi.getIndexStatus(
-            project.id,
-            token
-          );
-          setIndexStatus(status);
-          if (status.status === "ready" || status.status === "failed") {
-            clearInterval(reindexPollRef.current!);
-            reindexPollRef.current = null;
-            setIsReindexing(false);
-            queryClient.invalidateQueries({ queryKey: indexQueryKeys.status(projectId, token) });
-          }
-        } catch {
-          clearInterval(reindexPollRef.current!);
-          reindexPollRef.current = null;
-          setIsReindexing(false);
-        }
-      }, 3000);
+      // WebSocket will handle status updates automatically
     } catch (err) {
       setLocalError(err instanceof Error ? err.message : "Failed to trigger reindex");
       setIsReindexing(false);

--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -206,7 +206,13 @@ export default function ProjectSettingsPage() {
 
     const timeoutId = setTimeout(() => {
       if (isActive) {
-        ws = createIndexWebSocket(project.id, handleMessage);
+        ws = createIndexWebSocket(
+          project.id,
+          handleMessage,
+          undefined,
+          undefined,
+          accessTokenRef.current
+        );
       }
     }, 100);
 

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -150,7 +150,22 @@ export function HealthCheckPanel({
 
     const timeoutId = setTimeout(() => {
       if (isActive) {
-        ws = createLintWebSocket(projectId, handleMessage, undefined, undefined, accessToken);
+        ws = createLintWebSocket(
+          projectId,
+          handleMessage,
+          () => {
+            if (isActive) {
+              setIsRunning(false);
+              setError("Lint WebSocket connection failed");
+            }
+          },
+          (event) => {
+            if (isActive && event.code !== 1000) {
+              setIsRunning(false);
+            }
+          },
+          accessToken
+        );
       }
     }, 100);
 

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -148,7 +148,7 @@ export function HealthCheckPanel({
     // Small delay to avoid spurious connections during Strict Mode remounts
     const timeoutId = setTimeout(() => {
       if (isActive) {
-        ws = createLintWebSocket(projectId, handleMessage);
+        ws = createLintWebSocket(projectId, handleMessage, undefined, undefined, accessToken);
       }
     }, 100);
 

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -146,6 +146,8 @@ export function HealthCheckPanel({
     };
 
     // Small delay to avoid spurious connections during Strict Mode remounts
+    if (!accessToken) return;
+
     const timeoutId = setTimeout(() => {
       if (isActive) {
         ws = createLintWebSocket(projectId, handleMessage, undefined, undefined, accessToken);
@@ -159,7 +161,7 @@ export function HealthCheckPanel({
         ws.close();
       }
     };
-  }, [isOpen, projectId, fetchData]);
+  }, [isOpen, projectId, accessToken, fetchData]);
 
   // Trigger a new lint run
   const handleRunLint = async () => {

--- a/lib/api/indexStatus.ts
+++ b/lib/api/indexStatus.ts
@@ -65,6 +65,7 @@ export class IndexWebSocketManager {
   private maxReconnectAttempts = 5;
   private reconnectDelay = 1000;
   private isClosing = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     projectId: string,
@@ -77,7 +78,10 @@ export class IndexWebSocketManager {
   }
 
   connect(): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
+    if (
+      this.ws?.readyState === WebSocket.OPEN ||
+      this.ws?.readyState === WebSocket.CONNECTING
+    ) {
       return;
     }
 
@@ -93,11 +97,20 @@ export class IndexWebSocketManager {
       },
       this.token
     );
+
+    // Reset retry budget on successful open
+    this.ws.addEventListener("open", () => {
+      this.reconnectAttempts = 0;
+    });
   }
 
   disconnect(): void {
     this.isClosing = true;
     this.reconnectAttempts = 0;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.ws) {
       this.ws.close(1000, "Client closing connection");
       this.ws = null;
@@ -105,13 +118,16 @@ export class IndexWebSocketManager {
   }
 
   private handleReconnect(): void {
-    if (this.isClosing) return;
+    if (this.isClosing || this.reconnectTimer !== null) return;
 
     if (this.reconnectAttempts < this.maxReconnectAttempts) {
       this.reconnectAttempts++;
       const delay =
         this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
-      setTimeout(() => this.connect(), delay);
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
+        this.connect();
+      }, delay);
     }
   }
 }

--- a/lib/api/indexStatus.ts
+++ b/lib/api/indexStatus.ts
@@ -19,15 +19,17 @@ export function createIndexWebSocket(
   projectId: string,
   onMessage: (message: IndexWebSocketMessage) => void,
   onError?: (error: Event) => void,
-  onClose?: (event: CloseEvent) => void
+  onClose?: (event: CloseEvent) => void,
+  token?: string
 ): WebSocket {
   const wsUrl =
     process.env.NEXT_PUBLIC_WS_URL ||
     process.env.NEXT_PUBLIC_API_URL?.replace(/^http/, "ws") ||
     "ws://localhost:8000";
 
+  const params = token ? `?token=${encodeURIComponent(token)}` : "";
   const ws = new WebSocket(
-    `${wsUrl}/api/v1/projects/${projectId}/ontology/index-ws`
+    `${wsUrl}/api/v1/projects/${projectId}/ontology/index-ws${params}`
   );
 
   ws.onmessage = (event) => {
@@ -58,6 +60,7 @@ export class IndexWebSocketManager {
   private ws: WebSocket | null = null;
   private projectId: string;
   private onMessage: (message: IndexWebSocketMessage) => void;
+  private token?: string;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
   private reconnectDelay = 1000;
@@ -65,10 +68,12 @@ export class IndexWebSocketManager {
 
   constructor(
     projectId: string,
-    onMessage: (message: IndexWebSocketMessage) => void
+    onMessage: (message: IndexWebSocketMessage) => void,
+    token?: string
   ) {
     this.projectId = projectId;
     this.onMessage = onMessage;
+    this.token = token;
   }
 
   connect(): void {
@@ -85,7 +90,8 @@ export class IndexWebSocketManager {
         if (!this.isClosing && event.code !== 1000) {
           this.handleReconnect();
         }
-      }
+      },
+      this.token
     );
   }
 

--- a/lib/api/indexStatus.ts
+++ b/lib/api/indexStatus.ts
@@ -1,0 +1,111 @@
+/**
+ * WebSocket client for real-time ontology index status updates.
+ *
+ * Mirrors the pattern in lib/api/lint.ts for lint WebSocket updates.
+ */
+
+export interface IndexWebSocketMessage {
+  type: "index_started" | "index_complete" | "index_failed";
+  project_id: string;
+  branch?: string;
+  entity_count?: number;
+  error?: string;
+}
+
+/**
+ * Create a WebSocket connection for ontology index updates.
+ */
+export function createIndexWebSocket(
+  projectId: string,
+  onMessage: (message: IndexWebSocketMessage) => void,
+  onError?: (error: Event) => void,
+  onClose?: (event: CloseEvent) => void
+): WebSocket {
+  const wsUrl =
+    process.env.NEXT_PUBLIC_WS_URL ||
+    process.env.NEXT_PUBLIC_API_URL?.replace(/^http/, "ws") ||
+    "ws://localhost:8000";
+
+  const ws = new WebSocket(
+    `${wsUrl}/api/v1/projects/${projectId}/ontology/index-ws`
+  );
+
+  ws.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data) as IndexWebSocketMessage;
+      onMessage(data);
+    } catch (e) {
+      console.error("Failed to parse index WebSocket message:", e);
+    }
+  };
+
+  ws.onerror = (error) => {
+    console.error("Index WebSocket error:", error);
+    onError?.(error);
+  };
+
+  ws.onclose = (event) => {
+    onClose?.(event);
+  };
+
+  return ws;
+}
+
+/**
+ * Hook-friendly WebSocket manager with auto-reconnect.
+ */
+export class IndexWebSocketManager {
+  private ws: WebSocket | null = null;
+  private projectId: string;
+  private onMessage: (message: IndexWebSocketMessage) => void;
+  private reconnectAttempts = 0;
+  private maxReconnectAttempts = 5;
+  private reconnectDelay = 1000;
+  private isClosing = false;
+
+  constructor(
+    projectId: string,
+    onMessage: (message: IndexWebSocketMessage) => void
+  ) {
+    this.projectId = projectId;
+    this.onMessage = onMessage;
+  }
+
+  connect(): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      return;
+    }
+
+    this.isClosing = false;
+    this.ws = createIndexWebSocket(
+      this.projectId,
+      this.onMessage,
+      () => this.handleReconnect(),
+      (event) => {
+        if (!this.isClosing && event.code !== 1000) {
+          this.handleReconnect();
+        }
+      }
+    );
+  }
+
+  disconnect(): void {
+    this.isClosing = true;
+    this.reconnectAttempts = 0;
+    if (this.ws) {
+      this.ws.close(1000, "Client closing connection");
+      this.ws = null;
+    }
+  }
+
+  private handleReconnect(): void {
+    if (this.isClosing) return;
+
+    if (this.reconnectAttempts < this.maxReconnectAttempts) {
+      this.reconnectAttempts++;
+      const delay =
+        this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
+      setTimeout(() => this.connect(), delay);
+    }
+  }
+}

--- a/lib/api/lint.ts
+++ b/lib/api/lint.ts
@@ -174,14 +174,16 @@ export function createLintWebSocket(
   projectId: string,
   onMessage: (message: LintWebSocketMessage) => void,
   onError?: (error: Event) => void,
-  onClose?: (event: CloseEvent) => void
+  onClose?: (event: CloseEvent) => void,
+  token?: string
 ): WebSocket {
   const wsUrl =
     process.env.NEXT_PUBLIC_WS_URL ||
     process.env.NEXT_PUBLIC_API_URL?.replace(/^http/, "ws") ||
     "ws://localhost:8000";
 
-  const ws = new WebSocket(`${wsUrl}/api/v1/projects/${projectId}/lint/ws`);
+  const params = token ? `?token=${encodeURIComponent(token)}` : "";
+  const ws = new WebSocket(`${wsUrl}/api/v1/projects/${projectId}/lint/ws${params}`);
 
   ws.onmessage = (event) => {
     try {
@@ -211,6 +213,7 @@ export class LintWebSocketManager {
   private ws: WebSocket | null = null;
   private projectId: string;
   private onMessage: (message: LintWebSocketMessage) => void;
+  private token?: string;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
   private reconnectDelay = 1000;
@@ -218,10 +221,12 @@ export class LintWebSocketManager {
 
   constructor(
     projectId: string,
-    onMessage: (message: LintWebSocketMessage) => void
+    onMessage: (message: LintWebSocketMessage) => void,
+    token?: string
   ) {
     this.projectId = projectId;
     this.onMessage = onMessage;
+    this.token = token;
   }
 
   connect(): void {
@@ -238,7 +243,8 @@ export class LintWebSocketManager {
         if (!this.isClosing && event.code !== 1000) {
           this.handleReconnect();
         }
-      }
+      },
+      this.token
     );
   }
 

--- a/lib/hooks/useCollaborationStatus.ts
+++ b/lib/hooks/useCollaborationStatus.ts
@@ -6,6 +6,7 @@ import type { ConnectionState } from "@/components/ui/ConnectionStatus";
 interface UseCollaborationStatusOptions {
   projectId: string;
   enabled?: boolean;
+  token?: string;
 }
 
 /**
@@ -15,6 +16,7 @@ interface UseCollaborationStatusOptions {
 export function useCollaborationStatus({
   projectId,
   enabled = true,
+  token,
 }: UseCollaborationStatusOptions) {
   const [status, setStatus] = useState<ConnectionState>("disconnected");
   const wsRef = useRef<WebSocket | null>(null);
@@ -27,8 +29,9 @@ export function useCollaborationStatus({
   const getWsUrl = useCallback(() => {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
     const wsUrl = apiUrl.replace(/^http/, "ws");
-    return `${wsUrl}/api/v1/projects/${projectId}/lint/ws`;
-  }, [projectId]);
+    const params = token ? `?token=${encodeURIComponent(token)}` : "";
+    return `${wsUrl}/api/v1/projects/${projectId}/lint/ws${params}`;
+  }, [projectId, token]);
 
   const connect = useCallback(() => {
     if (!enabled || !projectId || isClosingRef.current) return;

--- a/lib/hooks/useProjectViewer.ts
+++ b/lib/hooks/useProjectViewer.ts
@@ -15,6 +15,8 @@ export interface UseProjectViewerOptions {
   accessToken?: string;
   sessionStatus: "loading" | "authenticated" | "unauthenticated";
   activeBranch?: string;
+  /** Enable WebSocket connections (lint status, collaboration). Defaults to false. */
+  enableWebSocket?: boolean;
 }
 
 export function useProjectViewer({
@@ -22,6 +24,7 @@ export function useProjectViewer({
   accessToken,
   sessionStatus,
   activeBranch,
+  enableWebSocket = false,
 }: UseProjectViewerOptions) {
   // Project data from shared React Query cache
   const {
@@ -67,10 +70,11 @@ export function useProjectViewer({
     branchKey: activeBranch,
   });
 
-  // WebSocket connection status
+  // WebSocket connection status (editor only)
   const collaboration = useCollaborationStatus({
     projectId,
-    enabled: !!projectId && sessionStatus !== "loading",
+    enabled: enableWebSocket && !!projectId && !!accessToken && sessionStatus === "authenticated",
+    token: accessToken,
   });
 
   // Derive fallback data for the selected node from the tree


### PR DESCRIPTION
## Summary

This PR replaces the polling-based index status mechanism with real-time WebSocket updates and adds authentication to both WebSocket connections.

### WebSocket for index status
- **New `lib/api/indexStatus.ts`** — `createIndexWebSocket()` and `IndexWebSocketManager` (mirrors `lib/api/lint.ts` pattern)
- **Settings page** — replaced `setInterval` polling with WebSocket subscription to `/api/v1/projects/{id}/ontology/index-ws`; receives `index_started`, `index_complete`, `index_failed` events in real-time
- Fixes the issue where polling stopped after a 404 response before the worker created the index record

### WebSocket authentication
- **`createIndexWebSocket()`** and **`createLintWebSocket()`** now accept an optional `token` parameter, forwarded as `?token=...` query string
- **`IndexWebSocketManager`** and **`LintWebSocketManager`** store and pass the token on connect/reconnect
- **Settings page** passes `accessTokenRef.current` to the index WebSocket
- **HealthCheckPanel** passes `accessToken` prop to the lint WebSocket

## Dependencies
- Requires CatholicOS/ontokit-api#76 (backend WebSocket endpoint + GET index-status route + auth)

Closes #137

## Test plan
- [x] Open project settings, click "Rebuild Index", verify status updates in real-time via WebSocket (no polling)
- [x] Verify status shows "indexing" during build, then "ready" with entity count on completion
- [ ] Verify failed index shows error message
- [ ] Verify lint WebSocket still works with token auth in HealthCheckPanel
- [ ] Verify unauthenticated WebSocket connections are rejected
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time ontology index status updates via WebSocket with automatic reconnection and exponential backoff.
  * Improved WebSocket authentication to support secure token-based connections.

* **Refactor**
  * Replaced polling-based index status checks with efficient WebSocket streaming.
  * Removed connection status indicator from project viewer interface.

* **Tests**
  * Added comprehensive test coverage for WebSocket index status management and hook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->