### PR TITLE
docs(guide): add Properties chapter — rdf:Property + OWL property typology

### DIFF
--- a/__tests__/components/docs/ChangelogToc.test.tsx
+++ b/__tests__/components/docs/ChangelogToc.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
@@ -12,6 +12,62 @@ const entries = [
   { version: "0.2.0", date: "2026-03-21" },
   { version: "0.1.0", date: "2026-02-18" },
 ];
+
+function setScrollState({
+  scrollY,
+  innerHeight,
+  scrollHeight,
+}: {
+  scrollY: number;
+  innerHeight: number;
+  scrollHeight: number;
+}) {
+  Object.defineProperty(window, "scrollY", {
+    configurable: true,
+    writable: true,
+    value: scrollY,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: innerHeight,
+  });
+  Object.defineProperty(document.documentElement, "scrollHeight", {
+    configurable: true,
+    writable: true,
+    value: scrollHeight,
+  });
+}
+
+function mountTargets(absoluteTops: Record<string, number>) {
+  for (const [id, absoluteTop] of Object.entries(absoluteTops)) {
+    const el = document.createElement("div");
+    el.id = id;
+    el.getBoundingClientRect = () => {
+      const top = absoluteTop - (window.scrollY ?? 0);
+      return {
+        top,
+        bottom: top + 100,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 100,
+        x: 0,
+        y: top,
+        toJSON: () => undefined,
+      } as DOMRect;
+    };
+    document.body.appendChild(el);
+  }
+}
+
+afterEach(() => {
+  for (const { version } of entries) {
+    const id = `v-${version.replace(/\./g, "-")}`;
+    const el = document.getElementById(id);
+    if (el) el.remove();
+  }
+});
 
 describe("ChangelogToc", () => {
   it("renders the Releases heading", () => {
@@ -61,5 +117,61 @@ describe("ChangelogToc", () => {
   it("renders nothing-breaking when given an empty list", () => {
     render(<ChangelogToc entries={[]} />);
     expect(screen.getByText("Releases")).toBeDefined();
+  });
+
+  it("activates the closest section above the scroll probe on mount", () => {
+    setScrollState({ scrollY: 0, innerHeight: 800, scrollHeight: 3000 });
+    mountTargets({ "v-0-3-0": 50, "v-0-2-0": 1100, "v-0-1-0": 2100 });
+    render(<ChangelogToc entries={entries} />);
+    expect(
+      screen.getByText("0.3.0").closest("a")?.getAttribute("aria-current"),
+    ).toBe("true");
+    expect(
+      screen.getByText("0.2.0").closest("a")?.getAttribute("aria-current"),
+    ).toBeNull();
+  });
+
+  it("updates the active section after a scroll event", () => {
+    setScrollState({ scrollY: 0, innerHeight: 800, scrollHeight: 3000 });
+    mountTargets({ "v-0-3-0": 50, "v-0-2-0": 1100, "v-0-1-0": 2100 });
+    render(<ChangelogToc entries={entries} />);
+
+    setScrollState({ scrollY: 1100, innerHeight: 800, scrollHeight: 3000 });
+    fireEvent.scroll(window);
+
+    expect(
+      screen.getByText("0.2.0").closest("a")?.getAttribute("aria-current"),
+    ).toBe("true");
+  });
+
+  it("activates the last entry when the page is scrolled to the bottom", () => {
+    setScrollState({ scrollY: 0, innerHeight: 800, scrollHeight: 3000 });
+    mountTargets({ "v-0-3-0": 50, "v-0-2-0": 1100, "v-0-1-0": 2100 });
+    render(<ChangelogToc entries={entries} />);
+
+    // viewportBottom (2200 + 800 = 3000) - docHeight (3000) = 0 < 8 → bottom guard
+    setScrollState({ scrollY: 2200, innerHeight: 800, scrollHeight: 3000 });
+    fireEvent.scroll(window);
+
+    expect(
+      screen.getByText("0.1.0").closest("a")?.getAttribute("aria-current"),
+    ).toBe("true");
+  });
+
+  it("removes scroll and resize listeners on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    setScrollState({ scrollY: 0, innerHeight: 800, scrollHeight: 3000 });
+    mountTargets({ "v-0-3-0": 50, "v-0-2-0": 1100, "v-0-1-0": 2100 });
+    const { unmount } = render(<ChangelogToc entries={entries} />);
+    unmount();
+    const events = removeSpy.mock.calls.map(([type]) => type);
+    expect(events).toContain("scroll");
+    expect(events).toContain("resize");
+    removeSpy.mockRestore();
+  });
+
+  it("does not crash when no matching section elements exist", () => {
+    setScrollState({ scrollY: 0, innerHeight: 800, scrollHeight: 3000 });
+    expect(() => render(<ChangelogToc entries={entries} />)).not.toThrow();
   });
 });

--- a/__tests__/components/docs/ChangelogToc.test.tsx
+++ b/__tests__/components/docs/ChangelogToc.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+import { ChangelogToc } from "@/components/docs/ChangelogToc";
+
+const entries = [
+  { version: "0.3.0", date: "2026-04-09" },
+  { version: "0.2.0", date: "2026-03-21" },
+  { version: "0.1.0", date: "2026-02-18" },
+];
+
+describe("ChangelogToc", () => {
+  it("renders the Releases heading", () => {
+    render(<ChangelogToc entries={entries} />);
+    expect(screen.getByText("Releases")).toBeDefined();
+  });
+
+  it("renders one link per entry with the version label", () => {
+    render(<ChangelogToc entries={entries} />);
+    for (const { version } of entries) {
+      expect(screen.getByText(version)).toBeDefined();
+    }
+  });
+
+  it("renders the date next to each version", () => {
+    render(<ChangelogToc entries={entries} />);
+    for (const { date } of entries) {
+      expect(screen.getByText(date)).toBeDefined();
+    }
+  });
+
+  it("links each version to its anchor id", () => {
+    render(<ChangelogToc entries={entries} />);
+    expect(screen.getByText("0.3.0").closest("a")?.getAttribute("href")).toBe(
+      "#v-0-3-0",
+    );
+    expect(screen.getByText("0.2.0").closest("a")?.getAttribute("href")).toBe(
+      "#v-0-2-0",
+    );
+    expect(screen.getByText("0.1.0").closest("a")?.getAttribute("href")).toBe(
+      "#v-0-1-0",
+    );
+  });
+
+  it("marks the first entry active on initial render", () => {
+    render(<ChangelogToc entries={entries} />);
+    const first = screen.getByText("0.3.0").closest("a");
+    expect(first?.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("does not mark non-first entries active on initial render", () => {
+    render(<ChangelogToc entries={entries} />);
+    const second = screen.getByText("0.2.0").closest("a");
+    expect(second?.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("renders nothing-breaking when given an empty list", () => {
+    render(<ChangelogToc entries={[]} />);
+    expect(screen.getByText("Releases")).toBeDefined();
+  });
+});

--- a/__tests__/lib/docs/changelog.test.ts
+++ b/__tests__/lib/docs/changelog.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { changelogAnchorId } from "@/lib/docs/changelog";
+
+describe("changelogAnchorId", () => {
+  it("prefixes with v- and replaces dots with hyphens", () => {
+    expect(changelogAnchorId("0.3.0")).toBe("v-0-3-0");
+  });
+
+  it("handles a version with no dots", () => {
+    expect(changelogAnchorId("1")).toBe("v-1");
+  });
+
+  it("handles a four-segment version", () => {
+    expect(changelogAnchorId("1.2.3.4")).toBe("v-1-2-3-4");
+  });
+
+  it("preserves pre-release suffixes (no dots inside the suffix)", () => {
+    expect(changelogAnchorId("1.0.0-rc1")).toBe("v-1-0-0-rc1");
+  });
+
+  it("replaces dots inside pre-release suffixes too", () => {
+    expect(changelogAnchorId("1.0.0-rc.1")).toBe("v-1-0-0-rc-1");
+  });
+
+  it("returns the same id for the same input (deterministic)", () => {
+    expect(changelogAnchorId("0.1.0")).toBe(changelogAnchorId("0.1.0"));
+  });
+});

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -42,6 +42,7 @@ export default function ApiDocsPage() {
         <ApiReferenceReact
           configuration={{
             url: `${API_BASE_URL}/openapi.json`,
+            servers: [{ url: API_BASE_URL }],
             theme: "kepler",
             hideModels: false,
             hideDownloadButton: false,

--- a/app/docs/changelog/page.tsx
+++ b/app/docs/changelog/page.tsx
@@ -1,3 +1,5 @@
+import { ChangelogToc } from "@/components/docs/ChangelogToc";
+
 interface ChangelogCategory {
   title: string;
   items: string[];
@@ -170,46 +172,52 @@ const changelog: ChangelogEntry[] = [
 
 export default function ChangelogPage() {
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
-      <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
-        Changelog
-      </h1>
-      <p className="text-slate-600 dark:text-slate-400 mb-8">
-        Summary of changes for each release.
-      </p>
+    <div className="container mx-auto px-4 py-8 flex gap-8">
+      <div className="min-w-0 flex-1 max-w-4xl">
+        <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
+          Changelog
+        </h1>
+        <p className="text-slate-600 dark:text-slate-400 mb-8">
+          Summary of changes for each release.
+        </p>
 
-      <div className="space-y-8">
-        {changelog.map((entry) => (
-          <div
-            key={entry.version}
-            className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6"
-          >
-            <div className="flex items-baseline gap-3 mb-4">
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
-                {entry.version}
-              </h2>
-              <span className="text-sm text-slate-500 dark:text-slate-400">
-                {entry.date}
-              </span>
-            </div>
+        <div className="space-y-8">
+          {changelog.map((entry) => (
+            <section
+              key={entry.version}
+              id={`v-${entry.version.replace(/\./g, "-")}`}
+              className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 scroll-mt-4"
+            >
+              <div className="flex items-baseline gap-3 mb-4">
+                <h2 className="text-xl font-semibold text-slate-900 dark:text-white">
+                  {entry.version}
+                </h2>
+                <span className="text-sm text-slate-500 dark:text-slate-400">
+                  {entry.date}
+                </span>
+              </div>
 
-            <div className="space-y-4">
-              {entry.categories.map((category) => (
-                <div key={category.title}>
-                  <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-300 mb-2">
-                    {category.title}
-                  </h3>
-                  <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 text-sm space-y-1">
-                    {category.items.map((item, i) => (
-                      <li key={i}>{item}</li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
+              <div className="space-y-4">
+                {entry.categories.map((category) => (
+                  <div key={category.title}>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-300 mb-2">
+                      {category.title}
+                    </h3>
+                    <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 text-sm space-y-1">
+                      {category.items.map((item, i) => (
+                        <li key={i}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
       </div>
+      <ChangelogToc
+        entries={changelog.map(({ version, date }) => ({ version, date }))}
+      />
     </div>
   );
 }

--- a/app/docs/changelog/page.tsx
+++ b/app/docs/changelog/page.tsx
@@ -173,6 +173,9 @@ const changelog: ChangelogEntry[] = [
 export default function ChangelogPage() {
   return (
     <div className="container mx-auto px-4 py-8 flex gap-8">
+      <ChangelogToc
+        entries={changelog.map(({ version, date }) => ({ version, date }))}
+      />
       <div className="min-w-0 flex-1 max-w-4xl">
         <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
           Changelog
@@ -215,9 +218,6 @@ export default function ChangelogPage() {
           ))}
         </div>
       </div>
-      <ChangelogToc
-        entries={changelog.map(({ version, date }) => ({ version, date }))}
-      />
     </div>
   );
 }

--- a/app/docs/changelog/page.tsx
+++ b/app/docs/changelog/page.tsx
@@ -1,4 +1,5 @@
 import { ChangelogToc } from "@/components/docs/ChangelogToc";
+import { changelogAnchorId } from "@/lib/docs/changelog";
 
 interface ChangelogCategory {
   title: string;
@@ -188,7 +189,7 @@ export default function ChangelogPage() {
           {changelog.map((entry) => (
             <section
               key={entry.version}
-              id={`v-${entry.version.replace(/\./g, "-")}`}
+              id={changelogAnchorId(entry.version)}
               className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-6 scroll-mt-4"
             >
               <div className="flex items-baseline gap-3 mb-4">

--- a/app/docs/guide/formats/page.tsx
+++ b/app/docs/guide/formats/page.tsx
@@ -7,7 +7,7 @@ export default function FormatsPage() {
         What are the Ontology Formats?
       </h1>
       <p className="text-slate-600 dark:text-slate-400 mb-8">
-        RDF is the underlying data model, but there are several serialization formats for writing
+        RDF is the underlying data model, but there are several serialization formats for writing{" "}
         it down. Each has trade-offs in readability, verbosity, and tool support.
       </p>
 
@@ -19,14 +19,14 @@ export default function FormatsPage() {
           </h2>
           <div className="prose prose-slate dark:prose-invert max-w-none space-y-4">
             <p className="text-slate-600 dark:text-slate-400">
-              The Resource Description Framework (RDF) represents knowledge as a set
-              of <strong>triples</strong>: subject &ndash; predicate &ndash; object. Subjects and
-              predicates are IRIs; objects can be IRIs or literal values (strings, numbers, dates).
+              The Resource Description Framework (RDF) represents knowledge as a set{" "}
+              of <strong>triples</strong>: subject &ndash; predicate &ndash; object. Subjects and{" "}
+              predicates are IRIs; objects can be IRIs or literal values (strings, numbers, dates).{" "}
               A collection of triples forms a directed graph.
             </p>
             <p className="text-slate-600 dark:text-slate-400">
-              The <em>format</em> (or serialization) determines how those triples are written in a
-              file. The same graph can be serialized in Turtle, RDF/XML, JSON-LD, or any other RDF
+              The <em>format</em> (or serialization) determines how those triples are written in a{" "}
+              file. The same graph can be serialized in Turtle, RDF/XML, JSON-LD, or any other RDF{" "}
               format &mdash; the information content is identical.
             </p>
           </div>
@@ -39,8 +39,8 @@ export default function FormatsPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              Turtle (Terse RDF Triple Language) is the most popular human-readable RDF format. It
-              supports prefix abbreviations, multi-value shorthand with commas, and multi-predicate
+              Turtle (Terse RDF Triple Language) is the most popular human-readable RDF format. It{" "}
+              supports prefix abbreviations, multi-value shorthand with commas, and multi-predicate{" "}
               shorthand with semicolons. OntoKit uses Turtle as its canonical format.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -66,7 +66,7 @@ ex:Dog a owl:Class ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              The original W3C serialization from 1999. Verbose but widely supported by XML
+              The original W3C serialization from 1999. Verbose but widely supported by XML{" "}
               toolchains. Harder for humans to read but excellent for machine-to-machine exchange.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -92,8 +92,8 @@ ex:Dog a owl:Class ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              A line-based format where each line is exactly one triple with full IRIs (no
-              prefixes). Extremely simple to parse and ideal for streaming or bulk loading, but
+              A line-based format where each line is exactly one triple with full IRIs (no{" "}
+              prefixes). Extremely simple to parse and ideal for streaming or bulk loading, but{" "}
               very verbose.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -113,9 +113,9 @@ ex:Dog a owl:Class ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              JSON-LD embeds RDF data in standard JSON using
-              a <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">@context</code> block.
-              Popular with web developers because it integrates directly with JavaScript and REST
+              JSON-LD embeds RDF data in standard JSON using{" "}
+              a <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">@context</code> block.{" "}
+              Popular with web developers because it integrates directly with JavaScript and REST{" "}
               APIs. Used by Schema.org for structured data in web pages.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -150,8 +150,8 @@ ex:Dog a owl:Class ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400">
-              N3 is a superset of Turtle that adds formulas, variables, and built-in predicates for
-              expressing rules. While less common for publishing ontologies, it is used in reasoning
+              N3 is a superset of Turtle that adds formulas, variables, and built-in predicates for{" "}
+              expressing rules. While less common for publishing ontologies, it is used in reasoning{" "}
               and logic programming contexts.
             </p>
           </div>

--- a/app/docs/guide/introduction/page.tsx
+++ b/app/docs/guide/introduction/page.tsx
@@ -18,15 +18,15 @@ export default function IntroductionPage() {
           </h2>
           <div className="prose prose-slate dark:prose-invert max-w-none space-y-4">
             <p className="text-slate-600 dark:text-slate-400">
-              In philosophy, an ontology is the study of what exists &mdash; the nature of being and
-              the categories of reality. In computer science and the Semantic Web, the term has been
-              borrowed to mean something more specific: a <strong>formal, explicit specification of
+              In philosophy, an ontology is the study of what exists &mdash; the nature of being and{" "}
+              the categories of reality. In computer science and the Semantic Web, the term has been{" "}
+              borrowed to mean something more specific: a <strong>formal, explicit specification of{" "}
               a shared conceptualization</strong>.
             </p>
             <p className="text-slate-600 dark:text-slate-400">
-              Put simply, an ontology is a structured way to describe the concepts in a domain (such
-              as medicine, law, or cultural heritage) and the relationships between them. Unlike a
-              simple glossary or database schema, an ontology uses logic-based formalisms that allow
+              Put simply, an ontology is a structured way to describe the concepts in a domain (such{" "}
+              as medicine, law, or cultural heritage) and the relationships between them. Unlike a{" "}
+              simple glossary or database schema, an ontology uses logic-based formalisms that allow{" "}
               machines to reason about the data automatically.
             </p>
           </div>
@@ -40,22 +40,22 @@ export default function IntroductionPage() {
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700 space-y-3">
             <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-2">
               <li>
-                <strong>Interoperability:</strong> Ontologies provide a common vocabulary so that
-                different systems, organizations, and datasets can share and integrate data without
+                <strong>Interoperability:</strong> Ontologies provide a common vocabulary so that{" "}
+                different systems, organizations, and datasets can share and integrate data without{" "}
                 ambiguity.
               </li>
               <li>
-                <strong>Reasoning:</strong> Because ontologies are logic-based, reasoners can infer
-                new facts that were not explicitly stated &mdash; for example, deducing that a
-                &ldquo;Penguin&rdquo; is a &ldquo;Bird&rdquo; even if only the subclass chain is
+                <strong>Reasoning:</strong> Because ontologies are logic-based, reasoners can infer{" "}
+                new facts that were not explicitly stated &mdash; for example, deducing that a{" "}
+                &ldquo;Penguin&rdquo; is a &ldquo;Bird&rdquo; even if only the subclass chain is{" "}
                 defined.
               </li>
               <li>
-                <strong>Knowledge reuse:</strong> Well-designed ontologies can be shared and extended
+                <strong>Knowledge reuse:</strong> Well-designed ontologies can be shared and extended{" "}
                 across projects, preventing each team from reinventing the same domain model.
               </li>
               <li>
-                <strong>Data validation:</strong> Ontologies define constraints (e.g., a person must
+                <strong>Data validation:</strong> Ontologies define constraints (e.g., a person must{" "}
                 have exactly one birth date) that can be used to validate data quality.
               </li>
             </ul>
@@ -73,7 +73,7 @@ export default function IntroductionPage() {
                 Biomedical Sciences
               </h3>
               <p className="text-slate-600 dark:text-slate-400 text-sm">
-                The Gene Ontology (GO) and SNOMED CT organize biological processes and clinical
+                The Gene Ontology (GO) and SNOMED CT organize biological processes and clinical{" "}
                 terminology used by researchers and hospitals worldwide.
               </p>
             </div>
@@ -82,7 +82,7 @@ export default function IntroductionPage() {
                 Cultural Heritage
               </h3>
               <p className="text-slate-600 dark:text-slate-400 text-sm">
-                CIDOC-CRM models museum artifacts, historical events, and provenance so that
+                CIDOC-CRM models museum artifacts, historical events, and provenance so that{" "}
                 collections across institutions can be linked together.
               </p>
             </div>
@@ -91,7 +91,7 @@ export default function IntroductionPage() {
                 E-Commerce
               </h3>
               <p className="text-slate-600 dark:text-slate-400 text-sm">
-                Schema.org provides structured product data that search engines use to display rich
+                Schema.org provides structured product data that search engines use to display rich{" "}
                 snippets and power product comparisons.
               </p>
             </div>
@@ -100,7 +100,7 @@ export default function IntroductionPage() {
                 Libraries & Publishing
               </h3>
               <p className="text-slate-600 dark:text-slate-400 text-sm">
-                Dublin Core and BIBFRAME describe publications and library holdings, enabling
+                Dublin Core and BIBFRAME describe publications and library holdings, enabling{" "}
                 cross-catalog search and linked open data.
               </p>
             </div>
@@ -114,7 +114,7 @@ export default function IntroductionPage() {
           </h2>
           <div className="prose prose-slate dark:prose-invert max-w-none space-y-4">
             <p className="text-slate-600 dark:text-slate-400">
-              Ontologies sit at the heart of the W3C Semantic Web architecture, often visualized as
+              Ontologies sit at the heart of the W3C Semantic Web architecture, often visualized as{" "}
               a layered &ldquo;cake&rdquo;:
             </p>
           </div>
@@ -136,8 +136,8 @@ export default function IntroductionPage() {
   └───────────────────────┘`}</pre>
           </div>
           <p className="text-slate-600 dark:text-slate-400 text-sm mt-3">
-            Each layer builds on those below it. RDF provides the basic data model of triples (subject,
-            predicate, object). RDFS adds vocabulary constructs like classes and properties. OWL adds
+            Each layer builds on those below it. RDF provides the basic data model of triples (subject,{" "}
+            predicate, object). RDFS adds vocabulary constructs like classes and properties. OWL adds{" "}
             formal logic for richer ontology modeling.
           </p>
         </section>

--- a/app/docs/guide/introduction/page.tsx
+++ b/app/docs/guide/introduction/page.tsx
@@ -55,8 +55,19 @@ export default function IntroductionPage() {
                 across projects, preventing each team from reinventing the same domain model.
               </li>
               <li>
-                <strong>Data validation:</strong> Ontologies define constraints (e.g., a person must{" "}
-                have exactly one birth date) that can be used to validate data quality.
+                <strong>Entailment &amp; consistency checking:</strong> Ontologies express{" "}
+                constraints (e.g., a person has at most one birth date) that a reasoner uses to{" "}
+                derive new facts and detect contradictions. Because OWL adopts the open-world{" "}
+                assumption, it isn&apos;t a closed-world data validator &mdash; for that, use{" "}
+                <a
+                  href="https://www.w3.org/TR/shacl/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  SHACL
+                </a>{" "}
+                or a similar shape/constraint language alongside the ontology.
               </li>
             </ul>
           </div>

--- a/app/docs/guide/page.tsx
+++ b/app/docs/guide/page.tsx
@@ -8,7 +8,7 @@ export default function GuideLandingPage() {
         Guide to Ontologies
       </h1>
       <p className="text-slate-600 dark:text-slate-400 mb-8">
-        A beginner-friendly introduction to ontologies, their formats, syntaxes, and the
+        A beginner-friendly introduction to ontologies, their formats, syntaxes, and the{" "}
         vocabularies that power the Semantic Web.
       </p>
 

--- a/app/docs/guide/properties/page.tsx
+++ b/app/docs/guide/properties/page.tsx
@@ -7,10 +7,10 @@ export default function PropertiesPage() {
         What are Properties?
       </h1>
       <p className="text-slate-600 dark:text-slate-400 mb-8">
-        Properties are the verbs of an ontology &mdash; they describe how individuals relate
-        to each other and what attributes they carry. RDF defines a single base type and OWL
-        layers a richer typology on top, with axioms for characteristics (functional,
-        transitive, &hellip;) and relationships between properties (sub-property,
+        Properties are the verbs of an ontology &mdash; they describe how individuals relate{" "}
+        to each other and what attributes they carry. RDF defines a single base type and OWL{" "}
+        layers a richer typology on top, with axioms for characteristics (functional,{" "}
+        transitive, &hellip;) and relationships between properties (sub-property,{" "}
         equivalence, disjointness).
       </p>
 
@@ -22,14 +22,14 @@ export default function PropertiesPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Every predicate that connects a subject to an object in an RDF triple is, at
-              minimum, an <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code>.
-              The W3C RDF specification doesn&apos;t distinguish between &ldquo;properties that
-              point to other resources&rdquo; and &ldquo;properties that hold literal
-              values&rdquo; &mdash; it&apos;s just one flat type. RDFS adds
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code> and
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code>
-              to constrain what classes a property can apply to and what kind of values it
+              Every predicate that connects a subject to an object in an RDF triple is, at{" "}
+              minimum, an <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code>.{" "}
+              The W3C RDF specification doesn&apos;t distinguish between &ldquo;properties that{" "}
+              point to other resources&rdquo; and &ldquo;properties that hold literal{" "}
+              values&rdquo; &mdash; it&apos;s just one flat type. RDFS adds{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code> and{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code>{" "}
+              to constrain what classes a property can apply to and what kind of values it{" "}
               accepts, but the typology stops there.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -41,8 +41,8 @@ ex:hasMember a rdf:Property ;
     rdfs:range  ex:Person .`}</pre>
             </div>
             <p className="text-slate-600 dark:text-slate-400 mt-3 text-sm">
-              For most modelling tasks the OWL property kinds (below) are a better fit, since
-              they let reasoners distinguish references from literal values and enforce the
+              For most modelling tasks the OWL property kinds (below) are a better fit, since{" "}
+              they let reasoners distinguish references from literal values and enforce the{" "}
               difference automatically.
             </p>
           </div>
@@ -55,10 +55,10 @@ ex:hasMember a rdf:Property ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Connects an individual to <em>another individual</em> &mdash; the range is always
-              another resource (an IRI or blank node), never a literal. Use object properties
-              for relationships between things: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">memberOf</code>,
+              Connects an individual to <em>another individual</em> &mdash; the range is always{" "}
+              another resource (an IRI or blank node), never a literal. Use object properties{" "}
+              for relationships between things: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">memberOf</code>,{" "}
               <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">locatedIn</code>.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -80,13 +80,13 @@ ex:Alice ex:hasParent ex:Bob .   # both must be IRIs / individuals`}</pre>
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Connects an individual to a <em>literal value</em> typed by an XSD or
-              RDF datatype: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:string</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:integer</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:date</code>, etc.
-              Use datatype properties for raw attributes:
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasAge</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasName</code>,
+              Connects an individual to a <em>literal value</em> typed by an XSD or{" "}
+              RDF datatype: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:string</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:integer</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:date</code>, etc.{" "}
+              Use datatype properties for raw attributes:{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasAge</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasName</code>,{" "}
               <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">birthDate</code>.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -108,12 +108,12 @@ ex:Alice ex:hasAge "34"^^xsd:nonNegativeInteger .`}</pre>
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Carries metadata about an entity rather than asserting a logical relationship.
-              Annotation properties are <strong>invisible to OWL reasoners</strong> &mdash; they
-              don&apos;t participate in inference, but they&apos;re what people read in the UI.
-              Common examples: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:label</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:comment</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:prefLabel</code>,
+              Carries metadata about an entity rather than asserting a logical relationship.{" "}
+              Annotation properties are <strong>invisible to OWL reasoners</strong> &mdash; they{" "}
+              don&apos;t participate in inference, but they&apos;re what people read in the UI.{" "}
+              Common examples: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:label</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:comment</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:prefLabel</code>,{" "}
               <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">dcterms:creator</code>.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -123,9 +123,9 @@ ex:Alice ex:hasAge "34"^^xsd:nonNegativeInteger .`}</pre>
 ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
             </div>
             <p className="text-slate-600 dark:text-slate-400 mt-3 text-sm">
-              Rule of thumb: if a value should drive logical conclusions (membership, equivalence,
-              consistency checking), it belongs on an object or datatype property. If it&apos;s
-              for humans &mdash; labels, comments, dates, authorship &mdash; use an annotation
+              Rule of thumb: if a value should drive logical conclusions (membership, equivalence,{" "}
+              consistency checking), it belongs on an object or datatype property. If it&apos;s{" "}
+              for humans &mdash; labels, comments, dates, authorship &mdash; use an annotation{" "}
               property.
             </p>
           </div>
@@ -137,9 +137,9 @@ ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
             Characteristic Axioms
           </h2>
           <p className="text-slate-600 dark:text-slate-400 mb-4">
-            OWL lets you mark a property with axioms that constrain how it behaves &mdash; a
-            reasoner uses these to derive new triples or detect contradictions. In OWL 2 DL
-            these characteristics apply to object properties; the only one also permitted on
+            OWL lets you mark a property with axioms that constrain how it behaves &mdash; a{" "}
+            reasoner uses these to derive new triples or detect contradictions. In OWL 2 DL{" "}
+            these characteristics apply to object properties; the only one also permitted on{" "}
             datatype properties is <code className="font-mono text-xs">owl:FunctionalProperty</code>.
           </p>
           <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
@@ -204,8 +204,8 @@ ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
             Relationships Between Properties
           </h2>
           <p className="text-slate-600 dark:text-slate-400 mb-4">
-            Properties can also relate to <em>each other</em>, not just to instances. These
-            axioms let you organise properties into hierarchies, declare alignments, or rule
+            Properties can also relate to <em>each other</em>, not just to instances. These{" "}
+            axioms let you organise properties into hierarchies, declare alignments, or rule{" "}
             out impossible combinations.
           </p>
           <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
@@ -220,31 +220,31 @@ ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
                 <tr>
                   <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">rdfs:subPropertyOf</td>
                   <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                    Every triple using the sub-property also entails one using the super-property.
-                    E.g. <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasMother</code>
-                    <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:subPropertyOf</code>
+                    Every triple using the sub-property also entails one using the super-property.{" "}
+                    E.g. <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasMother</code>{" "}
+                    <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:subPropertyOf</code>{" "}
                     <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code>.
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:equivalentProperty</td>
                   <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                    Two properties always carry the same triples in both directions &mdash;
+                    Two properties always carry the same triples in both directions &mdash;{" "}
                     a reasoner can substitute one for the other freely.
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:inverseOf</td>
                   <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                    Reverses subject and object. If a <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code> b,
+                    Reverses subject and object. If a <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code> b,{" "}
                     then b <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasChild</code> a.
                   </td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:propertyDisjointWith</td>
                   <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                    Two properties cannot share any pair of values. Used for mutually-exclusive
-                    relations &mdash; e.g. <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasSpouse</code> vs
+                    Two properties cannot share any pair of values. Used for mutually-exclusive{" "}
+                    relations &mdash; e.g. <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasSpouse</code> vs{" "}
                     <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code>.
                   </td>
                 </tr>
@@ -257,7 +257,7 @@ ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
                 <tr>
                   <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:propertyChainAxiom</td>
                   <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                    Derive a property by chaining others. E.g.
+                    Derive a property by chaining others. E.g.{" "}
                     <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasGrandparent ≡ hasParent ∘ hasParent</code>.
                   </td>
                 </tr>
@@ -281,17 +281,17 @@ ex:hasGrandparent owl:propertyChainAxiom ( ex:hasParent ex:hasParent ) .`}</pre>
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code> declares
-              what class a subject must belong to in order to be a valid subject of the property;
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code> does
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code> declares{" "}
+              what class a subject must belong to in order to be a valid subject of the property;{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code> does{" "}
               the same for the object.
             </p>
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              In OWL these are <strong>not validation constraints</strong> &mdash; they&apos;re
-              entailments. Asserting <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent rdfs:domain Person</code>
-              and then writing <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">ex:Spot ex:hasParent ex:Rex</code> doesn&apos;t
-              raise an error; it lets a reasoner conclude that Spot <em>is</em> a Person.
-              Use SHACL or domain-specific lint rules if you want classical &ldquo;wrong type&rdquo;
+              In OWL these are <strong>not validation constraints</strong> &mdash; they&apos;re{" "}
+              entailments. Asserting <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent rdfs:domain Person</code>{" "}
+              and then writing <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">ex:Spot ex:hasParent ex:Rex</code> doesn&apos;t{" "}
+              raise an error; it lets a reasoner conclude that Spot <em>is</em> a Person.{" "}
+              Use SHACL or domain-specific lint rules if you want classical &ldquo;wrong type&rdquo;{" "}
               validation.
             </p>
           </div>
@@ -305,20 +305,20 @@ ex:hasGrandparent owl:propertyChainAxiom ( ex:hasParent ex:hasParent ) .`}</pre>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-2 text-sm">
               <li>
-                Will the value be a <strong>reference to another individual</strong> in your
+                Will the value be a <strong>reference to another individual</strong> in your{" "}
                 ontology? &rarr; <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:ObjectProperty</code>.
               </li>
               <li>
-                Will the value be a <strong>literal</strong> (number, string, date, &hellip;)? &rarr;
+                Will the value be a <strong>literal</strong> (number, string, date, &hellip;)? &rarr;{" "}
                 <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:DatatypeProperty</code>.
               </li>
               <li>
-                Is the value <strong>metadata for humans</strong>, not for the reasoner? &rarr;
+                Is the value <strong>metadata for humans</strong>, not for the reasoner? &rarr;{" "}
                 <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:AnnotationProperty</code>.
               </li>
               <li>
-                Are you <strong>not committing to OWL</strong> at all (e.g. plain RDFS)? &rarr;
-                <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code> works,
+                Are you <strong>not committing to OWL</strong> at all (e.g. plain RDFS)? &rarr;{" "}
+                <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code> works,{" "}
                 but you lose reasoner support for the distinctions above.
               </li>
             </ul>
@@ -335,7 +335,7 @@ ex:hasGrandparent owl:propertyChainAxiom ( ex:hasParent ex:hasParent ) .`}</pre>
               <li>
                 <a href="https://www.w3.org/TR/rdf12-schema/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
                   RDF 1.2 Schema
-                </a>
+                </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
                   {" "}&mdash; the base <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code>,
                   {" "}<code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code>,
@@ -346,16 +346,16 @@ ex:hasGrandparent owl:propertyChainAxiom ( ex:hasParent ex:hasParent ) .`}</pre>
               <li>
                 <a href="https://www.w3.org/TR/owl2-syntax/#Object_Properties" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
                   OWL 2 Structural Specification &mdash; Properties
-                </a>
+                </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
-                  {" "}&mdash; canonical reference for object / datatype / annotation properties
+                  {" "}&mdash; canonical reference for object / datatype / annotation properties{" "}
                   and all the characteristic and relationship axioms.
                 </span>
               </li>
               <li>
                 <a href="https://www.w3.org/TR/owl2-primer/#Object_Properties" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
                   OWL 2 Primer &mdash; Properties
-                </a>
+                </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
                   {" "}&mdash; gentler tutorial introduction with worked examples.
                 </span>

--- a/app/docs/guide/properties/page.tsx
+++ b/app/docs/guide/properties/page.tsx
@@ -1,0 +1,370 @@
+import { GuidePrevNext } from "@/components/docs/GuidePrevNext";
+
+export default function PropertiesPage() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">
+        What are Properties?
+      </h1>
+      <p className="text-slate-600 dark:text-slate-400 mb-8">
+        Properties are the verbs of an ontology &mdash; they describe how individuals relate
+        to each other and what attributes they carry. RDF defines a single base type and OWL
+        layers a richer typology on top, with axioms for characteristics (functional,
+        transitive, &hellip;) and relationships between properties (sub-property,
+        equivalence, disjointness).
+      </p>
+
+      <div className="space-y-8">
+        {/* rdf:Property */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            The Base: <code className="bg-slate-200 dark:bg-slate-600 px-2 py-0.5 rounded text-xl">rdf:Property</code>
+          </h2>
+          <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
+            <p className="text-slate-600 dark:text-slate-400 mb-3">
+              Every predicate that connects a subject to an object in an RDF triple is, at
+              minimum, an <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code>.
+              The W3C RDF specification doesn&apos;t distinguish between &ldquo;properties that
+              point to other resources&rdquo; and &ldquo;properties that hold literal
+              values&rdquo; &mdash; it&apos;s just one flat type. RDFS adds
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code> and
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code>
+              to constrain what classes a property can apply to and what kind of values it
+              accepts, but the typology stops there.
+            </p>
+            <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+              <pre>{`@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:hasMember a rdf:Property ;
+    rdfs:domain ex:Group ;
+    rdfs:range  ex:Person .`}</pre>
+            </div>
+            <p className="text-slate-600 dark:text-slate-400 mt-3 text-sm">
+              For most modelling tasks the OWL property kinds (below) are a better fit, since
+              they let reasoners distinguish references from literal values and enforce the
+              difference automatically.
+            </p>
+          </div>
+        </section>
+
+        {/* OWL Object Property */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            <code className="bg-slate-200 dark:bg-slate-600 px-2 py-0.5 rounded text-xl">owl:ObjectProperty</code>
+          </h2>
+          <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
+            <p className="text-slate-600 dark:text-slate-400 mb-3">
+              Connects an individual to <em>another individual</em> &mdash; the range is always
+              another resource (an IRI or blank node), never a literal. Use object properties
+              for relationships between things: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">memberOf</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">locatedIn</code>.
+            </p>
+            <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+              <pre>{`@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+
+ex:hasParent a owl:ObjectProperty ;
+    rdfs:domain ex:Person ;
+    rdfs:range  ex:Person .
+
+ex:Alice ex:hasParent ex:Bob .   # both must be IRIs / individuals`}</pre>
+            </div>
+          </div>
+        </section>
+
+        {/* OWL Datatype Property */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            <code className="bg-slate-200 dark:bg-slate-600 px-2 py-0.5 rounded text-xl">owl:DatatypeProperty</code>
+          </h2>
+          <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
+            <p className="text-slate-600 dark:text-slate-400 mb-3">
+              Connects an individual to a <em>literal value</em> typed by an XSD or
+              RDF datatype: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:string</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:integer</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">xsd:date</code>, etc.
+              Use datatype properties for raw attributes:
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasAge</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasName</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">birthDate</code>.
+            </p>
+            <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+              <pre>{`@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+ex:hasAge a owl:DatatypeProperty ;
+    rdfs:domain ex:Person ;
+    rdfs:range  xsd:nonNegativeInteger .
+
+ex:Alice ex:hasAge "34"^^xsd:nonNegativeInteger .`}</pre>
+            </div>
+          </div>
+        </section>
+
+        {/* OWL Annotation Property */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            <code className="bg-slate-200 dark:bg-slate-600 px-2 py-0.5 rounded text-xl">owl:AnnotationProperty</code>
+          </h2>
+          <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
+            <p className="text-slate-600 dark:text-slate-400 mb-3">
+              Carries metadata about an entity rather than asserting a logical relationship.
+              Annotation properties are <strong>invisible to OWL reasoners</strong> &mdash; they
+              don&apos;t participate in inference, but they&apos;re what people read in the UI.
+              Common examples: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:label</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:comment</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:prefLabel</code>,
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">dcterms:creator</code>.
+            </p>
+            <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+              <pre>{`ex:hasMaintainer a owl:AnnotationProperty ;
+    rdfs:label "Has maintainer"@en .
+
+ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
+            </div>
+            <p className="text-slate-600 dark:text-slate-400 mt-3 text-sm">
+              Rule of thumb: if a value should drive logical conclusions (membership, equivalence,
+              consistency checking), it belongs on an object or datatype property. If it&apos;s
+              for humans &mdash; labels, comments, dates, authorship &mdash; use an annotation
+              property.
+            </p>
+          </div>
+        </section>
+
+        {/* Property Characteristics */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            Characteristic Axioms
+          </h2>
+          <p className="text-slate-600 dark:text-slate-400 mb-4">
+            OWL lets you mark a property with axioms that constrain how it behaves &mdash; a
+            reasoner uses these to derive new triples or detect contradictions. These apply
+            to object properties (and most also to datatype properties).
+          </p>
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-slate-700">
+                <tr>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Axiom</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Meaning</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Example</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:FunctionalProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">Each subject has at most one value</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">hasFather</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:InverseFunctionalProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">Each value identifies at most one subject (only on object properties)</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">hasISBN</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:TransitiveProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">If a P b and b P c, then a P c</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">isAncestorOf</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:SymmetricProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">If a P b, then b P a</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">hasSibling</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:AsymmetricProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">If a P b, then b P a is false</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">hasParent</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:ReflexiveProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">Every individual P itself</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">knows</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:IrreflexiveProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">No individual P itself</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">isParentOf</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto mt-4">
+            <pre>{`ex:isAncestorOf a owl:ObjectProperty , owl:TransitiveProperty , owl:IrreflexiveProperty .
+
+# From  Alice -isAncestorOf-> Bob  and  Bob -isAncestorOf-> Carol
+# A reasoner derives  Alice -isAncestorOf-> Carol`}</pre>
+          </div>
+        </section>
+
+        {/* Property Relationships */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            Relationships Between Properties
+          </h2>
+          <p className="text-slate-600 dark:text-slate-400 mb-4">
+            Properties can also relate to <em>each other</em>, not just to instances. These
+            axioms let you organise properties into hierarchies, declare alignments, or rule
+            out impossible combinations.
+          </p>
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-slate-700">
+                <tr>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Axiom</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-slate-900 dark:text-white">Meaning</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 dark:divide-slate-700">
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">rdfs:subPropertyOf</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
+                    Every triple using the sub-property also entails one using the super-property.
+                    E.g. <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasMother</code>
+                    <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:subPropertyOf</code>
+                    <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code>.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:equivalentProperty</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
+                    Two properties always carry the same triples in both directions &mdash;
+                    a reasoner can substitute one for the other freely.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:inverseOf</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
+                    Reverses subject and object. If a <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code> b,
+                    then b <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasChild</code> a.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:propertyDisjointWith</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
+                    Two properties cannot share any pair of values. Used for mutually-exclusive
+                    relations &mdash; e.g. <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasSpouse</code> vs
+                    <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent</code>.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:AllDisjointProperties</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
+                    The n-ary form: declare three or more properties pairwise-disjoint in one axiom.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:propertyChainAxiom</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
+                    Derive a property by chaining others. E.g.
+                    <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasGrandparent ≡ hasParent ∘ hasParent</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto mt-4">
+            <pre>{`ex:hasParent owl:inverseOf ex:hasChild .
+
+ex:hasSpouse owl:propertyDisjointWith ex:hasParent ;
+             a owl:SymmetricProperty .
+
+ex:hasGrandparent owl:propertyChainAxiom ( ex:hasParent ex:hasParent ) .`}</pre>
+          </div>
+        </section>
+
+        {/* Domain and Range */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            Domain and Range
+          </h2>
+          <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
+            <p className="text-slate-600 dark:text-slate-400 mb-3">
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code> declares
+              what class a subject must belong to in order to be a valid subject of the property;
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code> does
+              the same for the object.
+            </p>
+            <p className="text-slate-600 dark:text-slate-400 mb-3">
+              In OWL these are <strong>not validation constraints</strong> &mdash; they&apos;re
+              entailments. Asserting <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">hasParent rdfs:domain Person</code>
+              and then writing <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">ex:Spot ex:hasParent ex:Rex</code> doesn&apos;t
+              raise an error; it lets a reasoner conclude that Spot <em>is</em> a Person.
+              Use SHACL or domain-specific lint rules if you want classical &ldquo;wrong type&rdquo;
+              validation.
+            </p>
+          </div>
+        </section>
+
+        {/* Choosing the Right Kind */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            Choosing the Right Kind
+          </h2>
+          <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
+            <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-2 text-sm">
+              <li>
+                Will the value be a <strong>reference to another individual</strong> in your
+                ontology? &rarr; <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:ObjectProperty</code>.
+              </li>
+              <li>
+                Will the value be a <strong>literal</strong> (number, string, date, &hellip;)? &rarr;
+                <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:DatatypeProperty</code>.
+              </li>
+              <li>
+                Is the value <strong>metadata for humans</strong>, not for the reasoner? &rarr;
+                <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:AnnotationProperty</code>.
+              </li>
+              <li>
+                Are you <strong>not committing to OWL</strong> at all (e.g. plain RDFS)? &rarr;
+                <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code> works,
+                but you lose reasoner support for the distinctions above.
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        {/* References */}
+        <section>
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-200 mb-4">
+            References
+          </h2>
+          <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
+            <ul className="space-y-3 text-sm">
+              <li>
+                <a href="https://www.w3.org/TR/rdf12-schema/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
+                  RDF 1.2 Schema
+                </a>
+                <span className="text-slate-600 dark:text-slate-400">
+                  {" "}&mdash; the base <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdf:Property</code>,
+                  {" "}<code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code>,
+                  {" "}<code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code>,
+                  {" "}<code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:subPropertyOf</code>.
+                </span>
+              </li>
+              <li>
+                <a href="https://www.w3.org/TR/owl2-syntax/#Object_Properties" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
+                  OWL 2 Structural Specification &mdash; Properties
+                </a>
+                <span className="text-slate-600 dark:text-slate-400">
+                  {" "}&mdash; canonical reference for object / datatype / annotation properties
+                  and all the characteristic and relationship axioms.
+                </span>
+              </li>
+              <li>
+                <a href="https://www.w3.org/TR/owl2-primer/#Object_Properties" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
+                  OWL 2 Primer &mdash; Properties
+                </a>
+                <span className="text-slate-600 dark:text-slate-400">
+                  {" "}&mdash; gentler tutorial introduction with worked examples.
+                </span>
+              </li>
+            </ul>
+          </div>
+        </section>
+      </div>
+
+      <GuidePrevNext currentSlug="properties" />
+    </div>
+  );
+}

--- a/app/docs/guide/properties/page.tsx
+++ b/app/docs/guide/properties/page.tsx
@@ -138,8 +138,9 @@ ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
           </h2>
           <p className="text-slate-600 dark:text-slate-400 mb-4">
             OWL lets you mark a property with axioms that constrain how it behaves &mdash; a
-            reasoner uses these to derive new triples or detect contradictions. These apply
-            to object properties (and most also to datatype properties).
+            reasoner uses these to derive new triples or detect contradictions. In OWL 2 DL
+            these characteristics apply to object properties; the only one also permitted on
+            datatype properties is <code className="font-mono text-xs">owl:FunctionalProperty</code>.
           </p>
           <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
             <table className="w-full text-sm">
@@ -159,7 +160,7 @@ ex:MyOntology ex:hasMaintainer "Jane Doe" .  # not used in inference`}</pre>
                 <tr>
                   <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:InverseFunctionalProperty</td>
                   <td className="px-4 py-3 text-slate-600 dark:text-slate-400">Each value identifies at most one subject (only on object properties)</td>
-                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">hasISBN</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-400 font-mono text-xs">hasPassport</td>
                 </tr>
                 <tr>
                   <td className="px-4 py-3 font-mono text-xs text-slate-900 dark:text-white">owl:TransitiveProperty</td>

--- a/app/docs/guide/syntax/page.tsx
+++ b/app/docs/guide/syntax/page.tsx
@@ -7,7 +7,7 @@ export default function SyntaxPage() {
         What is an Ontology Syntax?
       </h1>
       <p className="text-slate-600 dark:text-slate-400 mb-8">
-        While formats determine how RDF triples are serialized, <em>ontology syntaxes</em> are
+        While formats determine how RDF triples are serialized, <em>ontology syntaxes</em> are{" "}
         purpose-built notations for expressing OWL axioms and class expressions.
       </p>
 
@@ -19,10 +19,10 @@ export default function SyntaxPage() {
           </h2>
           <div className="prose prose-slate dark:prose-invert max-w-none">
             <p className="text-slate-600 dark:text-slate-400">
-              OWL is a logical language with complex expressions like &ldquo;the class of things
-              that have at least 3 wheels and are made by a European manufacturer.&rdquo; Different
-              communities need different notations: logicians prefer Description Logic notation,
-              ontology editors often use Manchester Syntax, and web developers prefer Turtle/RDF.
+              OWL is a logical language with complex expressions like &ldquo;the class of things{" "}
+              that have at least 3 wheels and are made by a European manufacturer.&rdquo; Different{" "}
+              communities need different notations: logicians prefer Description Logic notation,{" "}
+              ontology editors often use Manchester Syntax, and web developers prefer Turtle/RDF.{" "}
               All these syntaxes express the same OWL semantics.
             </p>
           </div>
@@ -36,13 +36,13 @@ export default function SyntaxPage() {
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
               Designed for readability by ontology authors. Uses English-like keywords
-              (<code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">some</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">only</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">and</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">or</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">min</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">max</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">exactly</code>)
+              (<code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">some</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">only</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">and</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">or</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">min</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">max</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">exactly</code>){" "}
               and is widely used in tools like Prot&eacute;g&eacute;.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -70,7 +70,7 @@ Class: MargheritaPizza
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              The normative syntax in the OWL 2 specification. Uses nested function-call notation
+              The normative syntax in the OWL 2 specification. Uses nested function-call notation{" "}
               that maps directly to the OWL 2 structural specification. Precise but less readable.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -105,7 +105,7 @@ SubClassOf(
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              An XML serialization that mirrors the OWL 2 structural specification element by
+              An XML serialization that mirrors the OWL 2 structural specification element by{" "}
               element. Useful when XML tooling is required but very verbose.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -133,8 +133,8 @@ SubClassOf(
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              OWL axioms can also be expressed in Turtle using the OWL RDF mapping. This is the
-              format OntoKit uses internally. Complex class expressions use blank nodes and
+              OWL axioms can also be expressed in Turtle using the OWL RDF mapping. This is the{" "}
+              format OntoKit uses internally. Complex class expressions use blank nodes and{" "}
               RDF collections.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -161,7 +161,7 @@ ex:Pizza owl:disjointWith ex:Pasta .`}</pre>
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-4">
-              The mathematical notation used in academic papers. OWL 2 DL corresponds to the
+              The mathematical notation used in academic papers. OWL 2 DL corresponds to the{" "}
               Description Logic SROIQ(D). Compact but requires familiarity with logical symbols.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">

--- a/app/docs/guide/types/page.tsx
+++ b/app/docs/guide/types/page.tsx
@@ -7,7 +7,7 @@ export default function TypesPage() {
         What are the Types of Ontologies?
       </h1>
       <p className="text-slate-600 dark:text-slate-400 mb-8">
-        Ontologies range from simple word lists to rich logical theories. Understanding the spectrum
+        Ontologies range from simple word lists to rich logical theories. Understanding the spectrum{" "}
         helps you choose the right level of formality for your project.
       </p>
 
@@ -23,13 +23,13 @@ export default function TypesPage() {
             </p>
             <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 space-y-2">
               <li>
-                <strong>Lightweight ontologies</strong> capture basic hierarchies and associations
-                without complex logical axioms. They are easier to build and maintain but offer
+                <strong>Lightweight ontologies</strong> capture basic hierarchies and associations{" "}
+                without complex logical axioms. They are easier to build and maintain but offer{" "}
                 limited reasoning.
               </li>
               <li>
-                <strong>Heavyweight ontologies</strong> add rich axioms &mdash; cardinality
-                constraints, property restrictions, disjointness, equivalence &mdash; enabling
+                <strong>Heavyweight ontologies</strong> add rich axioms &mdash; cardinality{" "}
+                constraints, property restrictions, disjointness, equivalence &mdash; enabling{" "}
                 automated classification and consistency checking.
               </li>
             </ul>
@@ -43,12 +43,12 @@ export default function TypesPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              A taxonomy is a hierarchical classification &mdash; a tree of &ldquo;is-a&rdquo;
-              relationships. Think of the Linnaean biological classification (Kingdom &rarr; Phylum
+              A taxonomy is a hierarchical classification &mdash; a tree of &ldquo;is-a&rdquo;{" "}
+              relationships. Think of the Linnaean biological classification (Kingdom &rarr; Phylum{" "}
               &rarr; Class &rarr; &hellip; &rarr; Species) or a website&rsquo;s category navigation.
             </p>
             <p className="text-slate-600 dark:text-slate-400 text-sm">
-              Taxonomies are the simplest form of ontology. They organize concepts into parent/child
+              Taxonomies are the simplest form of ontology. They organize concepts into parent/child{" "}
               relationships but do not define properties or constraints.
             </p>
           </div>
@@ -61,13 +61,13 @@ export default function TypesPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              A step beyond taxonomies, thesauri add relationships like &ldquo;broader
-              term&rdquo;, &ldquo;narrower term&rdquo;, and &ldquo;related term&rdquo;. They also
-              record preferred labels, alternative labels, and scope notes. SKOS (Simple Knowledge
+              A step beyond taxonomies, thesauri add relationships like &ldquo;broader{" "}
+              term&rdquo;, &ldquo;narrower term&rdquo;, and &ldquo;related term&rdquo;. They also{" "}
+              record preferred labels, alternative labels, and scope notes. SKOS (Simple Knowledge{" "}
               Organization System) is the W3C standard for publishing thesauri on the web.
             </p>
             <p className="text-slate-600 dark:text-slate-400 text-sm">
-              Examples include the Library of Congress Subject Headings (LCSH), the Getty Art &
+              Examples include the Library of Congress Subject Headings (LCSH), the Getty Art &{" "}
               Architecture Thesaurus (AAT), and UNESCO Thesaurus.
             </p>
           </div>
@@ -80,13 +80,13 @@ export default function TypesPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Formal ontologies use the Web Ontology Language (OWL) to express rich logical axioms.
-              OWL is grounded in Description Logics and supports class restrictions, cardinality
-              constraints, property characteristics (transitive, symmetric, functional), and
+              Formal ontologies use the Web Ontology Language (OWL) to express rich logical axioms.{" "}
+              OWL is grounded in Description Logics and supports class restrictions, cardinality{" "}
+              constraints, property characteristics (transitive, symmetric, functional), and{" "}
               equivalence/disjointness declarations.
             </p>
             <p className="text-slate-600 dark:text-slate-400 text-sm">
-              This is the level of formality that OntoKit targets &mdash; editing and curating
+              This is the level of formality that OntoKit targets &mdash; editing and curating{" "}
               OWL ontologies with full expressiveness.
             </p>
           </div>
@@ -103,8 +103,8 @@ export default function TypesPage() {
                 Domain Ontologies
               </h3>
               <p className="text-slate-600 dark:text-slate-400 text-sm">
-                Focused on a specific subject area: biomedicine, finance, geography, etc. They
-                define the classes and properties relevant to that domain. Examples: Gene Ontology,
+                Focused on a specific subject area: biomedicine, finance, geography, etc. They{" "}
+                define the classes and properties relevant to that domain. Examples: Gene Ontology,{" "}
                 FIBO (Financial Industry Business Ontology), GeoNames.
               </p>
             </div>
@@ -113,8 +113,8 @@ export default function TypesPage() {
                 Upper-Level Ontologies
               </h3>
               <p className="text-slate-600 dark:text-slate-400 text-sm">
-                Provide very general categories (object, event, quality, role) that span all
-                domains. Domain ontologies can align to an upper ontology for cross-domain
+                Provide very general categories (object, event, quality, role) that span all{" "}
+                domains. Domain ontologies can align to an upper ontology for cross-domain{" "}
                 interoperability. Examples: BFO (Basic Formal Ontology), DOLCE, SUMO.
               </p>
             </div>

--- a/app/docs/guide/vocabularies/page.tsx
+++ b/app/docs/guide/vocabularies/page.tsx
@@ -7,8 +7,8 @@ export default function VocabulariesPage() {
         What is an Ontology Vocabulary?
       </h1>
       <p className="text-slate-600 dark:text-slate-400 mb-8">
-        Vocabularies are shared sets of terms (classes and properties) that ontologies reuse to
-        describe common concepts. Using well-known vocabularies makes your data interoperable with
+        Vocabularies are shared sets of terms (classes and properties) that ontologies reuse to{" "}
+        describe common concepts. Using well-known vocabularies makes your data interoperable with{" "}
         the rest of the Semantic Web.
       </p>
 
@@ -20,13 +20,13 @@ export default function VocabulariesPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              The foundational vocabulary for defining classes and properties in RDF.
-              Provides <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:Class</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:subClassOf</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:label</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:comment</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code>, and
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code>.
+              The foundational vocabulary for defining classes and properties in RDF.{" "}
+              Provides <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:Class</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:subClassOf</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:label</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:comment</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:domain</code>, and{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">rdfs:range</code>.{" "}
               Almost every ontology uses RDFS terms.
             </p>
             <p className="text-sm">
@@ -44,9 +44,9 @@ export default function VocabulariesPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              A set of 15 core metadata elements (title, creator, date, subject, etc.) widely used
-              in libraries, digital repositories, and ontology metadata.
-              The <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">dcterms:</code> namespace
+              A set of 15 core metadata elements (title, creator, date, subject, etc.) widely used{" "}
+              in libraries, digital repositories, and ontology metadata.{" "}
+              The <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">dcterms:</code> namespace{" "}
               provides refined versions with formal ranges and domains.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -72,12 +72,12 @@ export default function VocabulariesPage() {
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Designed for thesauri, classification schemes, and controlled vocabularies. Key
-              terms include
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:Concept</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:broader</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:narrower</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:prefLabel</code>, and
+              Designed for thesauri, classification schemes, and controlled vocabularies. Key{" "}
+              terms include{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:Concept</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:broader</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:narrower</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:prefLabel</code>, and{" "}
               <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">skos:altLabel</code>.
             </p>
             <div className="bg-slate-900 text-slate-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
@@ -106,11 +106,11 @@ ex:Mammals a skos:Concept ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Describes people, their activities, and their relationships. Commonly used terms
-              include
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">foaf:Person</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">foaf:name</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">foaf:knows</code>, and
+              Describes people, their activities, and their relationships. Commonly used terms{" "}
+              include{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">foaf:Person</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">foaf:name</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">foaf:knows</code>, and{" "}
               <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">foaf:homepage</code>.
             </p>
             <p className="text-sm">
@@ -128,8 +128,8 @@ ex:Mammals a skos:Concept ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              A collaborative vocabulary backed by Google, Microsoft, Yahoo, and Yandex. It defines
-              types for everyday things: products, events, organizations, recipes, reviews, and more.
+              A collaborative vocabulary backed by Google, Microsoft, Yahoo, and Yandex. It defines{" "}
+              types for everyday things: products, events, organizations, recipes, reviews, and more.{" "}
               Used extensively in web pages for structured data and rich search results.
             </p>
             <p className="text-sm">
@@ -147,13 +147,13 @@ ex:Mammals a skos:Concept ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              OWL itself provides vocabulary terms for formal ontology
-              modeling: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:Class</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:ObjectProperty</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:DatatypeProperty</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:Restriction</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:equivalentClass</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:disjointWith</code>, and
+              OWL itself provides vocabulary terms for formal ontology{" "}
+              modeling: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:Class</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:ObjectProperty</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:DatatypeProperty</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:Restriction</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:equivalentClass</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">owl:disjointWith</code>, and{" "}
               many more.
             </p>
             <p className="text-sm">
@@ -171,10 +171,10 @@ ex:Mammals a skos:Concept ;
           </h2>
           <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
             <p className="text-slate-600 dark:text-slate-400 mb-3">
-              Captures the provenance of data &mdash; who created it, when, from what sources, and
-              through which processes. Key
-              types: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">prov:Entity</code>,
-              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">prov:Activity</code>,
+              Captures the provenance of data &mdash; who created it, when, from what sources, and{" "}
+              through which processes. Key{" "}
+              types: <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">prov:Entity</code>,{" "}
+              <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">prov:Activity</code>,{" "}
               <code className="bg-slate-200 dark:bg-slate-600 px-1 rounded-sm text-xs">prov:Agent</code>.
             </p>
             <p className="text-sm">
@@ -270,7 +270,7 @@ ex:Mammals a skos:Concept ;
               <li>
                 <a href="https://lov.linkeddata.es/dataset/lov/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
                   Linked Open Vocabularies (LOV)
-                </a>
+                </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
                   {" "}&mdash; A curated catalog of reusable RDF vocabularies with search and usage statistics.
                 </span>
@@ -278,7 +278,7 @@ ex:Mammals a skos:Concept ;
               <li>
                 <a href="https://prefix.cc/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
                   prefix.cc
-                </a>
+                </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
                   {" "}&mdash; A community-maintained registry for looking up namespace prefixes and their IRIs.
                 </span>
@@ -286,7 +286,7 @@ ex:Mammals a skos:Concept ;
               <li>
                 <a href="https://bartoc.org/" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline font-medium">
                   BARTOC
-                </a>
+                </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
                   {" "}&mdash; Basel Register of Thesauri, Ontologies & Classifications.
                 </span>

--- a/app/docs/guide/vocabularies/page.tsx
+++ b/app/docs/guide/vocabularies/page.tsx
@@ -272,7 +272,7 @@ ex:Mammals a skos:Concept ;
                   Linked Open Vocabularies (LOV)
                 </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
-                  {" "}&mdash; A curated catalog of reusable RDF vocabularies with search and usage statistics.
+                  &mdash; A curated catalog of reusable RDF vocabularies with search and usage statistics.
                 </span>
               </li>
               <li>
@@ -280,7 +280,7 @@ ex:Mammals a skos:Concept ;
                   prefix.cc
                 </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
-                  {" "}&mdash; A community-maintained registry for looking up namespace prefixes and their IRIs.
+                  &mdash; A community-maintained registry for looking up namespace prefixes and their IRIs.
                 </span>
               </li>
               <li>
@@ -288,7 +288,7 @@ ex:Mammals a skos:Concept ;
                   BARTOC
                 </a>{" "}
                 <span className="text-slate-600 dark:text-slate-400">
-                  {" "}&mdash; Basel Register of Thesauri, Ontologies & Classifications.
+                  &mdash; Basel Register of Thesauri, Ontologies & Classifications.
                 </span>
               </li>
             </ul>

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -18,8 +18,8 @@ export default function DocsPage() {
               </h2>
               <div className="prose prose-slate dark:prose-invert max-w-none">
                 <p className="text-slate-600 dark:text-slate-400 mb-4">
-                  OntoKit is a modern, collaborative OWL ontology curation platform designed as a
-                  replacement for Stanford WebProtege. It provides a streamlined workflow for creating,
+                  OntoKit is a modern, collaborative OWL ontology curation platform designed as a{" "}
+                  replacement for Stanford WebProtege. It provides a streamlined workflow for creating,{" "}
                   editing, and managing semantic web ontologies.
                 </p>
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
@@ -45,44 +45,44 @@ export default function DocsPage() {
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Projects</h3>
                   <p className="text-slate-600 dark:text-slate-400 text-sm">
-                    Projects are containers for your ontologies. Each project has its own Git repository
+                    Projects are containers for your ontologies. Each project has its own Git repository{" "}
                     for version control, team members, and access settings.
                   </p>
                 </div>
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Branches</h3>
                   <p className="text-slate-600 dark:text-slate-400 text-sm">
-                    Work on changes in isolated branches without affecting the main ontology.
+                    Work on changes in isolated branches without affecting the main ontology.{" "}
                     Merge changes through pull requests when ready.
                   </p>
                 </div>
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Pull Requests</h3>
                   <p className="text-slate-600 dark:text-slate-400 text-sm">
-                    Propose changes to the ontology through pull requests. Review semantic diffs,
+                    Propose changes to the ontology through pull requests. Review semantic diffs,{" "}
                     discuss changes, and merge when approved.
                   </p>
                 </div>
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Suggestions</h3>
                   <p className="text-slate-600 dark:text-slate-400 text-sm">
-                    Suggesters can propose changes without direct edit access. Suggestions are
-                    auto-saved as you work and submitted for editor review with approve, reject, or
+                    Suggesters can propose changes without direct edit access. Suggestions are{" "}
+                    auto-saved as you work and submitted for editor review with approve, reject, or{" "}
                     request-changes outcomes.
                   </p>
                 </div>
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Linting</h3>
                   <p className="text-slate-600 dark:text-slate-400 text-sm">
-                    Automatic validation checks your ontology for common issues, missing labels,
+                    Automatic validation checks your ontology for common issues, missing labels,{" "}
                     and best practice violations.
                   </p>
                 </div>
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Auto-Save</h3>
                   <p className="text-slate-600 dark:text-slate-400 text-sm">
-                    A two-tier auto-save system protects your work: edits are cached locally on blur,
-                    and committed to git when you navigate away. Draft indicators show unsaved changes
+                    A two-tier auto-save system protects your work: edits are cached locally on blur,{" "}
+                    and committed to git when you navigate away. Draft indicators show unsaved changes{" "}
                     on tree nodes.
                   </p>
                 </div>
@@ -96,7 +96,7 @@ export default function DocsPage() {
               </h2>
               <div className="space-y-4">
                 <p className="text-slate-600 dark:text-slate-400">
-                  Each project member is assigned a role that determines what they can do.
+                  Each project member is assigned a role that determines what they can do.{" "}
                   Roles are project-scoped &mdash; a user can have different roles in different projects.
                 </p>
                 <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden">
@@ -111,38 +111,38 @@ export default function DocsPage() {
                       <tr>
                         <td className="px-4 py-3 text-slate-900 dark:text-white font-medium align-top">Owner</td>
                         <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                          Full control over the project. Can delete the project, transfer ownership,
+                          Full control over the project. Can delete the project, transfer ownership,{" "}
                           manage members and settings, create branches, edit the ontology, and run the health check.
                         </td>
                       </tr>
                       <tr>
                         <td className="px-4 py-3 text-slate-900 dark:text-white font-medium align-top">Admin</td>
                         <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                          Manage members and project settings, create branches, edit the ontology,
+                          Manage members and project settings, create branches, edit the ontology,{" "}
                           and run the health check. Cannot delete the project.
                         </td>
                       </tr>
                       <tr>
                         <td className="px-4 py-3 text-slate-900 dark:text-white font-medium align-top">Editor</td>
                         <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                          Create branches, edit ontology source, and create pull requests.
-                          Review and approve/reject suggestions from suggesters.
+                          Create branches, edit ontology source, and create pull requests.{" "}
+                          Review and approve/reject suggestions from suggesters.{" "}
                           Cannot manage members, change settings, or run the health check.
                         </td>
                       </tr>
                       <tr>
                         <td className="px-4 py-3 text-slate-900 dark:text-white font-medium align-top">Suggester</td>
                         <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                          Propose changes via suggestion sessions that are reviewed by editors.
-                          Can browse the ontology, create and submit suggestions, and view their
-                          own suggestion history. Cannot directly edit the ontology or create branches.
+                          Propose changes via suggestion sessions that are reviewed by editors.{" "}
+                          Can browse the ontology, create and submit suggestions, and view their{" "}
+                          own suggestion history. Cannot directly edit the ontology or create branches.{" "}
                           This is the default role for new project members.
                         </td>
                       </tr>
                       <tr>
                         <td className="px-4 py-3 text-slate-900 dark:text-white font-medium align-top">Viewer</td>
                         <td className="px-4 py-3 text-slate-600 dark:text-slate-400">
-                          Browse the class tree, view the source in read-only mode, and view
+                          Browse the class tree, view the source in read-only mode, and view{" "}
                           health check results. Cannot make any changes.
                         </td>
                       </tr>
@@ -170,24 +170,24 @@ export default function DocsPage() {
               </h2>
               <div className="space-y-4">
                 <p className="text-slate-600 dark:text-slate-400">
-                  OntoKit offers two editing modes to suit different workflows. Your preference
+                  OntoKit offers two editing modes to suit different workflows. Your preference{" "}
                   is saved and persists across sessions.
                 </p>
                 <div className="grid gap-4 md:grid-cols-2">
                   <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                     <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Standard Mode</h3>
                     <p className="text-slate-600 dark:text-slate-400 text-sm">
-                      A form-based editing experience for classes, properties, and individuals.
-                      Edit labels, comments, annotations, and relationships through structured
-                      fields. Entities are read-only by default &mdash; click &quot;Edit Item&quot; to
+                      A form-based editing experience for classes, properties, and individuals.{" "}
+                      Edit labels, comments, annotations, and relationships through structured{" "}
+                      fields. Entities are read-only by default &mdash; click &quot;Edit Item&quot; to{" "}
                       start editing, with changes auto-saved as you work.
                     </p>
                   </div>
                   <div className="bg-white dark:bg-slate-800 rounded-lg p-5 border border-slate-200 dark:border-slate-700">
                     <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">Developer Mode</h3>
                     <p className="text-slate-600 dark:text-slate-400 text-sm">
-                      Direct access to the Turtle source with full syntax highlighting,
-                      auto-completion, and inline validation in a Monaco-based editor. Ideal for
+                      Direct access to the Turtle source with full syntax highlighting,{" "}
+                      auto-completion, and inline validation in a Monaco-based editor. Ideal for{" "}
                       power users who prefer working with raw RDF/OWL syntax.
                     </p>
                   </div>
@@ -204,8 +204,8 @@ export default function DocsPage() {
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-3">Entity Tree</h3>
                   <p className="text-slate-600 dark:text-slate-400 mb-3">
-                    Navigate your ontology using hierarchical trees for classes, properties, and
-                    individuals. Entities are organized by their subclass/subproperty relationships,
+                    Navigate your ontology using hierarchical trees for classes, properties, and{" "}
+                    individuals. Entities are organized by their subclass/subproperty relationships,{" "}
                     with lazy loading for large ontologies.
                   </p>
                   <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 text-sm space-y-1">
@@ -223,8 +223,8 @@ export default function DocsPage() {
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-3">Detail Panel</h3>
                   <p className="text-slate-600 dark:text-slate-400 mb-3">
-                    View and edit entity metadata through structured forms. Separate panels are
-                    provided for classes, properties, and individuals, each tailored to their
+                    View and edit entity metadata through structured forms. Separate panels are{" "}
+                    provided for classes, properties, and individuals, each tailored to their{" "}
                     specific OWL constructs.
                   </p>
                   <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 text-sm space-y-1">
@@ -243,7 +243,7 @@ export default function DocsPage() {
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-3">Graph Visualization</h3>
                   <p className="text-slate-600 dark:text-slate-400 mb-3">
-                    Explore ontology relationships visually with an interactive graph view powered
+                    Explore ontology relationships visually with an interactive graph view powered{" "}
                     by React Flow and ELK layout.
                   </p>
                   <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 text-sm space-y-1">
@@ -257,8 +257,8 @@ export default function DocsPage() {
                 <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-3">Source Editor</h3>
                   <p className="text-slate-600 dark:text-slate-400 mb-3">
-                    Edit your ontology directly in Turtle syntax with full syntax highlighting,
-                    auto-completion, and inline validation. Available in Developer mode or via
+                    Edit your ontology directly in Turtle syntax with full syntax highlighting,{" "}
+                    auto-completion, and inline validation. Available in Developer mode or via{" "}
                     the Source tab.
                   </p>
                   <ul className="list-disc list-inside text-slate-600 dark:text-slate-400 text-sm space-y-1">
@@ -362,8 +362,8 @@ export default function DocsPage() {
                     Canonical Turtle Format
                   </h3>
                   <p className="text-slate-600 dark:text-slate-400 mb-4">
-                    When you import an ontology file, OntoKit normalizes it to a canonical Turtle format.
-                    This ensures consistent formatting across all edits and produces minimal, meaningful
+                    When you import an ontology file, OntoKit normalizes it to a canonical Turtle format.{" "}
+                    This ensures consistent formatting across all edits and produces minimal, meaningful{" "}
                     diffs in version history. The normalization happens once at import time.
                   </p>
                   <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
@@ -385,7 +385,7 @@ export default function DocsPage() {
                     Metadata Synchronization
                   </h3>
                   <p className="text-slate-600 dark:text-slate-400 mb-4">
-                    When you update a project&apos;s name or description in Project Settings, OntoKit
+                    When you update a project&apos;s name or description in Project Settings, OntoKit{" "}
                     automatically syncs these changes to the ontology&apos;s RDF metadata properties.
                   </p>
                   <div className="bg-slate-50 dark:bg-slate-700/50 rounded-lg p-4">
@@ -414,7 +414,7 @@ export default function DocsPage() {
               </h2>
               <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-slate-200 dark:border-slate-700">
                 <p className="text-slate-600 dark:text-slate-400 mb-4">
-                  OntoKit provides a comprehensive REST API for programmatic access to all platform features.
+                  OntoKit provides a comprehensive REST API for programmatic access to all platform features.{" "}
                   Use the API to integrate OntoKit with your existing tools and workflows.
                 </p>
                 <Link

--- a/components/docs/ChangelogToc.tsx
+++ b/components/docs/ChangelogToc.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface TocEntry {
+  version: string;
+  date: string;
+}
+
+const idFor = (version: string) => `v-${version.replace(/\./g, "-")}`;
+
+export function ChangelogToc({ entries }: { entries: TocEntry[] }) {
+  const [active, setActive] = useState<string | null>(
+    entries[0] ? idFor(entries[0].version) : null,
+  );
+
+  useEffect(() => {
+    const ids = entries.map(({ version }) => idFor(version));
+    const targets = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (targets.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (items) => {
+        const visible = items
+          .filter((i) => i.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActive(visible[0].target.id);
+        }
+      },
+      { rootMargin: "-80px 0px -60% 0px", threshold: 0 },
+    );
+
+    targets.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [entries]);
+
+  return (
+    <nav className="hidden lg:block w-48 shrink-0" aria-label="Releases">
+      <div className="sticky top-4">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-3 px-3">
+          Releases
+        </h3>
+        <ul className="space-y-0.5">
+          {entries.map(({ version, date }) => {
+            const id = idFor(version);
+            const isActive = active === id;
+            return (
+              <li key={version}>
+                <a
+                  href={`#${id}`}
+                  aria-current={isActive ? "true" : undefined}
+                  className={cn(
+                    "block px-3 py-1.5 rounded-md transition-colors border-l-2",
+                    isActive
+                      ? "border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-300"
+                      : "border-transparent text-slate-600 hover:text-slate-900 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800",
+                  )}
+                >
+                  <span className="block font-mono text-sm">{version}</span>
+                  <span className="block text-xs text-slate-500 dark:text-slate-400">
+                    {date}
+                  </span>
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/components/docs/ChangelogToc.tsx
+++ b/components/docs/ChangelogToc.tsx
@@ -22,20 +22,33 @@ export function ChangelogToc({ entries }: { entries: TocEntry[] }) {
       .filter((el): el is HTMLElement => el !== null);
     if (targets.length === 0) return;
 
-    const observer = new IntersectionObserver(
-      (items) => {
-        const visible = items
-          .filter((i) => i.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
-        if (visible.length > 0) {
-          setActive(visible[0].target.id);
-        }
-      },
-      { rootMargin: "-80px 0px -60% 0px", threshold: 0 },
-    );
+    const update = () => {
+      const scrollY = window.scrollY;
+      const viewportBottom = scrollY + window.innerHeight;
+      const docHeight = document.documentElement.scrollHeight;
 
-    targets.forEach((el) => observer.observe(el));
-    return () => observer.disconnect();
+      if (docHeight - viewportBottom < 8) {
+        setActive(targets[targets.length - 1].id);
+        return;
+      }
+
+      const probe = scrollY + 120;
+      let current = targets[0].id;
+      for (const el of targets) {
+        const top = el.getBoundingClientRect().top + scrollY;
+        if (top <= probe) current = el.id;
+        else break;
+      }
+      setActive(current);
+    };
+
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
   }, [entries]);
 
   return (

--- a/components/docs/ChangelogToc.tsx
+++ b/components/docs/ChangelogToc.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { changelogAnchorId } from "@/lib/docs/changelog";
 import { cn } from "@/lib/utils";
 
 interface TocEntry {
@@ -8,15 +9,13 @@ interface TocEntry {
   date: string;
 }
 
-const idFor = (version: string) => `v-${version.replace(/\./g, "-")}`;
-
 export function ChangelogToc({ entries }: { entries: TocEntry[] }) {
   const [active, setActive] = useState<string | null>(
-    entries[0] ? idFor(entries[0].version) : null,
+    entries[0] ? changelogAnchorId(entries[0].version) : null,
   );
 
   useEffect(() => {
-    const ids = entries.map(({ version }) => idFor(version));
+    const ids = entries.map(({ version }) => changelogAnchorId(version));
     const targets = ids
       .map((id) => document.getElementById(id))
       .filter((el): el is HTMLElement => el !== null);
@@ -59,7 +58,7 @@ export function ChangelogToc({ entries }: { entries: TocEntry[] }) {
         </h3>
         <ul className="space-y-0.5">
           {entries.map(({ version, date }) => {
-            const id = idFor(version);
+            const id = changelogAnchorId(version);
             const isActive = active === id;
             return (
               <li key={version}>

--- a/lib/docs/changelog.ts
+++ b/lib/docs/changelog.ts
@@ -1,0 +1,2 @@
+export const changelogAnchorId = (version: string) =>
+  `v-${version.replace(/\./g, "-")}`;

--- a/lib/docs/guide-chapters.ts
+++ b/lib/docs/guide-chapters.ts
@@ -41,6 +41,13 @@ export const guideChapters: GuideChapter[] = [
     description:
       "Discover standard vocabularies like RDFS, Dublin Core, SKOS, FOAF, and Schema.org.",
   },
+  {
+    slug: "properties",
+    title: "What are Properties?",
+    shortTitle: "Properties",
+    description:
+      "From the base rdf:Property to OWL's three property kinds, characteristic axioms (functional, transitive, …), and disjointness.",
+  },
 ];
 
 export function getAdjacentChapters(currentSlug: string) {


### PR DESCRIPTION
## Summary

Adds a 6th chapter to the ontology guide (after Vocabularies). Covers what was missing — the property typology that the rest of the docs assume readers already know:

- **The base** \`rdf:Property\` and why OWL property kinds are usually the better fit
- **The three OWL property kinds** — \`owl:ObjectProperty\` (individual → individual), \`owl:DatatypeProperty\` (individual → literal), \`owl:AnnotationProperty\` (metadata, invisible to reasoner)
- **Characteristic axioms** — Functional, InverseFunctional, Transitive, Symmetric, Asymmetric, Reflexive, Irreflexive — in a single comparison table, plus a worked example showing transitive + irreflexive composing into a real reasoner derivation
- **Relationships between properties** — \`rdfs:subPropertyOf\`, \`owl:equivalentProperty\`, \`owl:inverseOf\`, \`owl:propertyDisjointWith\`, \`owl:AllDisjointProperties\`, \`owl:propertyChainAxiom\` — with examples for each
- **Domain and range** with the "OWL is entailment, not validation" caveat that trips up newcomers
- **"Choosing the Right Kind"** four-bullet decision list
- References to W3C RDF 1.2 Schema and OWL 2 Structural / Primer specs

## Wiring

Adds an entry to \`guideChapters\` in \`lib/docs/guide-chapters.ts\`. The index card grid (\`app/docs/guide/page.tsx\`), the sidebar (\`GuideSidebar\`), and the prev/next navigation (\`GuidePrevNext\` via \`getAdjacentChapters\`) all pick it up automatically — no other code changes.

## Test plan

- [ ] Navigate to \`/docs/guide\`, confirm a 6th card "What are Properties?" appears
- [ ] Click into the chapter, verify all sections render correctly in light + dark mode
- [ ] Confirm the "Vocabularies" page now shows "Properties" as the next-link in the prev/next nav
- [ ] Confirm the new chapter appears in the sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a changelog table-of-contents with sticky side navigation and anchored release sections for improved browsing.

* **Documentation**
  * Added a comprehensive "Properties" guide covering RDF/OWL property kinds, characteristics, relationships, domain/range guidance, checklist, and guide navigation.
  * Multiple guide pages updated for consistent text spacing to fix rendering/spacing across docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->