### PR TITLE
chore: add Serena project memories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ public/sitemap.xml
 
 .ontokit-web.log
 .ontokit-web.pid
+
+# Local git worktrees
+.worktrees/

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/code_style_and_conventions.md
+++ b/.serena/memories/code_style_and_conventions.md
@@ -1,0 +1,61 @@
+# Code Style & Conventions — ontokit-web
+
+## TypeScript
+- **Strict mode** enabled (`"strict": true` in `tsconfig.json`)
+- Target: ES2022, module: esnext, moduleResolution: bundler
+- `jsx: "react-jsx"` (no React-in-scope import needed)
+- `incremental: true`, `noEmit: true` (build is via Next, type-check via `tsc --noEmit`)
+- Path alias: `"@/*": ["./*"]` — root-relative imports
+
+## ESLint (flat config, eslint.config.mjs)
+Extends:
+- `eslint-config-next/core-web-vitals`
+- `eslint-config-next/typescript`
+
+Custom rules:
+- `react-hooks/set-state-in-effect`: warn (TODO: address)
+- `react-hooks/immutability`: warn (TODO: address)
+- `@typescript-eslint/no-explicit-any`: warn
+- `@typescript-eslint/no-unused-vars`: error, but `_`-prefixed args/vars are ignored
+
+Ignored paths: `node_modules/**`, `.next/**`, `out/**`, `build/**`, `next-env.d.ts`.
+
+## Architectural patterns
+- **API client**: all backend communication goes through `lib/api/client.ts`
+  - Type-safe methods: `api.get`, `api.post`, etc.
+  - Domain APIs: `ontologyApi`, `classApi`, `projectOntologyApi`
+  - Errors wrapped via `ApiError`
+  - Auth: access tokens passed via `session.accessToken` (NextAuth)
+- **Auth**: NextAuth.js v5 (`auth.ts` at root). Zitadel OIDC. Token refresh handled there.
+- **State boundaries**:
+  - Server state → TanStack Query (`@tanstack/react-query`)
+  - Client UI state → Zustand stores (`lib/stores/`)
+  - Editor selection → URL state (`classIri` query param)
+- **Web Workers**: heavy lifting (IRI indexing for lint) goes through workers — do NOT block the main thread
+- **Monaco/Turtle**:
+  - Custom language in `lib/editor/languages/turtle.ts`
+  - Internal vs external IRIs distinguished via `commonPrefixes`
+  - Hover provider resolves full IRIs; Ctrl+Click navigates internal / opens external
+- **i18n**: `next-intl`; routes under `app/[locale]/`
+
+## Styling
+- **Tailwind CSS v4** (PostCSS plugin)
+- `cn()` helper in `lib/utils.ts` for class merging (clsx + tailwind-merge)
+
+## Validation
+- **Zod v4** for runtime schema validation
+
+## Testing conventions
+- **Vitest** + jsdom + `@testing-library/react`
+- Tests live in `__tests__/` (separate from source)
+- Coverage via `@vitest/coverage-v8`
+
+## Naming / file conventions
+- React components: PascalCase `.tsx`, one component per file
+- Hooks: `useXxx.ts(x)` in `lib/hooks/`
+- Stores: Zustand stores in `lib/stores/`
+- API clients: per-domain modules in `lib/api/`
+
+## Doc files in repo
+`CLAUDE.md`, `AGENTS.md` give Claude/agent guidance.
+`PLAN-ontology-atomization.md` + critical analysis are local planning docs (likely .gitignored or repo-local).

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,44 @@
+# OntoKit Web — Project Overview
+
+Web frontend for OntoKit, a collaborative OWL ontology curation platform. Built with **Next.js 15 (App Router)** + **React 19** + **TypeScript** (strict). Talks to the `ontokit-api` FastAPI backend.
+
+## Purpose
+Provides a browser-based ontology editor with three-panel layout (class tree / detail panel / source view), real-time collaboration, PR workflow, and ontology health linting.
+
+## Genesis
+Built to serve two open-source ontology projects:
+- **FOLIO** (Free Open Legal Information Ontology) — legal vocabulary
+- **Catholic Semantic Canon** (Catholic Digital Commons) — faith vocabulary
+
+Both need grassroots collaborative ontology editing tooling.
+
+## Core Capabilities
+- Ontology editor: ClassTree + DetailPanel + Monaco-based Turtle source editor
+- Custom Turtle syntax: hover IRI resolution, Ctrl+Click navigation (internal IRIs jump in tree, external open in browser)
+- Web Worker (`lib/editor/indexWorker.ts`) for IRI indexing — keeps lint off the UI thread
+- Real-time collab via WebSocket
+- Pull request workflow (review/merge ontology changes)
+- Ontology health checks (20+ semantic linting rules)
+- Graph viz (D3.js + @xyflow/react + ELK layout)
+- Git-style branch + revision history
+- i18n via `next-intl`, dark mode, responsive
+- Scalar-based API documentation browser
+
+## Tech Stack
+- **Framework**: Next.js 16.x (note: package.json pins ^16.2.4; CLAUDE.md/README still say "Next.js 15")
+- **UI**: React 19, Tailwind CSS v4, Radix UI primitives, lucide-react
+- **State**: Zustand (client) + TanStack Query (server state) + URL state for editor selection (`classIri` query param)
+- **Auth**: NextAuth.js v5 + Zitadel OIDC (token refresh + session in `auth.ts`)
+- **Editor**: @monaco-editor/react + monaco-editor with custom Turtle language
+- **Validation**: Zod v4
+- **Visualization**: D3, @xyflow/react, ELK
+- **Testing**: Vitest + @testing-library/react + jsdom
+- **Drag/drop**: @dnd-kit
+
+## Engines
+Node.js >= 22.13.0 (per package.json). README says >=20.9, package.json is authoritative.
+
+## Repo Location
+`/home/johnrdorazio/development/CatholicOS_org/ontokit/ontokit-web`
+
+Companion repo: `ontokit-api` (Python FastAPI backend, sibling directory).

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -39,6 +39,5 @@ Both need grassroots collaborative ontology editing tooling.
 Node.js >= 22.13.0 (per package.json). README says >=20.9, package.json is authoritative.
 
 ## Repo Location
