### PR TITLE
fix: mirror Expand layout in Collapse split-button group

### DIFF
--- a/components/editor/shared/EntityTreeToolbar.tsx
+++ b/components/editor/shared/EntityTreeToolbar.tsx
@@ -130,21 +130,21 @@ export function EntityTreeToolbar({
         {showCollapseGroup && (
           <div className="flex rounded-md border border-slate-200 dark:border-slate-600">
             <button
-              onClick={onCollapseAll}
-              disabled={collapseDisabled}
-              className={cn(btnBase, "rounded-l-md border-r border-slate-200 dark:border-slate-600", collapseDisabled ? btnDisabled : btnEnabled)}
-              aria-label="Collapse all"
-            >
-              <ChevronsRight className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Collapse</span>
-            </button>
-            <button
               onClick={onCollapseOneLevel}
               disabled={collapseDisabled}
-              className={cn(btnBase, "rounded-r-md px-1", collapseDisabled ? btnDisabled : btnEnabled)}
+              className={cn(btnBase, "rounded-l-md border-r border-slate-200 dark:border-slate-600", collapseDisabled ? btnDisabled : btnEnabled)}
               aria-label="Collapse one level"
             >
               <ChevronRight className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Collapse</span>
+            </button>
+            <button
+              onClick={onCollapseAll}
+              disabled={collapseDisabled}
+              className={cn(btnBase, "rounded-r-md px-1", collapseDisabled ? btnDisabled : btnEnabled)}
+              aria-label="Collapse all"
+            >
+              <ChevronsRight className="h-3.5 w-3.5" />
             </button>
           </div>
         )}


### PR DESCRIPTION
## Problem

Closes #208.

The Collapse split-button group had the opposite layout from the Expand group:

| Group | Left (main, labeled) | Right (icon-only) |
|---|---|---|
| **Expand** (before & after) | `ChevronDown` → expand one level | `ChevronsDown` → expand all |
| **Collapse** (before) | `ChevronsRight` → collapse **all** | `ChevronRight` → collapse one level |
| **Collapse** (after) | `ChevronRight` → collapse **one level** | `ChevronsRight` → collapse all |

A user who learned "labeled button = conservative one-step action" from the Expand group would accidentally collapse the entire tree on first click of Collapse.

## Fix

Swapped the `onClick` handlers, icons, and `aria-label` attributes in the Collapse group so both split-button clusters follow the same convention: labeled main button = one step, icon-only add-on = all levels.

## Testing

- Clicking **Collapse** (labeled) collapses one level only
- Clicking the double-caret add-on collapses all levels
- `aria-label` on each button matches its action
- No regressions in existing test suite (158/159 pass; 1 pre-existing failure in `LanguagePicker.test.tsx` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reordered collapse buttons in the editor toolbar for improved clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CatholicOS/ontokit-web/pull/242)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->