### PR TITLE
refactor: decouple useCollaborationStatus from lint WebSocket endpoint

### DIFF
--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -2088,11 +2088,11 @@ describe("HealthCheckPanel", () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
       try {
         const onWsStatusChange = vi.fn();
-        let capturedOpenListener: (() => void) | null = null;
+        const captured: { openListener: (() => void) | null } = { openListener: null };
         mockCreateLintWebSocket.mockImplementation(
           (_projectId: string, _onMessage: (msg: LintWebSocketMessage) => void) => {
             const ws = { close: vi.fn(), addEventListener: vi.fn((event: string, cb: () => void) => {
-              if (event === "open") capturedOpenListener = cb;
+              if (event === "open") captured.openListener = cb;
             }) };
             return ws as unknown as WebSocket;
           }
@@ -2102,7 +2102,7 @@ describe("HealthCheckPanel", () => {
         expect(onWsStatusChange).toHaveBeenCalledWith("connecting");
 
         await vi.advanceTimersByTimeAsync(110);
-        capturedOpenListener?.();
+        captured.openListener?.();
         expect(onWsStatusChange).toHaveBeenCalledWith("connected");
       } finally {
         vi.useRealTimers();
@@ -2113,11 +2113,11 @@ describe("HealthCheckPanel", () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
       try {
         const onWsStatusChange = vi.fn();
-        let capturedCloseListener: (() => void) | null = null;
+        const captured: { closeListener: (() => void) | null } = { closeListener: null };
         mockCreateLintWebSocket.mockImplementation(
           (_projectId: string, _onMessage: (msg: LintWebSocketMessage) => void) => {
             const ws = { close: vi.fn(), addEventListener: vi.fn((event: string, cb: () => void) => {
-              if (event === "close") capturedCloseListener = cb;
+              if (event === "close") captured.closeListener = cb;
             }) };
             return ws as unknown as WebSocket;
           }
@@ -2125,7 +2125,7 @@ describe("HealthCheckPanel", () => {
 
         setup({ onWsStatusChange });
         await vi.advanceTimersByTimeAsync(110);
-        capturedCloseListener?.();
+        captured.closeListener?.();
         expect(onWsStatusChange).toHaveBeenCalledWith("disconnected");
       } finally {
         vi.useRealTimers();

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -1809,7 +1809,7 @@ describe("HealthCheckPanel", () => {
     mockCreateLintWebSocket.mockImplementation(
       (_projectId: string, onMessage: (msg: LintWebSocketMessage) => void) => {
         capturedLintOnMessage = onMessage;
-        return { close: vi.fn() } as unknown as WebSocket;
+        return { close: vi.fn(), addEventListener: vi.fn() } as unknown as WebSocket;
       }
     );
 

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -2077,6 +2077,76 @@ describe("HealthCheckPanel", () => {
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0; });
   });
 
+  describe("onWsStatusChange callbacks", () => {
+    it("calls onWsStatusChange('disconnected') immediately when isOpen is false", () => {
+      const onWsStatusChange = vi.fn();
+      setup({ isOpen: false, onWsStatusChange });
+      expect(onWsStatusChange).toHaveBeenCalledWith("disconnected");
+    });
+
+    it("calls onWsStatusChange('connecting') then 'connected' when WS opens", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const onWsStatusChange = vi.fn();
+        let capturedOpenListener: (() => void) | null = null;
+        mockCreateLintWebSocket.mockImplementation(
+          (_projectId: string, _onMessage: (msg: LintWebSocketMessage) => void) => {
+            const ws = { close: vi.fn(), addEventListener: vi.fn((event: string, cb: () => void) => {
+              if (event === "open") capturedOpenListener = cb;
+            }) };
+            return ws as unknown as WebSocket;
+          }
+        );
+
+        setup({ onWsStatusChange });
+        expect(onWsStatusChange).toHaveBeenCalledWith("connecting");
+
+        await vi.advanceTimersByTimeAsync(110);
+        capturedOpenListener?.();
+        expect(onWsStatusChange).toHaveBeenCalledWith("connected");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("calls onWsStatusChange('disconnected') when WS closes", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const onWsStatusChange = vi.fn();
+        let capturedCloseListener: (() => void) | null = null;
+        mockCreateLintWebSocket.mockImplementation(
+          (_projectId: string, _onMessage: (msg: LintWebSocketMessage) => void) => {
+            const ws = { close: vi.fn(), addEventListener: vi.fn((event: string, cb: () => void) => {
+              if (event === "close") capturedCloseListener = cb;
+            }) };
+            return ws as unknown as WebSocket;
+          }
+        );
+
+        setup({ onWsStatusChange });
+        await vi.advanceTimersByTimeAsync(110);
+        capturedCloseListener?.();
+        expect(onWsStatusChange).toHaveBeenCalledWith("disconnected");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("calls onWsStatusChange('disconnected') on cleanup", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const onWsStatusChange = vi.fn();
+        const { unmount } = setup({ onWsStatusChange });
+        await vi.advanceTimersByTimeAsync(110);
+        onWsStatusChange.mockClear();
+        unmount();
+        expect(onWsStatusChange).toHaveBeenCalledWith("disconnected");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("does not reopen the lint WebSocket when the issue filter changes", async () => {
     // The fetchDataRef pattern keeps `filter` out of the WS effect's deps so
     // changing filters re-issues HTTP for filtered issues without tearing

--- a/__tests__/components/editor/HealthCheckPanel.test.tsx
+++ b/__tests__/components/editor/HealthCheckPanel.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/lib/api/lint", () => ({
     getLintConfig: vi.fn(),
     getLevels: vi.fn(),
   },
-  createLintWebSocket: vi.fn(() => ({ close: vi.fn() })),
+  createLintWebSocket: vi.fn(() => ({ close: vi.fn(), addEventListener: vi.fn() })),
 }));
 
 vi.mock("@/lib/api/quality", () => ({
@@ -133,7 +133,7 @@ describe("HealthCheckPanel", () => {
       checked_at: "",
       duration_ms: 0,
     });
-    mockCreateLintWebSocket.mockReturnValue({ close: vi.fn() } as unknown as WebSocket);
+    mockCreateLintWebSocket.mockReturnValue({ close: vi.fn(), addEventListener: vi.fn() } as unknown as WebSocket);
     mockQualityApi.getLatestDuplicates.mockResolvedValue({
       clusters: [],
       threshold: 0.85,

--- a/__tests__/components/editor/developer/DeveloperEditorLayout.test.tsx
+++ b/__tests__/components/editor/developer/DeveloperEditorLayout.test.tsx
@@ -1349,9 +1349,6 @@ describe("DeveloperEditorLayout", () => {
     });
 
     it("preserves the selection store on unmount so side-page Back-to-project links can read it", () => {
-      // Regression: editor used to clear the store on unmount, racing with
-      // side-page navigation — by the time settings/PRs/etc rendered, the
-      // store was empty and useProjectHomeHref dropped the selection.
       const { unmount } = render(
         <DeveloperEditorLayout
           {...defaultProps({ selectedIri: "http://example.org/Foo" })}
@@ -1360,6 +1357,24 @@ describe("DeveloperEditorLayout", () => {
       unmount();
       expect(useSelectionStore.getState().iri).toBe("http://example.org/Foo");
       expect(useSelectionStore.getState().type).toBe("class");
+    });
+  });
+
+  describe("HealthCheckPanel integration", () => {
+    it("does not render HealthCheckPanel by default", () => {
+      render(<DeveloperEditorLayout {...defaultProps()} />);
+      expect(screen.queryByTestId("health-check-panel")).toBeNull();
+    });
+
+    it("renders HealthCheckPanel when showHealthCheck is true", () => {
+      render(<DeveloperEditorLayout {...defaultProps({ showHealthCheck: true })} />);
+      expect(screen.getByTestId("health-check-panel")).toBeDefined();
+    });
+
+    it("passes onLintWsStatusChange through to HealthCheckPanel", () => {
+      const onLintWsStatusChange = vi.fn();
+      render(<DeveloperEditorLayout {...defaultProps({ showHealthCheck: true, onLintWsStatusChange })} />);
+      expect(screen.getByTestId("health-check-panel")).toBeDefined();
     });
   });
 });

--- a/__tests__/lib/hooks/useCollaborationStatus.test.ts
+++ b/__tests__/lib/hooks/useCollaborationStatus.test.ts
@@ -1,153 +1,30 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
 import { useCollaborationStatus } from "@/lib/hooks/useCollaborationStatus";
 
-// Mock WebSocket
-class MockWebSocket {
-  static instances: MockWebSocket[] = [];
-  url: string;
-  onopen: (() => void) | null = null;
-  onclose: (() => void) | null = null;
-  onerror: (() => void) | null = null;
-  onmessage: ((event: { data: string }) => void) | null = null;
-  close = vi.fn(() => {
-    this.onclose?.();
-  });
-
-  constructor(url: string) {
-    this.url = url;
-    MockWebSocket.instances.push(this);
-  }
-}
-
-beforeEach(() => {
-  vi.useFakeTimers();
-  MockWebSocket.instances = [];
-  vi.stubGlobal("WebSocket", MockWebSocket);
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-  vi.unstubAllGlobals();
-});
-
 describe("useCollaborationStatus", () => {
-  it("returns disconnected status when not enabled", () => {
+  it("returns disabled status (stub — collab endpoint not yet implemented)", () => {
     const { result } = renderHook(() =>
-      useCollaborationStatus({ projectId: "proj-1", enabled: false }),
+      useCollaborationStatus({ projectId: "proj-1" }),
     );
 
-    expect(result.current.status).toBe("disconnected");
+    expect(result.current.status).toBe("disabled");
     expect(result.current.isConnected).toBe(false);
   });
 
-  it("returns the correct endpoint path", () => {
+  it("returns the collab endpoint path", () => {
     const { result } = renderHook(() =>
-      useCollaborationStatus({ projectId: "proj-1", enabled: false }),
+      useCollaborationStatus({ projectId: "proj-1" }),
     );
 
-    expect(result.current.endpoint).toBe("/api/v1/projects/proj-1/lint/ws");
+    expect(result.current.endpoint).toBe("/api/v1/collab/ws");
   });
 
   it("returns the purpose description", () => {
     const { result } = renderHook(() =>
-      useCollaborationStatus({ projectId: "proj-1", enabled: false }),
+      useCollaborationStatus({ projectId: "proj-1" }),
     );
 
-    expect(result.current.purpose).toBe("Real-time lint status updates");
-  });
-
-  it("constructs correct WebSocket URL", () => {
-    renderHook(() =>
-      useCollaborationStatus({ projectId: "proj-1", enabled: true }),
-    );
-
-    // The hook has a 100ms delay before connecting
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-
-    expect(MockWebSocket.instances.length).toBeGreaterThan(0);
-    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
-    expect(ws.url).toBe("ws://localhost:8000/api/v1/projects/proj-1/lint/ws");
-  });
-
-  it("transitions to connecting then connected on open", () => {
-    const { result } = renderHook(() =>
-      useCollaborationStatus({ projectId: "proj-1", enabled: true }),
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-
-    // Should be connecting after timer
-    expect(result.current.status).toBe("connecting");
-
-    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
-    act(() => {
-      ws.onopen?.();
-    });
-
-    expect(result.current.status).toBe("connected");
-    expect(result.current.isConnected).toBe(true);
-  });
-
-  it("transitions to disconnected on close", () => {
-    const { result } = renderHook(() =>
-      useCollaborationStatus({ projectId: "proj-1", enabled: true }),
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-
-    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
-    act(() => {
-      ws.onopen?.();
-    });
-    expect(result.current.status).toBe("connected");
-
-    // Simulate a close (not initiated by disconnect())
-    act(() => {
-      ws.onclose?.();
-    });
-
-    expect(result.current.status).toBe("disconnected");
-  });
-
-  it("cleans up WebSocket on unmount", () => {
-    const { unmount } = renderHook(() =>
-      useCollaborationStatus({ projectId: "proj-1", enabled: true }),
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-
-    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
-    act(() => {
-      ws.onopen?.();
-    });
-
-    unmount();
-
-    expect(ws.close).toHaveBeenCalled();
-  });
-
-  it("does not create WebSocket when projectId is empty", () => {
-    renderHook(() =>
-      useCollaborationStatus({ projectId: "", enabled: true }),
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(200);
-    });
-
-    // No WebSocket should have been created (or only from cleanup)
-    const connectedInstances = MockWebSocket.instances.filter(
-      (ws) => ws.url.includes("/lint/ws"),
-    );
-    expect(connectedInstances).toHaveLength(0);
+    expect(result.current.purpose).toBe("Real-time collaboration (coming soon)");
   });
 });

--- a/__tests__/lib/hooks/useProjectViewer.test.ts
+++ b/__tests__/lib/hooks/useProjectViewer.test.ts
@@ -414,26 +414,6 @@ describe("useProjectViewer", () => {
     expect(result.current.treeError).toBeNull();
   });
 
-  it("exposes collaboration status", () => {
-    mockUseProject.mockReturnValue({
-      project: makeProject(),
-      isLoading: false,
-      error: null,
-      errorKind: null,
-    });
-
-    const { result } = renderHook(() =>
-      useProjectViewer({
-        projectId: "p1",
-        accessToken: "tok",
-        sessionStatus: "authenticated",
-        activeBranch: "main",
-      })
-    );
-
-    expect(result.current.connectionStatus).toBe("disconnected");
-  });
-
   it("exposes source state with defaults", () => {
     mockUseProject.mockReturnValue({
       project: makeProject(),

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -973,7 +973,7 @@ export default function EditorPage() {
                   purpose={collaboration.purpose}
                   endpoint={collaboration.endpoint}
                 />
-                {showHealthCheck && editorMode === "developer" && (
+                {showHealthCheck && (
                   <ConnectionStatus
                     state={lintWsStatus}
                     purpose="Real-time lint status updates"
@@ -1178,6 +1178,7 @@ export default function EditorPage() {
                 branch={activeBranch}
                 isOpen={showHealthCheck}
                 onClose={() => setShowHealthCheck(false)}
+                onWsStatusChange={setLintWsStatus}
                 onNavigateToClass={(iri, subjectType) => {
                   if (entityNavigationRef.current) {
                     entityNavigationRef.current(iri, subjectType);

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -92,7 +92,6 @@ export default function EditorPage() {
     accessToken: session?.accessToken,
     sessionStatus: status,
     activeBranch,
-    enableWebSocket: true,
   });
 
   const {
@@ -1084,6 +1083,7 @@ export default function EditorPage() {
                   accessToken={session?.accessToken}
                   activeBranch={activeBranch}
                   canEdit={!!canEdit}
+                  canManage={!!canManage}
                   entityNavigationRef={entityNavigationRef}
                   canSuggest={!!canSuggest}
                   isSuggestionMode={isSuggestionMode}

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -1169,8 +1169,8 @@ export default function EditorPage() {
             )}
           </div>
 
-          {/* Right Panel - Health Check (available in both modes) */}
-          {showHealthCheck && (
+          {/* Right Panel - Health Check (standard mode only; developer mode uses DeveloperEditorLayout's panel) */}
+          {showHealthCheck && editorMode !== "developer" && (
             <div className="w-96 flex-shrink-0">
               <HealthCheckPanel
                 projectId={projectId}

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -124,6 +124,13 @@ export default function EditorPage() {
   // UI state (editor-only)
   const [showHistory, setShowHistory] = useState(false);
   const [showHealthCheck, setShowHealthCheck] = useState(false);
+
+  // Reset lint WS status when the health check panel is hidden or mode switches away from developer
+  useEffect(() => {
+    if (!showHealthCheck || editorMode !== "developer") {
+      setLintWsStatus("disconnected");
+    }
+  }, [showHealthCheck, editorMode]);
   const sourceEditorRef = useRef<OntologySourceEditorRef>(null);
   const entityNavigationRef = useRef<((iri: string, type?: string) => void) | null>(null);
 

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -114,12 +114,6 @@ export default function EditorPage() {
   const collaboration = useCollaborationStatus({ projectId });
   const [lintWsStatus, setLintWsStatus] = useState<ConnectionState>("disconnected");
 
-  // Restore selected class from URL query param once tree is ready
-  useEffect(() => {
-    if (!classIriParam || isTreeLoading || !nodes.length) return;
-    if (selectedIri === classIriParam) return;
-    navigateToNode(classIriParam);
-  }, [classIriParam, isTreeLoading, nodes.length, selectedIri, navigateToNode]);
   // UI state (editor-only)
   const [showHistory, setShowHistory] = useState(false);
   const [showHealthCheck, setShowHealthCheck] = useState(false);

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -42,6 +42,8 @@ import { useSuggestionBeacon } from "@/lib/hooks/useSuggestionBeacon";
 import { DeleteImpactAnalysis } from "@/components/editor/DeleteImpactAnalysis";
 import { RemoteSyncIndicator } from "@/components/editor/RemoteSyncIndicator";
 import { ShareButton } from "@/components/editor/ShareButton";
+import { useCollaborationStatus } from "@/lib/hooks/useCollaborationStatus";
+import type { ConnectionState } from "@/components/ui/ConnectionStatus";
 
 import type { OntologySourceEditorRef } from "@/components/editor/OntologySourceEditor";
 
@@ -107,10 +109,18 @@ export default function EditorPage() {
     selectedNodeFallback,
     sourceContent, setSourceContent, isLoadingSource, sourceError, isPreloading,
     loadSourceContent, sourceIriIndex, setSourceIriIndex,
-    connectionStatus, wsEndpoint, wsPurpose,
     resetSourceState,
   } = viewer;
 
+  const collaboration = useCollaborationStatus({ projectId });
+  const [lintWsStatus, setLintWsStatus] = useState<ConnectionState>("disconnected");
+
+  // Restore selected class from URL query param once tree is ready
+  useEffect(() => {
+    if (!classIriParam || isTreeLoading || !nodes.length) return;
+    if (selectedIri === classIriParam) return;
+    navigateToNode(classIriParam);
+  }, [classIriParam, isTreeLoading, nodes.length, selectedIri, navigateToNode]);
   // UI state (editor-only)
   const [showHistory, setShowHistory] = useState(false);
   const [showHealthCheck, setShowHealthCheck] = useState(false);
@@ -953,15 +963,17 @@ export default function EditorPage() {
               {/* WebSocket Connection Status */}
               <div className="flex items-center gap-1">
                 <ConnectionStatus
-                  state="disabled"
-                  purpose="Real-time collaboration (coming soon)"
-                  endpoint="/api/v1/collab/ws"
+                  state={collaboration.status}
+                  purpose={collaboration.purpose}
+                  endpoint={collaboration.endpoint}
                 />
-                <ConnectionStatus
-                  state={connectionStatus}
-                  purpose={wsPurpose}
-                  endpoint={wsEndpoint}
-                />
+                {showHealthCheck && (
+                  <ConnectionStatus
+                    state={lintWsStatus}
+                    purpose="Real-time lint status updates"
+                    endpoint={`/api/v1/projects/${projectId}/lint/ws`}
+                  />
+                )}
               </div>
 
               {/* Branch Selector */}
@@ -1100,6 +1112,9 @@ export default function EditorPage() {
                   selectedNodeFallback={selectedNodeFallback}
                   onUpdateClass={isSuggestionMode ? handleSuggestClassUpdate : handleUpdateClass}
                   detailRefreshKey={detailRefreshKey}
+                  showHealthCheck={showHealthCheck}
+                  onCloseHealthCheck={() => setShowHealthCheck(false)}
+                  onLintWsStatusChange={setLintWsStatus}
                   onUpdateProperty={isSuggestionMode ? handleSuggestPropertyUpdate : handleUpdateProperty}
                   onUpdateIndividual={isSuggestionMode ? handleSuggestIndividualUpdate : handleUpdateIndividual}
                   onReparentClass={handleReparentClass}

--- a/app/projects/[id]/editor/page.tsx
+++ b/app/projects/[id]/editor/page.tsx
@@ -967,7 +967,7 @@ export default function EditorPage() {
                   purpose={collaboration.purpose}
                   endpoint={collaboration.endpoint}
                 />
-                {showHealthCheck && (
+                {showHealthCheck && editorMode === "developer" && (
                   <ConnectionStatus
                     state={lintWsStatus}
                     purpose="Real-time lint status updates"

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -20,6 +20,7 @@ import { useSelectionStore } from "@/lib/stores/selectionStore";
 import { useToast } from "@/lib/context/ToastContext";
 import { useProject, derivePermissions } from "@/lib/hooks/useProject";
 import type { OntologySourceEditorRef } from "@/components/editor/OntologySourceEditor";
+import { ConnectionStatus } from "@/components/ui/ConnectionStatus";
 
 export default function ProjectViewerPage() {
   const { data: session, status } = useSession();

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -274,6 +274,15 @@ function ViewerContent({
               <ModeSwitcher />
             </div>
             <div className="flex items-center gap-2">
+              {/* WebSocket Connection Status */}
+              <div className="flex items-center gap-1">
+                <ConnectionStatus
+                  state="disabled"
+                  purpose="Real-time collaboration (coming soon)"
+                  endpoint="/api/v1/collab/ws"
+                />
+              </div>
+
               {/* Share */}
               <ShareButton
                 projectId={projectId}

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -32,6 +32,7 @@ import {
 import type { ConsistencyCheckResult, ConsistencyIssue, DuplicateCluster, DuplicateDetectionResult } from "@/lib/ontology/qualityTypes";
 import Link from "next/link";
 import { cn, formatDateTime, getLocalName } from "@/lib/utils";
+import type { ConnectionState } from "@/components/ui/ConnectionStatus";
 
 interface HealthCheckPanelProps {
   projectId: string;
@@ -42,6 +43,8 @@ interface HealthCheckPanelProps {
   onNavigateToClass?: (iri: string, subjectType?: string) => void;
   /** Whether the current user can trigger a lint run (requires admin/manager role) */
   canRunLint?: boolean;
+  /** Called whenever the lint WebSocket connection state changes */
+  onWsStatusChange?: (status: ConnectionState) => void;
 }
 
 type HealthTab = "lint" | "consistency" | "duplicates";
@@ -67,6 +70,7 @@ export function HealthCheckPanel({
   isOpen,
   onClose,
   onNavigateToClass,
+  onWsStatusChange,
 }: HealthCheckPanelProps) {
   const [activeTab, setActiveTab] = useState<HealthTab>("lint");
   const [summary, setSummary] = useState<LintSummary | null>(null);
@@ -191,11 +195,17 @@ export function HealthCheckPanel({
 
   // WebSocket for real-time updates
   useEffect(() => {
-    if (!isOpen || !accessToken) return;
+    if (!isOpen) {
+      onWsStatusChange?.("disconnected");
+      return;
+    }
+    if (!accessToken) return;
 
     // Track if this effect is still active (handles React Strict Mode double-invoke)
     let isActive = true;
     let ws: WebSocket | null = null;
+
+    onWsStatusChange?.("connecting");
 
     const handleMessage = (message: LintWebSocketMessage) => {
       if (!isActive) return;
@@ -209,24 +219,26 @@ export function HealthCheckPanel({
 
     // Small delay to avoid spurious connections during Strict Mode remounts
     const timeoutId = setTimeout(() => {
-      if (isActive) {
-        ws = createLintWebSocket(
-          projectId,
-          handleMessage,
-          () => {
-            if (isActive) {
-              setIsRunning(false);
-              setError("Lint WebSocket connection failed");
-            }
-          },
-          (event) => {
-            if (isActive && event.code !== 1000) {
-              setIsRunning(false);
-            }
-          },
-          accessToken
-        );
-      }
+      if (!isActive) return;
+      ws = createLintWebSocket(
+        projectId,
+        handleMessage,
+        () => {
+          if (isActive) {
+            setIsRunning(false);
+            setError("Lint WebSocket connection failed");
+          }
+        },
+        (event) => {
+          if (isActive && event.code !== 1000) {
+            setIsRunning(false);
+          }
+        },
+        accessToken
+      );
+      ws.addEventListener("open", () => { if (isActive) onWsStatusChange?.("connected"); });
+      ws.addEventListener("close", () => { if (isActive) onWsStatusChange?.("disconnected"); });
+      ws.addEventListener("error", () => { if (isActive) onWsStatusChange?.("disconnected"); });
     }, 100);
 
     return () => {
@@ -235,8 +247,9 @@ export function HealthCheckPanel({
       if (ws) {
         ws.close();
       }
+      onWsStatusChange?.("disconnected");
     };
-  }, [isOpen, projectId, accessToken]);
+  }, [isOpen, projectId, accessToken, fetchData, onWsStatusChange]);
 
   const handleClearResults = async () => {
     if (!accessToken) return;

--- a/components/editor/HealthCheckPanel.tsx
+++ b/components/editor/HealthCheckPanel.tsx
@@ -249,7 +249,7 @@ export function HealthCheckPanel({
       }
       onWsStatusChange?.("disconnected");
     };
-  }, [isOpen, projectId, accessToken, fetchData, onWsStatusChange]);
+  }, [isOpen, projectId, accessToken, onWsStatusChange]);
 
   const handleClearResults = async () => {
     if (!accessToken) return;

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -30,6 +30,7 @@ import { useSelectionStore } from "@/lib/stores/selectionStore";
 import { getLocalName } from "@/lib/utils";
 import { extractTreeLabelMap } from "@/lib/graph/buildGraphData";
 import { useAnnounce } from "@/components/ui/ScreenReaderAnnouncer";
+import { HealthCheckPanel } from "@/components/editor/HealthCheckPanel";
 
 const OntologySourceEditor = dynamic(
   () => import("@/components/editor/OntologySourceEditor").then((mod) => mod.OntologySourceEditor),
@@ -62,6 +63,7 @@ export interface DeveloperEditorLayoutProps {
   accessToken?: string;
   activeBranch?: string;
   canEdit: boolean;
+  canManage?: boolean;
   canSuggest?: boolean;
   isSuggestionMode?: boolean;
   // Tree state (from useOntologyTree)
@@ -107,8 +109,8 @@ export interface DeveloperEditorLayoutProps {
   detailRefreshKey?: number;
 
   // Side panels
-  showHealthCheck: boolean;
-  onCloseHealthCheck: () => void;
+  showHealthCheck?: boolean;
+  onCloseHealthCheck?: () => void;
   onLintWsStatusChange?: (status: import("@/components/ui/ConnectionStatus").ConnectionState) => void;
 
   // Property & Individual editing
@@ -130,6 +132,7 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
     accessToken,
     activeBranch,
     canEdit,
+    canManage = false,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     canSuggest = false,
     isSuggestionMode = false,
@@ -165,7 +168,7 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
     selectedNodeFallback,
     onUpdateClass,
     detailRefreshKey,
-    showHealthCheck,
+    showHealthCheck = false,
     onCloseHealthCheck,
     onLintWsStatusChange,
     onUpdateProperty,
@@ -613,7 +616,7 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
                   accessToken={accessToken}
                   branch={activeBranch}
                   isOpen={showHealthCheck}
-                  onClose={onCloseHealthCheck}
+                  onClose={onCloseHealthCheck ?? (() => {})}
                   onNavigateToClass={(iri) => navigateToNode(iri)}
                   canRunLint={canManage}
                   onWsStatusChange={onLintWsStatusChange}

--- a/components/editor/developer/DeveloperEditorLayout.tsx
+++ b/components/editor/developer/DeveloperEditorLayout.tsx
@@ -106,6 +106,11 @@ export interface DeveloperEditorLayoutProps {
   onUpdateClass?: (classIri: string, data: ClassUpdatePayload) => Promise<void>;
   detailRefreshKey?: number;
 
+  // Side panels
+  showHealthCheck: boolean;
+  onCloseHealthCheck: () => void;
+  onLintWsStatusChange?: (status: import("@/components/ui/ConnectionStatus").ConnectionState) => void;
+
   // Property & Individual editing
   onUpdateProperty?: (propertyIri: string, data: TurtlePropertyUpdateData) => Promise<void>;
   onUpdateIndividual?: (individualIri: string, data: TurtleIndividualUpdateData) => Promise<void>;
@@ -160,6 +165,9 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
     selectedNodeFallback,
     onUpdateClass,
     detailRefreshKey,
+    showHealthCheck,
+    onCloseHealthCheck,
+    onLintWsStatusChange,
     onUpdateProperty,
     onUpdateIndividual,
     onReparentClass,
@@ -597,6 +605,21 @@ export function DeveloperEditorLayout(props: DeveloperEditorLayoutProps) {
               )}
             </div>
 
+            {/* Right Panel - Health Check */}
+            {showHealthCheck && (
+              <div className="w-96 flex-shrink-0">
+                <HealthCheckPanel
+                  projectId={projectId}
+                  accessToken={accessToken}
+                  branch={activeBranch}
+                  isOpen={showHealthCheck}
+                  onClose={onCloseHealthCheck}
+                  onNavigateToClass={(iri) => navigateToNode(iri)}
+                  canRunLint={canManage}
+                  onWsStatusChange={onLintWsStatusChange}
+                />
+              </div>
+            )}
           </>
         ) : (
           /* Source View */

--- a/lib/hooks/useCollaborationStatus.ts
+++ b/lib/hooks/useCollaborationStatus.ts
@@ -1,158 +1,22 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
 import type { ConnectionState } from "@/components/ui/ConnectionStatus";
 
-interface UseCollaborationStatusOptions {
-  projectId: string;
-  enabled?: boolean;
-  token?: string;
-}
-
 /**
- * Hook to track WebSocket connection status for the lint endpoint.
- * Maintains a persistent connection and reports status changes.
+ * Hook for real-time collaboration presence status.
+ * Currently disabled — the /collab/ws endpoint does not exist yet.
+ * When the endpoint is available, this hook should establish a WebSocket
+ * connection and return live presence/connection state.
  */
-export function useCollaborationStatus({
-  projectId,
-  enabled = true,
-  token,
-}: UseCollaborationStatusOptions) {
-  const [status, setStatus] = useState<ConnectionState>("disconnected");
-  const wsRef = useRef<WebSocket | null>(null);
-  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const reconnectAttemptsRef = useRef(0);
-  const maxReconnectAttempts = 5;
-  const isClosingRef = useRef(false);
-  const connectRef = useRef<() => void>(() => {});
-
-  const getWsUrl = useCallback(() => {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-    const wsUrl = apiUrl.replace(/^http/, "ws");
-    const params = token ? `?token=${encodeURIComponent(token)}` : "";
-    return `${wsUrl}/api/v1/projects/${projectId}/lint/ws${params}`;
-  }, [projectId, token]);
-
-  const connect = useCallback(() => {
-    if (!enabled || !projectId || isClosingRef.current) return;
-
-    // Clean up existing connection
-    if (wsRef.current) {
-      wsRef.current.close();
-      wsRef.current = null;
-    }
-
-    setStatus("connecting");
-
-    try {
-      const ws = new WebSocket(getWsUrl());
-      wsRef.current = ws;
-
-      ws.onopen = () => {
-        reconnectAttemptsRef.current = 0;
-        setStatus("connected");
-      };
-
-      ws.onclose = () => {
-        if (isClosingRef.current) {
-          setStatus("disconnected");
-          return;
-        }
-
-        setStatus("disconnected");
-
-        // Attempt reconnection with exponential backoff
-        if (reconnectAttemptsRef.current < maxReconnectAttempts) {
-          const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 30000);
-          reconnectAttemptsRef.current++;
-
-          reconnectTimeoutRef.current = setTimeout(() => {
-            setStatus("connecting");
-            connectRef.current();
-          }, delay);
-        }
-      };
-
-      ws.onerror = () => {
-        // Error will trigger onclose, so we don't need to do much here
-      };
-
-      // Handle messages from the lint WebSocket
-      ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          // Lint WebSocket sends messages about lint run status
-          // We don't need to do anything special with them here,
-          // but we could emit events if needed in the future
-          console.log("[WebSocket] Lint update:", data.type);
-        } catch {
-          // Ignore parse errors
-        }
-      };
-    } catch {
-      setStatus("disconnected");
-    }
-  }, [enabled, projectId, getWsUrl]);
-
-  // Keep the ref in sync so the onclose callback always calls the latest version
-  useEffect(() => {
-    connectRef.current = connect;
-  }, [connect]);
-
-  const disconnect = useCallback(() => {
-    isClosingRef.current = true;
-
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-
-    if (wsRef.current) {
-      wsRef.current.close();
-      wsRef.current = null;
-    }
-
-    setStatus("disconnected");
-  }, []);
-
-  // Connect when enabled and we have a project ID
-  useEffect(() => {
-    if (enabled && projectId) {
-      isClosingRef.current = false;
-      // Small delay to avoid double-connect in React Strict Mode
-      const timeout = setTimeout(connect, 100);
-      return () => {
-        clearTimeout(timeout);
-        disconnect();
-      };
-    } else {
-      disconnect();
-    }
-  }, [enabled, projectId, connect, disconnect]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      isClosingRef.current = true;
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-      }
-      if (wsRef.current) {
-        wsRef.current.close();
-      }
-    };
-  }, []);
-
-  // Get the endpoint path for display (without the host)
-  const endpointPath = `/api/v1/projects/${projectId}/lint/ws`;
+export function useCollaborationStatus(_options: { projectId: string; enabled?: boolean }) {
+  const status: ConnectionState = "disabled";
 
   return {
     status,
-    isConnected: status === "connected",
-    reconnect: connect,
-    /** The WebSocket endpoint path */
-    endpoint: endpointPath,
-    /** Description of what this WebSocket connection is used for */
-    purpose: "Real-time lint status updates",
+    isConnected: false,
+    /** The collaboration WebSocket endpoint path (not yet available) */
+    endpoint: "/api/v1/collab/ws",
+    /** Description of what this connection is for */
+    purpose: "Real-time collaboration (coming soon)",
   };
 }

--- a/lib/hooks/useProjectViewer.ts
+++ b/lib/hooks/useProjectViewer.ts
@@ -14,8 +14,6 @@ export interface UseProjectViewerOptions {
   accessToken?: string;
   sessionStatus: "loading" | "authenticated" | "unauthenticated";
   activeBranch?: string;
-  /** Enable WebSocket connections (lint status, collaboration). Defaults to false. */
-  enableWebSocket?: boolean;
 }
 
 export function useProjectViewer({
@@ -23,7 +21,6 @@ export function useProjectViewer({
   accessToken,
   sessionStatus,
   activeBranch,
-  enableWebSocket = false,
 }: UseProjectViewerOptions) {
   // Project data from shared React Query cache
   const {

--- a/lib/hooks/useProjectViewer.ts
+++ b/lib/hooks/useProjectViewer.ts
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import { useOntologyTree } from "@/lib/hooks/useOntologyTree";
-import { useCollaborationStatus } from "@/lib/hooks/useCollaborationStatus";
 import { useProject, derivePermissions } from "@/lib/hooks/useProject";
 import { useOpenPRCount } from "@/lib/hooks/useOpenPRCount";
 import { useLintSummary } from "@/lib/hooks/useLintSummary";
@@ -68,13 +67,6 @@ export function useProjectViewer({
     projectId,
     accessToken,
     branchKey: activeBranch,
-  });
-
-  // WebSocket connection status (editor only)
-  const collaboration = useCollaborationStatus({
-    projectId,
-    enabled: enableWebSocket && !!projectId && !!accessToken && sessionStatus === "authenticated",
-    token: accessToken,
   });
 
   // Derive fallback data for the selected node from the tree
@@ -295,10 +287,5 @@ export function useProjectViewer({
     setSourceIriIndex,
     isIndexing,
     resetSourceState,
-
-    // Collaboration
-    connectionStatus: collaboration.status,
-    wsEndpoint: collaboration.endpoint,
-    wsPurpose: collaboration.purpose,
   };
 }


### PR DESCRIPTION
Closes #140

## Summary

- **`useCollaborationStatus`**: removed all WebSocket logic — returns `"disabled"` state until the real `/collab/ws` endpoint is implemented
- **`HealthCheckPanel`**: added `onWsStatusChange` prop to expose the lint WS connection state to the parent
- **`DeveloperEditorLayout`**: threads `onLintWsStatusChange` prop down to `HealthCheckPanel`
- **Editor toolbar**: collab icon now uses `useCollaborationStatus`; lint icon uses `HealthCheckPanel` WS status and only renders when the panel is open (eliminating the duplicate connection)
- **Viewer toolbar**: removed lint WS icon — the viewer has no `HealthCheckPanel`
- Removed `connectionStatus` / `wsEndpoint` / `wsPurpose` from `useProjectViewer` return value
- Removed stale `"exposes collaboration status"` test from `useProjectViewer` tests

## Before / After

**Before:**
```
Editor toolbar:
  [collab icon: disabled hardcoded]  [lint icon: useCollaborationStatus → /lint/ws]
HealthCheckPanel: creates its own WebSocket → /lint/ws  ← duplicate connection
```

**After:**
```
Editor toolbar:
  [collab icon: useCollaborationStatus → disabled]  [lint icon: HealthCheckPanel WS, only when open]
HealthCheckPanel: single WebSocket → /lint/ws, exposes status via onWsStatusChange
```

## Test plan

- [ ] Open editor — collab icon shows as disabled; no lint icon visible when health check panel is closed
- [ ] Open health check panel — lint WS icon appears and shows connecting → connected
- [ ] Close health check panel — lint WS icon disappears
- [ ] Viewer page — only collab (disabled) icon visible, no lint icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Collaboration support simplified: real-time collaboration is shown as disabled/"coming soon".

* **UI**
  * Project header displays a disabled collaboration status indicator.
  * Editor (developer mode) shows a separate lint WebSocket status in the Health Check panel; that panel resets lint status when closed and reports connection progress.

* **Tests**
  * Removed a unit test that asserted collaboration connection status exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->