### PR TITLE
chore(ci): pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: dependabot/fetch-metadata@v3
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         id: metadata
       - if: >-
           steps.metadata.outputs.update-type != 'version-update:semver-major' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,31 +13,31 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-node
       - run: npm run lint
 
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-node
       - run: npm run type-check
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
       - uses: ./.github/actions/setup-node
       - run: npm run test:coverage -- --run --reporter=junit --outputFile=test-report.junit.xml
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
-      - uses: codecov/test-results-action@v1
+      - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-node
       - run: npm run build
         env:
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           generateReleaseNotes: true
 
@@ -73,22 +73,22 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/ontokit-web
           tags: |
             type=semver,pattern={{version}},value=${{ github.ref_name }},prefix=ontokit-web-
             type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }},prefix=ontokit-web-
             type=raw,value=latest
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           push: true

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,7 @@ jobs:
     # of the whole codebase, and Dependabot can't read repository secrets anyway.
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       # `semgrep ci` is incompatible with explicit --config flags when logged in
       # (SEMGREP_APP_TOKEN set) — it expects rules from the server-side AppSec
       # policy. When not logged in, fall back to the explicit local rulesets so


### PR DESCRIPTION
## Summary

Supply-chain hardening: every third-party action is now pinned to a specific commit SHA so that a compromised tag (e.g., force-pushed by an attacker with write access to the action's repo) cannot silently substitute malicious code into our CI runners.

Pattern used:
\`\`\`yaml
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
\`\`\`
The trailing comment preserves the human-readable version and is the format Dependabot recognizes for tracking.

### Actions pinned

| Action | Pinned to |
|--------|-----------|
| actions/checkout | v6 |
| actions/setup-node | v4 |
| codecov/codecov-action | v6 |
| codecov/test-results-action | v1 |
| dependabot/fetch-metadata | v3 |
| docker/setup-buildx-action | v4 |
| docker/login-action | v4 |
| docker/metadata-action | v6 |
| docker/build-push-action | v7 |
| ncipollo/release-action | v1 |

The local composite action \`./.github/actions/setup-node\` is intentionally not SHA-pinned — it lives in this repo so its content is already covered by the commit graph.

A matching PR will land on \`ontokit-api\`.

## Test plan

- [ ] All CI checks (Semgrep, lint, type-check, test, build) still pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)