### PR TITLE
feat: add project favorites with star icon and sort-to-top

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,25 +64,19 @@ export default function HomePage() {
     enabled: status !== "loading" && !((filter === "mine" || filter === "private") && !isAuthenticated),
   });
 
-  const [favoritedIds, setFavoritedIds] = useState<Set<string>>(() => {
-    const items = data?.pages.flatMap((page) => page.items) ?? [];
-    return new Set(items.filter((p) => p.is_favorited).map((p) => p.id));
-  });
+  // Optimistic overrides: only tracks changes made this session.
+  // Server data (is_favorited) remains the source of truth for all other projects.
+  const [favoriteOverrides, setFavoriteOverrides] = useState<Map<string, boolean>>(new Map());
 
   const handleFavoriteChange = (projectId: string, isFavorited: boolean) => {
-    setFavoritedIds((prev) => {
-      const next = new Set(prev);
-      if (isFavorited) next.add(projectId);
-      else next.delete(projectId);
-      return next;
-    });
+    setFavoriteOverrides((prev) => new Map(prev).set(projectId, isFavorited));
   };
 
   const rawProjects = data?.pages.flatMap((page) => page.items) ?? [];
   const projects = [...rawProjects].sort((a, b) => {
-    const aFav = favoritedIds.has(a.id) ? 1 : 0;
-    const bFav = favoritedIds.has(b.id) ? 1 : 0;
-    return bFav - aFav;
+    const aFav = favoriteOverrides.has(a.id) ? favoriteOverrides.get(a.id)! : (a.is_favorited ?? false);
+    const bFav = favoriteOverrides.has(b.id) ? favoriteOverrides.get(b.id)! : (b.is_favorited ?? false);
+    return (bFav ? 1 : 0) - (aFav ? 1 : 0);
   });
   const total = data?.pages.at(-1)?.total ?? 0;
   const unfilteredTotal = data?.pages.at(-1)?.unfiltered_total ?? 0;
