### PR TITLE
fix: preserve entity selection when navigating between viewer and editor

### DIFF
--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -12,7 +12,6 @@ import { CommitMessageDialog } from "@/components/editor/CommitMessageDialog";
 import { AddEntityDialog, type NewEntityInfo } from "@/components/editor/AddEntityDialog";
 import { useToast } from "@/lib/context/ToastContext";
 import { ModeSwitcher } from "@/components/editor/ModeSwitcher";
-import { ContinuousEditingToggle } from "@/components/editor/ContinuousEditingToggle";
 import { DeveloperEditorLayout } from "@/components/editor/developer/DeveloperEditorLayout";
 import { StandardEditorLayout } from "@/components/editor/standard/StandardEditorLayout";
 import { BranchSelector, RevisionHistoryPanel, HistoryButton } from "@/components/revision";
@@ -823,18 +822,17 @@ export default function EditorPage() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <Link
-                href={`/projects/${projectId}`}
+                href={`/projects/${projectId}${selectedIri ? `?classIri=${encodeURIComponent(selectedIri)}` : ""}`}
                 className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
               >
-                <ArrowLeft className="h-4 w-4" />
-                Back
+                <Eye className="h-4 w-4" />
+                Close Editor
               </Link>
               <div className="h-5 w-px bg-slate-200 dark:bg-slate-700" />
               <h1 className="font-semibold text-slate-900 dark:text-white">{project.name}</h1>
               <span className="text-sm text-slate-500 dark:text-slate-400">{totalClasses} classes</span>
               {/* Mode Switcher */}
               <ModeSwitcher />
-              {canSuggest && <ContinuousEditingToggle />}
 
               {/* Suggestion mode indicator */}
               {isSuggestionMode && (

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -258,7 +258,7 @@ function ViewerContent({
 
               {/* Open Editor / Sign In */}
               {canSuggest ? (
-                <Link href={`/projects/${projectId}/editor`}>
+                <Link href={`/projects/${projectId}/editor${selectedIri ? `?classIri=${encodeURIComponent(selectedIri)}` : ""}`}>
                   <Button size="sm" className="gap-2">
                     <Pencil className="h-4 w-4" />
                     <span className="hidden sm:inline">Open Editor</span>


### PR DESCRIPTION
Closes #98

## Summary

- **Viewer → Editor**: The "Open Editor" button now appends `?classIri=<encoded>` when an entity is selected. The editor already reads this param to restore the selected node on load.
- **Editor → Viewer**: The "Back" link is replaced with a **"Close Editor"** button (Eye icon) that navigates to `/projects/{id}?classIri=<encoded>`, so the viewer restores the same selection on return.
- **ContinuousEditingToggle removed** from the editor toolbar: the toggle duplicated what the viewer↔editor navigation now handles explicitly. The underlying `continuousEditing` store preference is preserved for future use in settings.

## What was NOT changed

Items 4 and 5 from the issue (repurposing `continuousEditing` as a default-open-in-editor preference, and simplifying detail panel edit state) are left for a follow-up — they touch `ClassDetailPanel`, `PropertyDetailPanel`, `IndividualDetailPanel`, and the store, which carries more risk and warrants its own PR.

## Test plan

- [ ] Open a project in the viewer and select a class/property/individual
- [ ] Click **Open Editor** — verify the same entity is selected in the editor
- [ ] Change the selection in the editor, then click **Close Editor** — verify the viewer opens with that entity selected
- [ ] Open a project with no selection and click **Open Editor** — verify the editor opens without forcing a selection (no `classIri` param in the URL)
- [ ] Verify the **ContinuousEditingToggle** button no longer appears in the editor toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)