### PR TITLE
fix(ci): prevent shell injection in pr-target-guard workflow

### DIFF
--- a/.github/workflows/pr-target-guard.yml
+++ b/.github/workflows/pr-target-guard.yml
@@ -4,16 +4,21 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   check-source-branch:
     runs-on: ubuntu-latest
     steps:
       - name: Only allow PRs from dev to main
         if: github.head_ref != 'dev'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           echo "::error::PRs targeting main must come from the dev branch."
           echo "::error::Please retarget this PR to dev, or merge into dev first."
           echo ""
-          echo "  Source branch: ${{ github.head_ref }}"
-          echo "  Target branch: ${{ github.base_ref }}"
+          echo "  Source branch: $HEAD_REF"
+          echo "  Target branch: $BASE_REF"
           exit 1


### PR DESCRIPTION
## Summary

- Move `github.head_ref` / `github.base_ref` interpolations into env vars so a malicious branch name can't inject shell commands into the `run:` block at YAML compile time
- Add empty `permissions: {}` block so the workflow runs with no granted permissions by default (the ontokit-api version of this workflow already has it)

Found by Semgrep `p/owasp-top-ten` rule `yaml.github-actions.security.run-shell-injection`. Reference: [GitHub Security Lab on Actions injection](https://securitylab.github.com/research/github-actions-untrusted-input/).

Closes #191

## Test plan

- [ ] CI: workflow still triggers as expected (non-`dev` source branch on PR to `main`)
- [ ] Verify Semgrep no longer flags the file (next scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)