@@ -266,7 +260,12 @@ export default function HomePage() {
                   {projects.map((project) => (
                     <ProjectCard
                       key={project.id}
-                      project={project}
+                      project={{
+                        ...project,
+                        is_favorited: favoriteOverrides.has(project.id)
+                          ? favoriteOverrides.get(project.id)
+                          : project.is_favorited,
+                      }}
                       accessToken={session?.accessToken}
                       onFavoriteChange={handleFavoriteChange}
                     />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,7 +64,26 @@ export default function HomePage() {
     enabled: status !== "loading" && !((filter === "mine" || filter === "private") && !isAuthenticated),
   });
 
-  const projects = data?.pages.flatMap((page) => page.items) ?? [];
+  const [favoritedIds, setFavoritedIds] = useState<Set<string>>(() => {
+    const items = data?.pages.flatMap((page) => page.items) ?? [];
+    return new Set(items.filter((p) => p.is_favorited).map((p) => p.id));
+  });
+
+  const handleFavoriteChange = (projectId: string, isFavorited: boolean) => {
+    setFavoritedIds((prev) => {
+      const next = new Set(prev);
+      if (isFavorited) next.add(projectId);
+      else next.delete(projectId);
+      return next;
+    });
+  };
+
+  const rawProjects = data?.pages.flatMap((page) => page.items) ?? [];
+  const projects = [...rawProjects].sort((a, b) => {
+    const aFav = favoritedIds.has(a.id) ? 1 : 0;
+    const bFav = favoritedIds.has(b.id) ? 1 : 0;
+    return bFav - aFav;
+  });
   const total = data?.pages.at(-1)?.total ?? 0;
   const unfilteredTotal = data?.pages.at(-1)?.unfiltered_total ?? 0;
   const isFiltered = (!!debouncedSearch || filter !== "all") && unfilteredTotal > total;
@@ -245,7 +264,12 @@ export default function HomePage() {
                 </div>
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                   {projects.map((project) => (
-                    <ProjectCard key={project.id} project={project} />
+                    <ProjectCard
+                      key={project.id}
+                      project={project}
+                      accessToken={session?.accessToken}
+                      onFavoriteChange={handleFavoriteChange}
+                    />
                   ))}
                 </div>
                 {hasNextPage && (

--- a/components/projects/project-card.tsx
+++ b/components/projects/project-card.tsx
@@ -1,22 +1,27 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { Globe, Lock, Users } from "lucide-react";
+import { Globe, Lock, Users, Star } from "lucide-react";
 import { cn, formatDate } from "@/lib/utils";
-import type { Project } from "@/lib/api/projects";
+import { projectApi, type Project } from "@/lib/api/projects";
 import { derivePermissions } from "@/lib/hooks/useProject";
 import { useEditorModeStore } from "@/lib/stores/editorModeStore";
 
 interface ProjectCardProps {
   project: Project;
   className?: string;
+  accessToken?: string;
+  onFavoriteChange?: (projectId: string, isFavorited: boolean) => void;
 }
 
-export function ProjectCard({ project, className }: ProjectCardProps) {
+export function ProjectCard({ project, className, accessToken, onFavoriteChange }: ProjectCardProps) {
   const { data: session } = useSession();
   const { canSuggest } = derivePermissions(project, session?.accessToken);
   const preferEditMode = useEditorModeStore((s) => s.preferEditMode);
+  const [isFavorited, setIsFavorited] = useState(project.is_favorited ?? false);
+  const [isToggling, setIsToggling] = useState(false);
 
   // When the user has prefer-edit-mode on AND has at least suggester rights,
   // open the project straight to the editor. Anyone without edit/suggest
@@ -24,6 +29,28 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
   const href = preferEditMode && canSuggest
     ? `/projects/${project.id}/editor`
     : `/projects/${project.id}`;
+
+  const handleFavoriteClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!accessToken || isToggling) return;
+
+    const previous = isFavorited;
+    setIsFavorited(!previous); // optimistic update
+    setIsToggling(true);
+
+    try {
+      if (previous) {
+        await projectApi.unfavorite(project.id, accessToken);
+      } else {
+        await projectApi.favorite(project.id, accessToken);
+      }
+      onFavoriteChange?.(project.id, !previous);
+    } catch {
+      setIsFavorited(previous); // rollback on error
+    } finally {
+      setIsToggling(false);
+    }
+  };
 
   return (
     <Link
@@ -47,20 +74,44 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
             </p>
           )}
         </div>
-        <div
-          className={cn(
-            "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
-            project.is_public
-              ? "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400"
-              : "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
+        <div className="flex items-center gap-1.5 shrink-0">
+          {accessToken && (
+            <button
+              onClick={handleFavoriteClick}
+              disabled={isToggling}
+              aria-label={isFavorited ? "Remove from favorites" : "Add to favorites"}
+              aria-pressed={isFavorited}
+              className={cn(
+                "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                "hover:bg-amber-50 dark:hover:bg-amber-900/20",
+                isToggling && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              <Star
+                className={cn(
+                  "h-4 w-4 transition-colors",
+                  isFavorited
+                    ? "fill-amber-400 text-amber-400"
+                    : "text-slate-300 dark:text-slate-600 hover:text-amber-400"
+                )}
+              />
+            </button>
           )}
-          title={project.is_public ? "Public project" : "Private project"}
-        >
-          {project.is_public ? (
-            <Globe className="h-4 w-4" />
-          ) : (
-            <Lock className="h-4 w-4" />
-          )}
+          <div
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-full",
+              project.is_public
+                ? "bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400"
+                : "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
+            )}
+            title={project.is_public ? "Public project" : "Private project"}
+          >
+            {project.is_public ? (
+              <Globe className="h-4 w-4" />
+            ) : (
+              <Lock className="h-4 w-4" />
+            )}
+          </div>
         </div>
       </div>
 

--- a/components/projects/project-card.tsx
+++ b/components/projects/project-card.tsx
@@ -20,7 +20,7 @@ export function ProjectCard({ project, className, accessToken, onFavoriteChange 
   const { data: session } = useSession();
   const { canSuggest } = derivePermissions(project, session?.accessToken);
   const preferEditMode = useEditorModeStore((s) => s.preferEditMode);
-  const [isFavorited, setIsFavorited] = useState(project.is_favorited ?? false);
+  const isFavorited = project.is_favorited ?? false;
   const [isToggling, setIsToggling] = useState(false);
 
   // When the user has prefer-edit-mode on AND has at least suggester rights,
@@ -34,19 +34,18 @@ export function ProjectCard({ project, className, accessToken, onFavoriteChange 
     e.preventDefault();
     if (!accessToken || isToggling) return;
 
-    const previous = isFavorited;
-    setIsFavorited(!previous); // optimistic update
+    // Optimistic update via parent — parent holds the source of truth
+    onFavoriteChange?.(project.id, !isFavorited);
     setIsToggling(true);
 
     try {
-      if (previous) {
+      if (isFavorited) {
         await projectApi.unfavorite(project.id, accessToken);
       } else {
         await projectApi.favorite(project.id, accessToken);
       }
-      onFavoriteChange?.(project.id, !previous);
     } catch {
-      setIsFavorited(previous); // rollback on error
+      onFavoriteChange?.(project.id, isFavorited); // rollback in parent
     } finally {
       setIsToggling(false);
     }

--- a/lib/api/projects.ts
+++ b/lib/api/projects.ts
@@ -51,6 +51,8 @@ export interface Project {
   is_exemplar?: boolean;
   exemplar_slug?: string;
   exemplar_source_url?: string;
+  // Favorites
+  is_favorited?: boolean;
 }
 
 export interface ProjectListResponse {
@@ -297,6 +299,22 @@ export const projectApi = {
    */
   removeMember: (projectId: string, userId: string, token: string) =>
     api.delete(`/api/v1/projects/${projectId}/members/${userId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  /**
+   * Add a project to the current user's favorites
+   */
+  favorite: (id: string, token: string) =>
+    api.post<Project>(`/api/v1/projects/${id}/favorite`, {}, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  /**
+   * Remove a project from the current user's favorites
+   */
+  unfavorite: (id: string, token: string) =>
+    api.delete<Project>(`/api/v1/projects/${id}/favorite`, {
       headers: { Authorization: `Bearer ${token}` },
     }),
 


### PR DESCRIPTION
## Summary

- `Project` interface: adds `is_favorited?: boolean` field
- `projectApi`: adds `favorite()` and `unfavorite()` calling `POST`/`DELETE /api/v1/projects/{id}/favorite`
- `ProjectCard`: star button shown only to authenticated users; clicking toggles the favorite state with **optimistic UI** (immediate visual feedback, rollback on API error); fully accessible with `aria-label` and `aria-pressed`
- `HomePage`: tracks favorited IDs in local state and **sorts favorited projects to the top** within any active filter tab, maintaining existing creation-date order within each group

> **Note:** requires backend issue ontokit-api#30 for the `/favorite` endpoints to be available.

## Behavior

| Scenario | Behavior |
|---|---|
| Unauthenticated user | Star icon hidden |
| Click star (unfavorited) | Star fills yellow instantly; project moves to top |
| Click star (favorited) | Star empties; project returns to normal order |
| API error | Star reverts to previous state |

## Test plan

- [ ] Star icon appears on cards when signed in, hidden when signed out
- [ ] Clicking the star fills it yellow and moves the project to the top of the list
- [ ] Clicking again removes the favorite and restores the order
- [ ] Favorited state persists across page refreshes (returned by API in `is_favorited`)
- [ ] Works across all filter tabs (My Projects, Public, Private, All)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now favorite and unfavorite projects directly from project cards using a star button (requires authentication)
* Favorited projects are sorted to appear first in the listing
* Optimistic UI updates with automatic error recovery ensure a smooth user experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CatholicOS/ontokit-web/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->