### PR TITLE
fix: dim labels and reposition note for webhook-driven readonly fields

### DIFF
--- a/app/projects/[id]/settings/page.tsx
+++ b/app/projects/[id]/settings/page.tsx
@@ -2883,7 +2883,10 @@ function RemoteSyncSection({
               {/* Repository */}
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label className={cn(
+                    "mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300",
+                    isWebhookDriven && "opacity-60"
+                  )}>
                     Repository owner
                   </label>
                   <input
@@ -2901,7 +2904,10 @@ function RemoteSyncSection({
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label className={cn(
+                    "mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300",
+                    isWebhookDriven && "opacity-60"
+                  )}>
                     Repository name
                   </label>
                   <input
@@ -2920,12 +2926,6 @@ function RemoteSyncSection({
                 </div>
               </div>
 
-              {isWebhookDriven && (
-                <p className="text-xs text-indigo-500 dark:text-indigo-400">
-                  Repository fields are managed by the GitHub integration.
-                </p>
-              )}
-
               {/* Same-repo info when editing form matches GitHub integration */}
               {!isWebhookDriven && githubIntegration &&
                 repoOwner === githubIntegration.repo_owner &&
@@ -2939,7 +2939,10 @@ function RemoteSyncSection({
               {/* Branch + File path */}
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label className={cn(
+                    "mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300",
+                    isWebhookDriven && "opacity-60"
+                  )}>
                     Branch
                   </label>
                   <input
@@ -2957,7 +2960,10 @@ function RemoteSyncSection({
                   />
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  <label className={cn(
+                    "mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300",
+                    isWebhookDriven && "opacity-60"
+                  )}>
                     File path
                   </label>
                   <input
@@ -2975,6 +2981,12 @@ function RemoteSyncSection({
                   />
                 </div>
               </div>
+
+              {isWebhookDriven && (
+                <p className="text-xs text-indigo-500 dark:text-indigo-400">
+                  Repository fields are managed by the GitHub integration.
+                </p>
+              )}
 
               {/* Frequency + Update mode */}
               <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
Refs #5

## Problem

When `isWebhookDriven` is true, the four GitHub-integration input fields (`repo_owner`, `repo_name`, `branch`, `git_ontology_path`) were already rendered with `readOnly` and `cursor-not-allowed opacity-60` on the **inputs** themselves. However, their **labels** remained at full opacity, which was visually inconsistent — the fields looked disabled but the labels did not.

Additionally, the explanatory note _"Repository fields are managed by the GitHub integration."_ was placed **between** the first two-column grid (repo owner + name) and the second grid (branch + file path), making it ambiguous whether it applied to all four fields or only the bottom two.

## Changes

- **`app/projects/[id]/settings/page.tsx`**
  - Added `isWebhookDriven && "opacity-60"` to the `className` of all four field labels so they dim in sync with their inputs.
  - Moved the explanatory note to appear **after** both field grids so it clearly covers all four read-only fields as a group.

## Test plan

- [ ] Open a project that has a GitHub webhook configured (`isWebhookDriven === true`).
- [ ] Navigate to **Settings → GitHub Integration**.
- [ ] Verify the four labels ("Repository owner", "Repository name", "Branch", "File path") are visually dimmed (opacity-60) alongside their inputs.
- [ ] Verify the note "Repository fields are managed by the GitHub integration." appears below all four fields, not between them.
- [ ] Open a project **without** GitHub integration — verify labels are full opacity and inputs are editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)