### PR TITLE
Fix Private tab login prompt messaging

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,12 +160,20 @@ export default function HomePage() {
             {/* Private tab login prompt for unauthenticated users */}
             {(filter === "mine" || filter === "private") && !isAuthenticated ? (
               <div className="rounded-lg border border-slate-200 bg-white p-12 text-center dark:border-slate-700 dark:bg-slate-800">
-                <User className="mx-auto h-12 w-12 text-slate-400" />
+                {filter === "private" ? (
+                  <Lock className="mx-auto h-12 w-12 text-slate-400" />
+                ) : (
+                  <User className="mx-auto h-12 w-12 text-slate-400" />
+                )}
                 <h3 className="mt-4 text-lg font-medium text-slate-900 dark:text-slate-100">
-                  Sign in to see your projects
+                  {filter === "private"
+                    ? "Sign in to see private projects"
+                    : "Sign in to see your projects"}
                 </h3>
                 <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-                  View all projects you own or are a member of
+                  {filter === "private"
+                    ? "View all private projects you own or are a member of"
+                    : "View all projects you own or are a member of"}
                 </p>
                 <Button className="mt-6" onClick={() => signIn()}>
                   <LogIn className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- Differentiates the Private tab's unauthenticated prompt from the My Projects tab
- Private tab now shows: Lock icon, "Sign in to see private projects", "View all private projects you own or are a member of"
- My Projects tab remains unchanged: User icon, "Sign in to see your projects", "View all projects you own or are a member of"

Closes #164

## Test plan
- [x] Log out and navigate to the browse page
- [x] Select the "Private" tab — verify it shows "Sign in to see private projects" with the Lock icon
- [x] Select the "My Projects" tab — verify it still shows "Sign in to see your projects" with the User icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Access restriction prompts now intelligently display different visual indicators and messaging based on the specific type of content being accessed. When accessing restricted private content, users see lock-themed visual indicators accompanied by privacy-specific messaging. When accessing personal projects, user-themed indicators appear with personalized messaging. This provides clearer context for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->