-`/home/johnrdorazio/development/CatholicOS_org/ontokit/ontokit-web`
 
 Companion repo: `ontokit-api` (Python FastAPI backend, sibling directory).

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,7 +1,7 @@
 # Codebase Structure — ontokit-web
 
 ## Top-level layout
-```
+```text
 ontokit-web/
 ├── app/                  # Next.js App Router pages
 ├── components/           # React components by domain

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,0 +1,79 @@
+# Codebase Structure — ontokit-web
+
+## Top-level layout
+```
+ontokit-web/
+├── app/                  # Next.js App Router pages
+├── components/           # React components by domain
+├── lib/                  # Clients, hooks, stores, helpers
+├── messages/             # i18n translation files (next-intl)
+├── public/               # Static assets
+├── __tests__/            # Vitest test suites (separate from app/components)
+├── scripts/              # Release + version mgmt scripts
+├── docs/                 # Project docs
+├── .planning/            # Local planning docs
+├── auth.ts               # NextAuth.js config (root-level), token refresh + session
+├── next.config.ts
+├── tsconfig.json
+├── eslint.config.mjs
+├── vitest.config.ts
+├── postcss.config.js
+├── package.json / package-lock.json
+├── .env.example / .env.local
+├── ontokit-web.sh        # dev server lifecycle wrapper (start/stop/restart/status)
+├── Dockerfile
+└── CLAUDE.md / AGENTS.md / README.md / SECURITY.md / RELEASING.md
+```
+
+## app/ (Next.js App Router)
+- `[locale]/` — internationalized routes
+- `api/` — BFF API routes
+- `api-docs/` — API documentation browser (Scalar)
+- `auth/` — auth pages
+- `docs/` — documentation pages
+- `projects/` — project listing + per-project pages
+  - `projects/[id]/editor/page.tsx` — main ontology editor (three-panel layout)
+- `settings/` — user settings
+
+## components/ (organized by domain)
+- `ui/` — reusable Radix-based UI primitives
+- `editor/` — ontology editor (ClassTree, ClassDetailPanel, TurtleEditor, …)
+- `pr/` — pull request workflow
+- `revision/` — branch + revision history
+- `graph/` — ontology graph visualization
+- `diff/` — diff viewer
+- `collab/` — collaboration indicators
+- `layout/` — header / sidebar
+- `projects/` — project listing
+- `suggestions/` — suggestion UI
+- `docs/` — documentation rendering
+- `icons/` — custom SVGs
+- `auth/` — auth components
+
+## lib/
+- `api/` — type-safe API clients
+  - `client.ts` — base `api.get/post/...` + `ApiError`
+  - Domain APIs: `ontologyApi`, `classApi`, `projectOntologyApi`, plus `projects`, `revisions`, `lint`, `pullRequests` clients
+- `editor/` — Monaco support: `languages/turtle.ts`, `indexWorker.ts` (Web Worker for IRI indexing)
+- `ontology/` — `types.ts` with OWL entity types (`OWLClass`, `OWLProperty`, …)
+- `collab/` — WebSocket collab client
+- `graph/` — graph data structures
+- `git-graph/` — git history graph rendering
+- `hooks/` — custom React hooks (e.g. `useOntologyTree`)
+- `stores/` — Zustand stores
+- `context/` — React contexts
+- `i18n/` — internationalization plumbing
+- `docs/` — docs utilities
+- `utils.ts` — `cn()`, `getLocalName(iri)`, `getPreferredLabel(labels, lang)`
+
+## Editor architecture (`app/projects/[id]/editor/page.tsx`)
+- Three-panel: Class tree (left) / Detail panel (right) / Source + Health tabs (bottom)
+- Tree state: `useOntologyTree` hook with lazy loading
+- Source view: Monaco + custom Turtle language
+- Lint indexing offloaded to Web Worker
+
+## Tests
+`__tests__/` (Vitest, jsdom env, @testing-library/react)
+
+## TypeScript paths
+- `"@/*": ["./*"]` — root-level alias

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,55 @@
+# Suggested Commands — ontokit-web
+
+## First-time setup
+```bash
+npm install
+cp .env.example .env.local      # then edit
+```
+
+## Dev server (preferred: lifecycle script)
+```bash
+./ontokit-web.sh start          # background, logs → .ontokit-web.log, pid → .ontokit-web.pid
+./ontokit-web.sh stop
+./ontokit-web.sh restart
+./ontokit-web.sh status
+./ontokit-web.sh restart --force   # kill any blocking process on the port
+```
+- The script auto-detects non-interactive stdin and behaves like `--force` (kills blockers without prompting).
+- Override port: `PORT=4000 ./ontokit-web.sh start`.
+- Clear Next cache: `rm -rf .next && ./ontokit-web.sh start`.
+- Use this in agents/scripts; only fall back to `npm run dev` for interactive foreground work.
+
+## Raw npm scripts
+```bash
+npm run dev              # foreground dev server (next dev)
+npm run build            # next build
+npm run start            # next start (production)
+npm run lint             # eslint .
+npm run lint:fix         # eslint --fix .
+npm run type-check       # tsc --noEmit
+npm run test             # vitest
+npm run test:coverage    # vitest --coverage
+```
+
+## Docker
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_API_URL=http://api:8000 \
+  --build-arg NEXT_PUBLIC_WS_URL=ws://api:8000 \
+  -t ontokit-web .
+
+docker run -p 3000:3000 ontokit-web
+```
+
+## Security scan (Semgrep)
+With Pro:
+```bash
+semgrep --pro --config p/default --config p/owasp-top-ten \
+  --config p/javascript --config p/typescript \
+  --config p/react --config p/nextjs --config p/jwt
+```
+Without Pro: drop `--pro`.
+
+## System utilities (Linux/WSL2)
+Standard GNU coreutils (`ls`, `cd`, `grep`, `find`, `git`).
+Prefer Serena's `find_file`, `search_for_pattern`, `find_symbol` over shell `find`/`grep` inside the repo.

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,47 @@
+# When a Coding Task Is Complete — ontokit-web
+
+Run these BEFORE declaring work done or committing:
+
+1. **Lint (auto-fix)**
+   ```bash
+   npm run lint:fix
+   ```
+
+2. **Type check (strict TS)**
+   ```bash
+   npm run type-check
+   ```
+
+3. **Tests**
+   ```bash
+   npm run test
+   # or for coverage:
+   npm run test:coverage
+   ```
+
+4. **Build sanity (when changing config, deps, or major surface)**
+   ```bash
+   npm run build
+   ```
+
+5. **(Optional/CI) Semgrep**
+   ```bash
+   semgrep --pro --config p/default --config p/owasp-top-ten \
+     --config p/javascript --config p/typescript \
+     --config p/react --config p/nextjs --config p/jwt
+   # drop --pro if no Pro entitlement
+   ```
+
+6. **UI verification (rule from system prompt)**: For frontend changes, actually start the dev server and exercise the feature in a browser before reporting done. Type-check + tests verify code, not feature behavior.
+   ```bash
+   ./ontokit-web.sh restart
+   # then open http://localhost:3000 (or PORT override)
+   # tail -f .ontokit-web.log  for runtime errors
+   ```
+
+7. **CI** runs `semgrep ci` (diff-aware) — keep `.semgrepignore` honest.
+
+## Watch-outs
+- The two `react-hooks/*` warn-level rules (`set-state-in-effect`, `immutability`) are flagged TODOs — don't introduce new violations.
+- Don't introduce `any` if avoidable; rule is `warn` but flagged.
+- Backend coupling: API contract changes need coordinated work in `ontokit-api`.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -133,8 +133,11 @@ default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
-initial_prompt: ""
-
+initial_prompt: |
+  - Next.js 16, React 19, Node >=22.13.0. `package.json` is authoritative; some docs still say 15/20.
+  - Default branch is `dev`; PRs target `dev`.
+  - TypeScript strict + ESLint flat config. Do not introduce new `any` or `react-hooks/set-state-in-effect` / `react-hooks/immutability` warnings (existing ones are flagged TODOs).
+  - All API calls go through `lib/api/client.ts`; backend session token via `session.accessToken` with `credentials: include`.
 # time budget (seconds) per tool call for the retrieval of additional symbol information
 # such as docstrings or parameter information.
 # This overrides the corresponding setting in the global configuration; see the documentation there.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "ontokit-web"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary

- Commit Serena MCP memory files generated by onboarding
- Add `.worktrees/` to `.gitignore` (project-local git worktrees convention)

## Why

Serena's `.serena/memories/*.md` files capture project-specific knowledge — overview, structure, suggested commands, code style, and a task-completion checklist — that Serena writes during onboarding. Committing these means:

- Fresh checkouts and new worktrees activate the project with full context immediately
- Teammates using Serena MCP share the same baseline knowledge
- No per-machine, per-branch re-onboarding overhead

## Files

- `.serena/memories/project_overview.md`
- `.serena/memories/project_structure.md`
- `.serena/memories/suggested_commands.md`
- `.serena/memories/code_style_and_conventions.md`
- `.serena/memories/task_completion_checklist.md`

Serena's inner `.serena/.gitignore` (already present in the .serena directory and not part of this PR) excludes `cache/` and `project.local.yml` automatically, so transient state never gets committed.

## Test plan

- [ ] CI is green
- [ ] `git status` shows clean tree after merge (no untracked `.serena/` paths showing as needing commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)