### PR TITLE
fix(properties): classify by backend property_kind + add Other Properties group

### DIFF
--- a/__tests__/components/editor/standard/PropertyTree.test.tsx
+++ b/__tests__/components/editor/standard/PropertyTree.test.tsx
@@ -118,10 +118,13 @@ describe("PropertyTree", () => {
     });
   });
 
-  it("groups properties into Object Properties based on IRI pattern", async () => {
+  it("groups properties into Object Properties via property_kind=object", async () => {
+    // Note: the IRI here intentionally has no "objectproperty" substring —
+    // grouping must come from the backend-supplied property_kind, not from
+    // pattern-matching the IRI string.
     mockSearchEntities.mockResolvedValue({
       results: [
-        { iri: "http://ex.org/objectproperty/hasPart", label: "hasPart", deprecated: false },
+        { iri: "http://ex.org/hasPart", label: "hasPart", entity_type: "property", property_kind: "object", deprecated: false },
       ],
     });
     render(<PropertyTree {...defaultProps} />);
@@ -131,10 +134,10 @@ describe("PropertyTree", () => {
     });
   });
 
-  it("groups data properties based on IRI pattern", async () => {
+  it("groups data properties via property_kind=data", async () => {
     mockSearchEntities.mockResolvedValue({
       results: [
-        { iri: "http://ex.org/datatypeproperty/hasAge", label: "hasAge", deprecated: false },
+        { iri: "http://ex.org/hasAge", label: "hasAge", entity_type: "property", property_kind: "data", deprecated: false },
       ],
     });
     render(<PropertyTree {...defaultProps} />);
@@ -143,10 +146,10 @@ describe("PropertyTree", () => {
     });
   });
 
-  it("groups annotation properties based on IRI pattern", async () => {
+  it("groups annotation properties via property_kind=annotation", async () => {
     mockSearchEntities.mockResolvedValue({
       results: [
-        { iri: "http://www.w3.org/2000/01/rdf-schema#seeAlso", label: "seeAlso", deprecated: false },
+        { iri: "http://ex.org/seeAlso", label: "seeAlso", entity_type: "property", property_kind: "annotation", deprecated: false },
       ],
     });
     render(<PropertyTree {...defaultProps} />);
@@ -155,23 +158,45 @@ describe("PropertyTree", () => {
     });
   });
 
-  it("falls back to flat 'Properties' group when no type hints", async () => {
+  it("groups properties without property_kind into 'Other Properties'", async () => {
+    // Covers both edge cases (rdf:Property without OWL subtype) and older
+    // backends that haven't started populating property_kind yet.
     mockSearchEntities.mockResolvedValue({
       results: [
-        { iri: "http://ex.org/someProp", label: "someProp", deprecated: false },
+        { iri: "http://ex.org/someProp", label: "someProp", entity_type: "property", deprecated: false },
+        { iri: "http://ex.org/otherProp", label: "otherProp", entity_type: "property", property_kind: null, deprecated: false },
       ],
     });
     render(<PropertyTree {...defaultProps} />);
     await waitFor(() => {
-      // Properties with no IRI type hints default to object group
+      expect(screen.getByText("Other Properties")).toBeDefined();
+      expect(screen.getByText("someProp")).toBeDefined();
+      expect(screen.getByText("otherProp")).toBeDefined();
+    });
+  });
+
+  it("renders all four groups when properties of every kind are present", async () => {
+    mockSearchEntities.mockResolvedValue({
+      results: [
+        { iri: "http://ex.org/hasPart", label: "hasPart", entity_type: "property", property_kind: "object", deprecated: false },
+        { iri: "http://ex.org/hasAge", label: "hasAge", entity_type: "property", property_kind: "data", deprecated: false },
+        { iri: "http://ex.org/seeAlso", label: "seeAlso", entity_type: "property", property_kind: "annotation", deprecated: false },
+        { iri: "http://ex.org/raw", label: "raw", entity_type: "property", deprecated: false },
+      ],
+    });
+    render(<PropertyTree {...defaultProps} />);
+    await waitFor(() => {
       expect(screen.getByText("Object Properties")).toBeDefined();
+      expect(screen.getByText("Data Properties")).toBeDefined();
+      expect(screen.getByText("Annotation Properties")).toBeDefined();
+      expect(screen.getByText("Other Properties")).toBeDefined();
     });
   });
 
   it("uses local name when label is empty", async () => {
     mockSearchEntities.mockResolvedValue({
       results: [
-        { iri: "http://ex.org/objectproperty/myProp", label: "", deprecated: false },
+        { iri: "http://ex.org/myProp", label: "", entity_type: "property", property_kind: "object", deprecated: false },
       ],
     });
     render(<PropertyTree {...defaultProps} />);
@@ -183,7 +208,7 @@ describe("PropertyTree", () => {
   it("supports expand/collapse of property groups", async () => {
     mockSearchEntities.mockResolvedValue({
       results: [
-        { iri: "http://ex.org/objectproperty/hasPart", label: "hasPart", deprecated: false },
+        { iri: "http://ex.org/hasPart", label: "hasPart", entity_type: "property", property_kind: "object", deprecated: false },
       ],
     });
     const onSelect = vi.fn();

--- a/components/editor/standard/PropertyTree.tsx
+++ b/components/editor/standard/PropertyTree.tsx
@@ -51,35 +51,28 @@ export function PropertyTree({
 
         if (cancelled) return;
 
-        // Group properties by likely type based on IRI patterns
+        // Group properties by their declared OWL subtype as exposed by the
+        // backend. Falls back to "Other" when property_kind is missing — that
+        // covers both unusual rdf:type combinations (e.g. plain rdf:Property)
+        // and older backends that don't yet populate the field.
         const objectProps: EntitySearchResult[] = [];
         const dataProps: EntitySearchResult[] = [];
         const annotationProps: EntitySearchResult[] = [];
+        const otherProps: EntitySearchResult[] = [];
 
         for (const prop of response.results) {
-          const iri = prop.iri.toLowerCase();
-          if (
-            iri.includes("objectproperty") ||
-            iri.includes("object-property")
-          ) {
-            objectProps.push(prop);
-          } else if (
-            iri.includes("datatypeproperty") ||
-            iri.includes("datatype-property") ||
-            iri.includes("dataproperty")
-          ) {
-            dataProps.push(prop);
-          } else if (
-            iri.includes("annotationproperty") ||
-            iri.includes("annotation-property") ||
-            iri.startsWith("http://www.w3.org/2000/01/rdf-schema#") ||
-            iri.startsWith("http://www.w3.org/2004/02/skos/core#") ||
-            iri.startsWith("http://purl.org/dc/")
-          ) {
-            annotationProps.push(prop);
-          } else {
-            // Default to object property group
-            objectProps.push(prop);
+          switch (prop.property_kind) {
+            case "object":
+              objectProps.push(prop);
+              break;
+            case "data":
+              dataProps.push(prop);
+              break;
+            case "annotation":
+              annotationProps.push(prop);
+              break;
+            default:
+              otherProps.push(prop);
           }
         }
 
@@ -93,10 +86,8 @@ export function PropertyTree({
         if (annotationProps.length > 0) {
           newGroups.push({ label: "Annotation Properties", type: "annotation", items: annotationProps, isExpanded: true });
         }
-
-        // If all ended up in one bucket with no type hints, show flat
-        if (newGroups.length === 0 && response.results.length > 0) {
-          newGroups.push({ label: "Properties", type: "all", items: response.results, isExpanded: true });
+        if (otherProps.length > 0) {
+          newGroups.push({ label: "Other Properties", type: "other", items: otherProps, isExpanded: true });
         }
 
         setGroups(newGroups);

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -607,6 +607,14 @@ export interface EntitySearchResult {
   iri: string;
   label: string;
   entity_type: "class" | "property" | "individual";
+  /**
+   * OWL property subtype, populated only when entity_type === "property".
+   * Null/undefined for class / individual results, and also for properties
+   * whose rdf:type resolves to none of OWL.{Object,Datatype,Annotation}Property
+   * (defensive fallback). Lets clients group properties without IRI-substring
+   * guessing — see ontokit-api#117.
+   */
+  property_kind?: "object" | "data" | "annotation" | null;
   deprecated: boolean;
 }
 


### PR DESCRIPTION
## Summary

`PropertyTree` was bucketing properties via IRI-substring guessing — `iri.includes('objectproperty')` and similar — which is wrong for any real-world ontology. A property named \`:hasName\` or \`:worksFor\` contains none of the magic substrings and silently falls into Object Properties regardless of what its declared \`rdf:type\` actually is.

This PR replaces the heuristic with the **new \`property_kind\` field** exposed by the backend in [ontokit-api#117](https://github.com/CatholicOS/ontokit-api/issues/117) / [ontokit-api#120](https://github.com/CatholicOS/ontokit-api/pull/120). Each result is now grouped strictly by what its \`rdf:type\` resolves to:

| \`property_kind\` | Group |
|------------------|-------|
| \`object\` | Object Properties |
| \`data\` | Data Properties |
| \`annotation\` | Annotation Properties |
| \`null\` / unset | **Other Properties** *(new)* |

The "Other Properties" group catches:
- Properties whose \`rdf:type\` is something other than \`OWL.{Object,Datatype,Annotation}Property\` (e.g. plain \`rdf:Property\`)
- Older backend deployments that don't yet populate \`property_kind\` — those properties surface visibly under "Other" rather than being silently misclassified

## ⚠️ Dependency

**Depends on [ontokit-api#120](https://github.com/CatholicOS/ontokit-api/pull/120).** Until that PR ships and the backend rebuilds, all properties will land in "Other Properties" because \`property_kind\` will be undefined. Merge order:

1. ontokit-api#120 → \`dev\` → release
2. This PR → \`dev\`

Closes #176

## Test plan

- [x] All 13 PropertyTree tests pass with the new contract
- [x] Full suite: 2679 / 2679
- [x] Type check clean
- [ ] Manual: load a project with \`owl:DatatypeProperty\` instances; confirm they land under "Data Properties" (not Object Properties as before)
- [ ] Manual: load a project with mixed property types; verify all four groups can render together
- [ ] Manual: verify a property-only ontology with non-OWL \`rdf:Property\` instances groups under "Other Properties"

🤖 Generated with [Claude Code](https://claude.com/claude-code)