### PR TITLE
fix(a11y): replace aria-hidden button with role=presentation span in EntityTreeNode

### DIFF
--- a/components/editor/shared/EntityTreeNode.tsx
+++ b/components/editor/shared/EntityTreeNode.tsx
@@ -203,11 +203,10 @@ export const EntityTreeNodeRow = memo(function EntityTreeNodeRow({
     >
       {/* Expand/collapse chevron or leaf dot — same 16px box for alignment */}
       {hasChildren ? (
-        <button
+        <span
           onClick={handleToggle}
           className="w-4 h-4 flex items-center justify-center flex-shrink-0"
-          tabIndex={-1}
-          aria-hidden="true"
+          role="presentation"
         >
           {node.isLoading ? (
             <Circle className="w-3 h-3 animate-pulse" />
@@ -216,7 +215,7 @@ export const EntityTreeNodeRow = memo(function EntityTreeNodeRow({
           ) : (
             <ChevronRight className="w-4 h-4" />
           )}
-        </button>
+        </span>
       ) : (
         <span className="w-4 h-4 flex items-center justify-center flex-shrink-0">
           <span className="tree-leaf-dot" />


### PR DESCRIPTION
## Summary

- Replaces the `<button>` expand/collapse chevron in `EntityTreeNode` with a `<span role="presentation">`
- Removes the conflicting `tabIndex={-1}` and `aria-hidden="true"` combination that caused Chrome DevTools to flag: *"Blocked aria-hidden on an element because its descendant retained focus"*

## Why this fix works

A `<button>` can still receive focus programmatically (e.g. via mouse click) even with `tabIndex={-1}`, which contradicts `aria-hidden="true"`. A `<span role="presentation">` removes the element from the accessibility tree entirely while preserving click functionality for mouse users. Keyboard navigation is already handled by the parent `<li role="treeitem">`.

## Test plan

- [ ] Open the editor and expand/collapse tree nodes — chevron should still work on click
- [ ] Run Chrome DevTools accessibility audit — no more `aria-hidden` focus conflict warning
- [ ] Tab through the tree with keyboard — expand/collapse is handled by the parent `li`, no change in behavior

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)