### PR TITLE
fix: handle all errors in RemoteSyncIndicator to prevent console flooding

### DIFF
--- a/components/editor/RemoteSyncIndicator.tsx
+++ b/components/editor/RemoteSyncIndicator.tsx
@@ -8,7 +8,6 @@ import {
   remoteSyncApi,
   type RemoteSyncConfig,
 } from "@/lib/api/remoteSync";
-import { ApiError } from "@/lib/api/client";
 
 interface RemoteSyncIndicatorProps {
   projectId: string;
@@ -27,10 +26,8 @@ export function RemoteSyncIndicator({
     remoteSyncApi
       .getConfig(projectId, accessToken)
       .then(setConfig)
-      .catch((err) => {
-        if (err instanceof ApiError && err.status === 404) {
-          setConfig(null);
-        }
+      .catch(() => {
+        setConfig(null);
       });
   }, [projectId, accessToken]);
 


### PR DESCRIPTION
## Summary

- The `catch` block in `RemoteSyncIndicator` only handled `ApiError` with status `404`, leaving all other errors (500, network failures, CORS blocks) as unhandled promise rejections
- Any fetch failure means remote sync config is unavailable — the correct response in all cases is `setConfig(null)` so the component simply doesn't render
- Removes the now-unused `ApiError` import

## Root cause

```tsx
// Before — only catches 404, everything else floods the console
.catch((err) => {
  if (err instanceof ApiError && err.status === 404) {
    setConfig(null);
  }
});

// After — all errors handled uniformly
.catch(() => {
  setConfig(null);
});
```

## Test plan

- [ ] Open the editor on a project with no GitHub integration configured
- [ ] Confirm no unhandled promise rejection errors appear in the browser console
- [ ] On a project with GitHub sync configured, confirm the indicator still renders correctly

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)